### PR TITLE
[HOTFIX] Query agent is breaking when empty LinkTemplate is passed as one of its clauses

### DIFF
--- a/src/query_engine/query_element/And.h
+++ b/src/query_engine/query_element/And.h
@@ -201,6 +201,9 @@ class And : public Operator<N> {
             return false;
         } else {
             for (unsigned int i = 0; i < N; i++) {
+                if ((this->next_input_to_process[i] == this->query_answer[i].size()) && (this->all_answers_arrived[i])) {
+                    return true;
+                }
                 if (this->next_input_to_process[i] < this->query_answer[i].size()) {
                     return false;
                 }
@@ -275,6 +278,9 @@ class And : public Operator<N> {
             }
 
             if (this->border.size() == 0) {
+                if (processed_all_input()) {
+                    continue;
+                }
                 CandidateRecord candidate;
                 double fitness = 1.0;
                 for (unsigned int i = 0; i < N; i++) {

--- a/src/tests/cpp/and_operator_test.cc
+++ b/src/tests/cpp/and_operator_test.cc
@@ -61,8 +61,8 @@ void check_query_answer(string tag,
 }
 
 TEST(AndOperator, basics) {
-    TestSource* source1 = new TestSource(1);
-    TestSource* source2 = new TestSource(2);
+    TestSource* source1 = new TestSource(10);
+    TestSource* source2 = new TestSource(20);
     And<2>* and_operator = new And<2>({source1, source2});
     TestSink sink(and_operator);
     HandlesAnswer* query_answer;
@@ -239,4 +239,26 @@ TEST(AndOperator, operation_logic) {
     for (unsigned int clause = 0; clause < clause_count; clause++) {
         delete source[clause];
     }
+}
+
+TEST(AndOperator, empty_source) {
+    TestSource* source1 = new TestSource(100);
+    TestSource* source2 = new TestSource(200);
+    And<2>* and_operator = new And<2>({source1, source2});
+    TestSink sink(and_operator);
+    HandlesAnswer* query_answer;
+    Utils::sleep(1000);
+
+    EXPECT_TRUE(sink.empty());
+    EXPECT_FALSE(sink.finished());
+
+    source2->add("h2_0", 0.3, {"v1_1"}, {"2"});
+    source2->add("h2_1", 0.2, {"v2_1"}, {"1"});
+    EXPECT_TRUE(sink.empty());
+    EXPECT_FALSE(sink.finished());
+    source1->query_answers_finished();
+    source2->query_answers_finished();
+    Utils::sleep(SLEEP_DURATION);
+    EXPECT_TRUE(sink.empty());
+    EXPECT_TRUE(sink.finished());
 }


### PR DESCRIPTION
"And" operator was not checking for scenarios when one or more of the clauses are empty (i.e. has no QueryAnswer to provide).  This condition was making it crash.

The fix is to make the check and prevent the operator from trying to expand the border if that condition holds.