### PR TITLE
[#330] small improvements on Makefile and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ reset-nunet-dms:
 
 bazel:
 	@bash ./src/scripts/bazel.sh \
-	    `[ -n ${BAZEL_JOBS} ] && echo --jobs=${BAZEL_JOBS}` \
+	    `[ "${BAZEL_JOBS:-x}" != "x" ] && echo --jobs="${BAZEL_JOBS}"` \
 		$(filter-out $@, $(MAKECMDGOALS))
 
 test-all-no-cache:

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,7 @@ reset-nunet-dms:
 	@bash -x src/scripts/reset-nunet-dms.sh
 
 bazel:
-	@bash ./src/scripts/bazel.sh \
-	    `[ "${BAZEL_JOBS:-x}" != "x" ] && echo --jobs="${BAZEL_JOBS}"` \
-		$(filter-out $@, $(MAKECMDGOALS))
+	@bash ./src/scripts/bazel.sh $(filter-out $@, $(MAKECMDGOALS))
 
 test-all-no-cache:
 	@$(MAKE) bazel 'test --cache_test_results=no //tests/...'

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,15 @@ reset-nunet-dms:
 	@bash -x src/scripts/reset-nunet-dms.sh
 
 bazel:
-	@bash ./src/scripts/bazel.sh $(filter-out $@, $(MAKECMDGOALS))
+	@bash ./src/scripts/bazel.sh \
+	    `[ -n ${BAZEL_JOBS} ] && echo --jobs=${BAZEL_JOBS}` \
+		$(filter-out $@, $(MAKECMDGOALS))
+
+test-all-no-cache:
+	@$(MAKE) bazel 'test --cache_test_results=no //tests/...'
 
 test-all: build-image
-	@$(MAKE) bazel test //...
+	@$(MAKE) bazel test //tests/...
 
 lint-all:
 	@$(MAKE) bazel lint \

--- a/src/scripts/bazel.sh
+++ b/src/scripts/bazel.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-set -eou pipefail
+set -exou pipefail
 
 IMAGE_NAME="das-builder"
 CONTAINER_NAME=${IMAGE_NAME}-container
 BAZEL_CMD="/opt/bazel/bazelisk"
+
+ENV_VARS=$(printenv | sort | awk -F= '{print "--env "$1}')
 
 # local paths
 LOCAL_WORKDIR=$(pwd)
@@ -42,6 +44,7 @@ docker run --rm \
   --user="$(id -u)":"$(id -g)" \
   --name=$CONTAINER_NAME \
   -e BIN_DIR=$CONTAINER_BIN_DIR \
+  $ENV_VARS \
   --network=host \
   --volume /etc/passwd:/etc/passwd:ro \
   --volume "$LOCAL_PIP_CACHE":"$CONTAINER_PIP_CACHE" \

--- a/src/scripts/bazel.sh
+++ b/src/scripts/bazel.sh
@@ -56,4 +56,4 @@ docker run --rm \
   --workdir "$CONTAINER_WORKSPACE_DIR" \
   --entrypoint "$BAZEL_CMD" \
   "${IMAGE_NAME}" \
-  "$@"
+  $([ ${BAZEL_JOBS:-x} != x ] && echo --jobs=${BAZEL_JOBS}) "$@"

--- a/src/tests/cpp/remote_sink_iterator_test.cc
+++ b/src/tests/cpp/remote_sink_iterator_test.cc
@@ -38,6 +38,7 @@ TEST(RemoteSinkIterator, basics) {
 
     Utils::sleep(1000);
 
+    EXPECT_FALSE(producer.is_work_done());
     EXPECT_FALSE(consumer.finished());
 
     HandlesAnswer* qa;
@@ -69,6 +70,9 @@ TEST(RemoteSinkIterator, basics) {
     EXPECT_FALSE((qa = dynamic_cast<HandlesAnswer*>(consumer.pop())) == NULL);
     EXPECT_TRUE(strcmp(qa->handles[0], "h2") == 0);
     EXPECT_TRUE(double_equals(qa->importance, 0.2));
-    Utils::sleep(5000);  // XXXXXXXXXXXXXXXXXXXXXXXXXXX
+    size_t count = 0;
+    while (!producer.is_work_done() && count++ < 10) Utils::sleep(1000);  // 1 second
+    EXPECT_TRUE(producer.is_work_done());
+    Utils::sleep(1000);                                                   // 1 second
     EXPECT_TRUE(consumer.finished());
 }


### PR DESCRIPTION
Closes #330 

- Currently, bazel is executed with `--jobs=HOST_CPUS*0.5` (defined in the `.bazelrc` file), which means that in a machine with 12 cpu threads, bazel will run with 6 simultaneous jobs. This was made to prevent bazel to occupy 100% of the cpu resources. However, if the developer hardware is powerful enough or if there is no other heavy process competing with bazel, the developer might want to give all power to bazel. This PR allows that by making the bazel runner look for an environment variable named `BAZEL_JOBS`, that can have any arbritary value, and use it with the `--jobs` argument. If the env var is not present, bazel will still fallback to `--jobs=HOST_CPUS*0.5`.

- This PR also adds a new target to the `Makefile`: `test-all-no-cache` (self-explanatory, I guess).

- On master, `src/tests/cpp/remote_sink_iterator_test.cc` is eventually failing due to _**race timing conditions**_ in the communication between _consumer_ and _producer_ and the end of test process (which is when the objects are destroyed). Trying to avoid that, André added a 5 seconds sleep before the last assertion. However, there is a more appropriate way to prevent the issue, which is to ensure the producer has finished its work. This PR is doing that as well.