### PR TITLE
[#305] Fix StarNode and DASNode binding and flaky tests

### DIFF
--- a/src/hyperon_das_node/BUILD
+++ b/src/hyperon_das_node/BUILD
@@ -11,7 +11,10 @@ py_library(
 nanobind_extension(
     name = "hyperon_das_node_ext",
     srcs = ["hyperon_das_node_ext.cc"],
-    deps = ["//distributed_algorithm_node:distributed_algorithm_node_lib"],
+    deps = [
+      "//distributed_algorithm_node:distributed_algorithm_node_lib",
+      "//query_engine:query_engine_lib",
+    ],
 )
 
 py_wheel(

--- a/src/hyperon_das_node/hyperon_das_node_ext.cc
+++ b/src/hyperon_das_node/hyperon_das_node_ext.cc
@@ -10,11 +10,19 @@
 #include "distributed_algorithm_node/MessageBroker.h"
 #include "distributed_algorithm_node/StarNode.h"
 
+#include <type_traits>
+
+#include "query_engine/DASNode.h"
+#include "query_engine/HandlesAnswer.h"
+#include "query_engine/QueryAnswer.h"
+#include "query_engine/query_element/RemoteIterator.h"
+
 namespace nb = nanobind;
 using namespace nb::literals;  // Enables use of literal "_a" for named arguments
 
 using namespace std;
 using namespace distributed_algorithm_node;
+using namespace query_engine;
 
 // Shared pointers aliases
 using MessagePtr = shared_ptr<Message>;
@@ -95,7 +103,7 @@ NB_MODULE(hyperon_das_node_ext, m) {
     // Needs to be updated whenever a new MessageBrokerType is added.
     nb::enum_<MessageBrokerType>(m, "MessageBrokerType")
         .value("GRPC", MessageBrokerType::GRPC)
-        .value("RAM", MessageBrokerType::RAM);
+        .value("RAM", MessageBrokerType::RAM)
         .export_values();
 
   // DistributedAlgorithmNode.h bindings
@@ -120,9 +128,94 @@ NB_MODULE(hyperon_das_node_ext, m) {
       .def("message_factory", &DistributedAlgorithmNode::message_factory);
 
   // StarNode.h bindings
-  nb::class_<StarNode, DistributedAlgorithmNode>(m, "StarNode")
+  nb::class_<StarNode, DistributedAlgorithmNode, StarNodeTrampoline>(m, "StarNode")
       .def(nb::init<const string&, MessageBrokerType>(),
            "node_id"_a, "messaging_backend"_a = MessageBrokerType::GRPC)
       .def(nb::init<const string&, const string&, MessageBrokerType>(),
            "node_id"_a, "server_id"_a, "messaging_backend"_a = MessageBrokerType::GRPC);
+
+    // DASNode.h
+    nb::class_<DASNode, StarNode>(m, "DASNode")
+        .def(nb::init<const string&>(), "node_id"_a)
+        .def(nb::init<const string&, const string&>(), "node_id"_a, "server_id"_a)
+        .def_ro_static("PATTERN_MATCHING_QUERY", &DASNode::PATTERN_MATCHING_QUERY)
+        .def_ro_static("COUNTING_QUERY", &DASNode::COUNTING_QUERY)
+        .def(
+            "pattern_matcher_query",
+            [](DASNode& self,
+               const vector<string>& tokens,
+               const string& context,
+               bool update_attention_broker) -> shared_ptr<RemoteIterator<HandlesAnswer>> {
+                return shared_ptr<RemoteIterator<HandlesAnswer>>(
+                    self.pattern_matcher_query(tokens, context, update_attention_broker));
+            },
+            "tokens"_a,
+            "context"_a = "",
+            "update_attention_broker"_a = false)
+        .def("count_query",
+             &DASNode::count_query,
+             "tokens"_a,
+             "context"_a = "",
+             "update_attention_broker"_a = false)
+        .def("next_query_id", &DASNode::next_query_id)
+        .def("message_factory", &DASNode::message_factory, "command"_a, "args"_a);
+
+
+    // QueryAnswer.h bindings
+    nb::class_<QueryAnswer>(m, "QueryAnswer")
+        .def("tokenize", &QueryAnswer::tokenize)
+        .def("untokenize", &QueryAnswer::untokenize, "tokens"_a)
+        .def("to_string", &QueryAnswer::to_string);
+
+    // HandlesAnswer.h
+    nb::class_<HandlesAnswer, QueryAnswer>(m, "HandlesAnswer")
+        .def(nb::init<>())
+        .def(nb::init<double>(), "importance"_a)
+        .def(
+            "__init__",
+            [](HandlesAnswer& self, const string& handle, double importance) {
+                new (&self) HandlesAnswer(handle.c_str(), importance);
+            },
+            "handle"_a,
+            "importance"_a)
+        .def_prop_ro("handles",
+                     [](const HandlesAnswer& self) -> const vector<string> {
+                         vector<string> handles;
+                         for (size_t i = 0; i < self.handles_size; i++) {
+                             handles.emplace_back(self.handles[i]);
+                         }
+                         return handles;
+                     })
+        .def_ro("handles_size", &HandlesAnswer::handles_size)
+        .def_ro("importance", &HandlesAnswer::importance)
+        .def(
+            "add_handle",
+            [](HandlesAnswer& self, const string& handle) { self.add_handle(handle.c_str()); },
+            "handle"_a)
+        .def(
+            "merge",
+            [](HandlesAnswer& self, const HandlesAnswer& other, bool merge_handles) -> bool {
+                return self.merge((HandlesAnswer*) &other, merge_handles);
+            },
+            "other"_a,
+            "merge_handles"_a)
+        .def_static(
+            "copy",
+            [](const HandlesAnswer& other) -> shared_ptr<HandlesAnswer> {
+                return shared_ptr<HandlesAnswer>(HandlesAnswer::copy((HandlesAnswer*) &other));
+            },
+            // C++ implementation named it `base` instead of `other`, but `other` is more idiomatic
+            "other"_a);
+
+    // RemoteIterator.h
+    nb::class_<RemoteIterator<HandlesAnswer>>(m, "RemoteIterator")
+        .def(nb::init<const string&>(), "local_id"_a)
+        .def_ro("is_terminal", &RemoteIterator<HandlesAnswer>::is_terminal)
+        .def("graceful_shutdown", &RemoteIterator<HandlesAnswer>::graceful_shutdown)
+        .def("setup_buffers", &RemoteIterator<HandlesAnswer>::setup_buffers)
+        .def("finished", &RemoteIterator<HandlesAnswer>::finished)
+        .def("pop", [](RemoteIterator<HandlesAnswer>& self) -> shared_ptr<HandlesAnswer> {
+            return shared_ptr<HandlesAnswer>((HandlesAnswer*) self.pop());
+        });
+
 }

--- a/src/hyperon_das_node/hyperon_das_node_ext.cc
+++ b/src/hyperon_das_node/hyperon_das_node_ext.cc
@@ -97,33 +97,29 @@ NB_MODULE(hyperon_das_node_ext, m) {
         .value("GRPC", MessageBrokerType::GRPC)
         .value("RAM", MessageBrokerType::RAM);
 
-    // DistributedAlgorithmNode.h bindings
-    nb::class_<DistributedAlgorithmNode, MessageFactory, DistributedAlgorithmNodeTrampoline>(
-        m, "DistributedAlgorithmNode")
-        .def(nb::init<string, LeadershipBrokerType, MessageBrokerType>(),
-             "node_id"_a,
-             "leadership_algorithm"_a,
-             "messaging_backend"_a)
-        .def("join_network", &DistributedAlgorithmNode::join_network)
-        .def("is_leader", &DistributedAlgorithmNode::is_leader)
-        .def("leader_id", &DistributedAlgorithmNode::leader_id)
-        .def("has_leader", &DistributedAlgorithmNode::has_leader)
-        // Whenever we have a parameter that is a pointer or a reference, we need
-        // to specify the name of the argument. Otherwise nanobind will add a
-        // default arg0, arg1, etc.
-        .def("add_peer", &DistributedAlgorithmNode::add_peer, "peer_id"_a)
-        .def("node_id", &DistributedAlgorithmNode::node_id)
-        .def("broadcast", &DistributedAlgorithmNode::broadcast, "command"_a, "args"_a)
-        .def("send", &DistributedAlgorithmNode::send, "command"_a, "args"_a, "recipient"_a)
-        .def("node_joined_network", &DistributedAlgorithmNode::node_joined_network, "node_id"_a)
-        .def("cast_leadership_vote", &DistributedAlgorithmNode::cast_leadership_vote)
-        .def("message_factory", &DistributedAlgorithmNode::message_factory);
-    nb::class_<StarNode, DistributedAlgorithmNode>(m, "StarNode")
-        .def(nb::init<string, MessageBrokerType>(),
-             "node_id"_a,
-             "messaging_backend"_a = MessageBrokerType::GRPC)
-        .def(nb::init<string, string, MessageBrokerType>(),
-             "node_id"_a,
-             "server_id"_a,
-             "messaging_backend"_a = MessageBrokerType::GRPC);
+  // DistributedAlgorithmNode.h bindings
+  nb::class_<DistributedAlgorithmNode, MessageFactory, DistributedAlgorithmNodeTrampoline>(
+      m, "DistributedAlgorithmNode")
+      .def(nb::init<const string&, LeadershipBrokerType, MessageBrokerType>(),
+           "node_id"_a, "leadership_algorithm"_a, "messaging_backend"_a)
+      .def("join_network", &DistributedAlgorithmNode::join_network)
+      .def("is_leader", &DistributedAlgorithmNode::is_leader)
+      .def("leader_id", &DistributedAlgorithmNode::leader_id)
+      .def("has_leader", &DistributedAlgorithmNode::has_leader)
+      // Whenever we have a parameter that is a pointer or a reference, we need
+      // to specify the name of the argument. Otherwise nanobind will add a
+      // default arg0, arg1, etc.
+      .def("add_peer", &DistributedAlgorithmNode::add_peer, "peer_id"_a)
+      .def("node_id", &DistributedAlgorithmNode::node_id)
+      .def("broadcast", &DistributedAlgorithmNode::broadcast, "command"_a, "args"_a)
+      .def("send", &DistributedAlgorithmNode::send, "command"_a, "args"_a, "recipient"_a)
+      .def("node_joined_network", &DistributedAlgorithmNode::node_joined_network,
+           "node_id"_a)
+      .def("cast_leadership_vote", &DistributedAlgorithmNode::cast_leadership_vote)
+      .def("message_factory", &DistributedAlgorithmNode::message_factory);
+  nb::class_<StarNode, DistributedAlgorithmNode>(m, "StarNode")
+      .def(nb::init<const string&, MessageBrokerType>(),
+           "node_id"_a, "messaging_backend"_a = MessageBrokerType::GRPC)
+      .def(nb::init<const string&, const string&, MessageBrokerType>(),
+           "node_id"_a, "server_id"_a, "messaging_backend"_a = MessageBrokerType::GRPC);
 }

--- a/src/hyperon_das_node/hyperon_das_node_ext.cc
+++ b/src/hyperon_das_node/hyperon_das_node_ext.cc
@@ -75,9 +75,9 @@ class StarNodeTrampoline : public StarNode {
         NB_OVERRIDE(message_factory, command, args);
     };
     void node_joined_network(const string& node_id) override {
-        NB_OVERRIDE_PURE(node_joined_network, node_id);
+        NB_OVERRIDE(node_joined_network, node_id);
     };
-    string cast_leadership_vote() override { NB_OVERRIDE_PURE(cast_leadership_vote); };
+    string cast_leadership_vote() override { NB_OVERRIDE(cast_leadership_vote); };
 };
 // ****************************************************************************
 

--- a/src/hyperon_das_node/hyperon_das_node_ext.cc
+++ b/src/hyperon_das_node/hyperon_das_node_ext.cc
@@ -4,14 +4,13 @@
 #include <nanobind/stl/vector.h>
 #include <nanobind/trampoline.h>
 
+#include <type_traits>
+
 #include "distributed_algorithm_node/DistributedAlgorithmNode.h"
 #include "distributed_algorithm_node/LeadershipBroker.h"
 #include "distributed_algorithm_node/Message.h"
 #include "distributed_algorithm_node/MessageBroker.h"
 #include "distributed_algorithm_node/StarNode.h"
-
-#include <type_traits>
-
 #include "query_engine/DASNode.h"
 #include "query_engine/HandlesAnswer.h"
 #include "query_engine/QueryAnswer.h"
@@ -106,33 +105,37 @@ NB_MODULE(hyperon_das_node_ext, m) {
         .value("RAM", MessageBrokerType::RAM)
         .export_values();
 
-  // DistributedAlgorithmNode.h bindings
-  nb::class_<DistributedAlgorithmNode, MessageFactory, DistributedAlgorithmNodeTrampoline>(
-      m, "DistributedAlgorithmNode")
-      .def(nb::init<const string&, LeadershipBrokerType, MessageBrokerType>(),
-           "node_id"_a, "leadership_algorithm"_a, "messaging_backend"_a)
-      .def("join_network", &DistributedAlgorithmNode::join_network)
-      .def("is_leader", &DistributedAlgorithmNode::is_leader)
-      .def("leader_id", &DistributedAlgorithmNode::leader_id)
-      .def("has_leader", &DistributedAlgorithmNode::has_leader)
-      // Whenever we have a parameter that is a pointer or a reference, we need
-      // to specify the name of the argument. Otherwise nanobind will add a
-      // default arg0, arg1, etc.
-      .def("add_peer", &DistributedAlgorithmNode::add_peer, "peer_id"_a)
-      .def("node_id", &DistributedAlgorithmNode::node_id)
-      .def("broadcast", &DistributedAlgorithmNode::broadcast, "command"_a, "args"_a)
-      .def("send", &DistributedAlgorithmNode::send, "command"_a, "args"_a, "recipient"_a)
-      .def("node_joined_network", &DistributedAlgorithmNode::node_joined_network,
-           "node_id"_a)
-      .def("cast_leadership_vote", &DistributedAlgorithmNode::cast_leadership_vote)
-      .def("message_factory", &DistributedAlgorithmNode::message_factory);
+    // DistributedAlgorithmNode.h bindings
+    nb::class_<DistributedAlgorithmNode, MessageFactory, DistributedAlgorithmNodeTrampoline>(
+        m, "DistributedAlgorithmNode")
+        .def(nb::init<const string&, LeadershipBrokerType, MessageBrokerType>(),
+             "node_id"_a,
+             "leadership_algorithm"_a,
+             "messaging_backend"_a)
+        .def("join_network", &DistributedAlgorithmNode::join_network)
+        .def("is_leader", &DistributedAlgorithmNode::is_leader)
+        .def("leader_id", &DistributedAlgorithmNode::leader_id)
+        .def("has_leader", &DistributedAlgorithmNode::has_leader)
+        // Whenever we have a parameter that is a pointer or a reference, we need
+        // to specify the name of the argument. Otherwise nanobind will add a
+        // default arg0, arg1, etc.
+        .def("add_peer", &DistributedAlgorithmNode::add_peer, "peer_id"_a)
+        .def("node_id", &DistributedAlgorithmNode::node_id)
+        .def("broadcast", &DistributedAlgorithmNode::broadcast, "command"_a, "args"_a)
+        .def("send", &DistributedAlgorithmNode::send, "command"_a, "args"_a, "recipient"_a)
+        .def("node_joined_network", &DistributedAlgorithmNode::node_joined_network, "node_id"_a)
+        .def("cast_leadership_vote", &DistributedAlgorithmNode::cast_leadership_vote)
+        .def("message_factory", &DistributedAlgorithmNode::message_factory);
 
-  // StarNode.h bindings
-  nb::class_<StarNode, DistributedAlgorithmNode, StarNodeTrampoline>(m, "StarNode")
-      .def(nb::init<const string&, MessageBrokerType>(),
-           "node_id"_a, "messaging_backend"_a = MessageBrokerType::GRPC)
-      .def(nb::init<const string&, const string&, MessageBrokerType>(),
-           "node_id"_a, "server_id"_a, "messaging_backend"_a = MessageBrokerType::GRPC);
+    // StarNode.h bindings
+    nb::class_<StarNode, DistributedAlgorithmNode, StarNodeTrampoline>(m, "StarNode")
+        .def(nb::init<const string&, MessageBrokerType>(),
+             "node_id"_a,
+             "messaging_backend"_a = MessageBrokerType::GRPC)
+        .def(nb::init<const string&, const string&, MessageBrokerType>(),
+             "node_id"_a,
+             "server_id"_a,
+             "messaging_backend"_a = MessageBrokerType::GRPC);
 
     // DASNode.h
     nb::class_<DASNode, StarNode>(m, "DASNode")
@@ -159,7 +162,6 @@ NB_MODULE(hyperon_das_node_ext, m) {
              "update_attention_broker"_a = false)
         .def("next_query_id", &DASNode::next_query_id)
         .def("message_factory", &DASNode::message_factory, "command"_a, "args"_a);
-
 
     // QueryAnswer.h bindings
     nb::class_<QueryAnswer>(m, "QueryAnswer")
@@ -217,5 +219,4 @@ NB_MODULE(hyperon_das_node_ext, m) {
         .def("pop", [](RemoteIterator<HandlesAnswer>& self) -> shared_ptr<HandlesAnswer> {
             return shared_ptr<HandlesAnswer>((HandlesAnswer*) self.pop());
         });
-
 }

--- a/src/hyperon_das_node/hyperon_das_node_ext.cc
+++ b/src/hyperon_das_node/hyperon_das_node_ext.cc
@@ -96,6 +96,7 @@ NB_MODULE(hyperon_das_node_ext, m) {
     nb::enum_<MessageBrokerType>(m, "MessageBrokerType")
         .value("GRPC", MessageBrokerType::GRPC)
         .value("RAM", MessageBrokerType::RAM);
+        .export_values();
 
   // DistributedAlgorithmNode.h bindings
   nb::class_<DistributedAlgorithmNode, MessageFactory, DistributedAlgorithmNodeTrampoline>(
@@ -117,6 +118,8 @@ NB_MODULE(hyperon_das_node_ext, m) {
            "node_id"_a)
       .def("cast_leadership_vote", &DistributedAlgorithmNode::cast_leadership_vote)
       .def("message_factory", &DistributedAlgorithmNode::message_factory);
+
+  // StarNode.h bindings
   nb::class_<StarNode, DistributedAlgorithmNode>(m, "StarNode")
       .def(nb::init<const string&, MessageBrokerType>(),
            "node_id"_a, "messaging_backend"_a = MessageBrokerType::GRPC)

--- a/src/hyperon_das_node/hyperon_das_node_ext.cc
+++ b/src/hyperon_das_node/hyperon_das_node_ext.cc
@@ -137,6 +137,11 @@ NB_MODULE(hyperon_das_node_ext, m) {
              "server_id"_a,
              "messaging_backend"_a = MessageBrokerType::GRPC);
 
+    // TODO: Bindings after this comment belong to hyperon_das_query_engine_ext
+    // This is an easy fix because DASNode is a child of StarNode, and
+    // currently we could not figure out a way to make such inheritance without
+    // duplicating the binding structure in hyperon_das_query_engine_ext.
+
     // DASNode.h
     nb::class_<DASNode, StarNode>(m, "DASNode")
         .def(nb::init<const string&>(), "node_id"_a)

--- a/src/tests/python/unit/BUILD
+++ b/src/tests/python/unit/BUILD
@@ -189,7 +189,6 @@ py_test(
 
 py_test(
     name = "test_star_node",
-    tags = ["skip"],
     size = "small",
     srcs = ["test_star_node.py"],
     deps = [
@@ -199,7 +198,6 @@ py_test(
 
 py_test(
     name = "test_das_node",
-    tags = ["skip"],
     size = "small",
     srcs = ["test_das_node.py"],
     deps = [

--- a/src/tests/python/unit/test_das_node.py
+++ b/src/tests/python/unit/test_das_node.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from time import sleep
 
 from hyperon_das_query_engine import (
     DASNode,
@@ -73,6 +74,8 @@ class TestDASNode(TestCase):
         self.server = DASNode(node_id=self.server_id)
         self.client1 = DASNode(node_id=self.client1_id, server_id=self.server_id)
         self.client2 = DASNode(node_id=self.client2_id, server_id=self.server_id)
+
+        sleep(1)
 
         # Test id assignment
         self.assertEqual(self.server.node_id(), self.server_id)

--- a/src/tests/python/unit/test_star_node.py
+++ b/src/tests/python/unit/test_star_node.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from time import sleep
 
 from hyperon_das_node import StarNode
 
@@ -25,6 +26,8 @@ class TestStarNode(TestCase):
         self.server = StarNode(node_id=self.server_id)
         self.client1 = StarNode(node_id=self.client1_id, server_id=self.server_id)
         self.client2 = StarNode(node_id=self.client2_id, server_id=self.server_id)
+
+        sleep(1)
 
         # Test id assignment
         self.assertEqual(self.server.node_id(), self.server_id)


### PR DESCRIPTION
closes #305

## Binding
review constness of string in constructors of DistributedAlgorithmNode and StarNode
added the missing `.export_values()` to MessageBrokerTypes

Merged hyperon_das_query_engine bindings into hyperon_das_node as an easy fix, left TODO comments on the code to  figure out an elegant way to join both bindings.

## Tests
Added the same sleep behaviour on the StarNode and DASNode tests in python, present in C++ tests.
