### PR TITLE
[#197] Remove das proto from Dockerfile

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -32,11 +32,6 @@ RUN cd ${THIRD_PARTY} \
     && ln -s ${THIRD_PARTY} ${DAS_DIR}/src/3rd-party \
     && mv bazelisk ${BAZEL_DIR}
 
-# TODO: integrate this to bazel build (https://github.com/singnet/das/issues/197)
-ADD https://raw.githubusercontent.com/singnet/das-query-engine/master/proto/attention_broker.proto ${PROTO_DIR}
-ADD https://raw.githubusercontent.com/singnet/das-query-engine/master/proto/common.proto ${PROTO_DIR}
-ADD https://raw.githubusercontent.com/singnet/das-query-engine/master/proto/echo.proto ${PROTO_DIR}
-
 ################################################################################
 # To be removed when AtomDB is properly integrated
 # Redis client


### PR DESCRIPTION
closes #197

It is already using the das-proto files defined on MODULE.bazel:
```starlark
http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
http_archive(
    name = "com_github_singnet_das_proto",
    strip_prefix = "das-proto-0.1.14",
    sha256 = "c1e32db184cddb58468139d2fdc592be876c58cf67aa2600a2ec9670ca03cdc9",
    urls = ["https://github.com/singnet/das-proto/archive/refs/tags/0.1.14.tar.gz"],
)
```