### PR TITLE
[Fix] Add `update_attention_broker` to query client

### DIFF
--- a/src/main/query_client_main.cc
+++ b/src/main/query_client_main.cc
@@ -21,27 +21,28 @@ void ctrl_c_handler(int) {
 }
 
 int main(int argc, char* argv[]) {
-    if (argc < 4) {
+    if (argc < 5) {
         cerr << "Usage: " << argv[0]
-             << " CLIENT_HOST:CLIENT_PORT SERVER_HOST:SERVER_PORT QUERY_TOKEN+ (hosts are supposed to "
-                "be public IPs or known hostnames)"
+             << " CLIENT_HOST:CLIENT_PORT SERVER_HOST:SERVER_PORT UPDATE_ATTENTION_BROKER QUERY_TOKEN+ "
+                "(hosts are supposed to be public IPs or known hostnames)"
              << endl;
         exit(1);
     }
 
     string client_id = string(argv[1]);
     string server_id = string(argv[2]);
+    bool update_attention_broker = (string(argv[3]) == "true" || string(argv[3]) == "1");
 
     signal(SIGINT, &ctrl_c_handler);
     vector<string> query;
-    for (int i = 3; i < argc; i++) {
+    for (int i = 4; i < argc; i++) {
         query.push_back(argv[i]);
     }
 
     DASNode client(client_id, server_id);
     QueryAnswer* query_answer;
     unsigned int count = 0;
-    RemoteIterator<HandlesAnswer>* response = client.pattern_matcher_query(query);
+    RemoteIterator<HandlesAnswer>* response = client.pattern_matcher_query(query, "", update_attention_broker);
     while (!response->finished()) {
         if ((query_answer = response->pop()) == NULL) {
             Utils::sleep();

--- a/src/main/query_client_main.cc
+++ b/src/main/query_client_main.cc
@@ -42,7 +42,8 @@ int main(int argc, char* argv[]) {
     DASNode client(client_id, server_id);
     QueryAnswer* query_answer;
     unsigned int count = 0;
-    RemoteIterator<HandlesAnswer>* response = client.pattern_matcher_query(query, "", update_attention_broker);
+    RemoteIterator<HandlesAnswer>* response =
+        client.pattern_matcher_query(query, "", update_attention_broker);
     while (!response->finished()) {
         if ((query_answer = response->pop()) == NULL) {
             Utils::sleep();


### PR DESCRIPTION
This PR adds the `update_attention_broker` flag to the `./bin/query` client:

```
Usage: ./src/bin/query CLIENT_HOST:CLIENT_PORT SERVER_HOST:SERVER_PORT UPDATE_ATTENTION_BROKER QUERY_TOKEN+ (hosts are supposed to be public IPs or known hostnames)
```

User must set it to `true` by sending a `1` or `true`, any other value (eg `0` / `false` / ` `) will set the flag to `false`:
```
# update_attention_broker = false
./query 0.0.0.0:7777 0.0.0.0:31700 0 LINK_TEMPLATE Expression 3 NODE Symbol Similarity VARIABLE V1 VARIABLE V2
./query 0.0.0.0:7777 0.0.0.0:31700 false LINK_TEMPLATE Expression 3 NODE Symbol Similarity VARIABLE V1 VARIABLE V2

# update_attention_broker = true
./query 0.0.0.0:7777 0.0.0.0:31700 1 LINK_TEMPLATE Expression 3 NODE Symbol Similarity VARIABLE V1 VARIABLE V2
./query 0.0.0.0:7777 0.0.0.0:31700 true LINK_TEMPLATE Expression 3 NODE Symbol Similarity VARIABLE V1 VARIABLE V2
```

Possible bug (if this PR is fine, we do have a bug):

1 - Load the `animals.metta` into the DBs
2 - Run `make run-attention-broker`
3 - Run `make run-query-agent`
4 - Run `./query` in another terminal:

Not updating AB is fine:
```
./query 0.0.0.0:7777 0.0.0.0:31700 0 LINK_TEMPLATE Expression 3 NODE Symbol Similarity VARIABLE V1 NODE Symbol "\"monkey\""

>>>
DASNode::pattern_matcher_query() BEGIN
DASNode::pattern_matcher_query() tokens.size(): 11
DASNode::pattern_matcher_query() context: 
DASNode::pattern_matcher_query() update_attention_broker: 0
DASNode::next_query_id(): 0.0.0.0:60999
DASNode::pattern_matcher_query() END
SynchronousGRPC listening on 0.0.0.0:60999
HandlesAnswer<1,1> [7ec8526b8c8f15a6ac55273fedbf694f] {(V1: 8860480382d0ddf62623abf5c860e51d)} 0.000000
HandlesAnswer<1,1> [ecb646aa07a906dc3db6588a1681f13d] {(V1: 3225ea795289574ceee32e091ad54ef4)} 0.000000
...
```

But if we set the `update_attention_broker`, then the query agent crashed with:
```
./query 0.0.0.0:7777 0.0.0.0:31700 1 LINK_TEMPLATE Expression 3 NODE Symbol Similarity VARIABLE V1 NODE Symbol "\"monkey\""

>>>
SynchronousGRPC listening on 0.0.0.0:7777
DASNode::pattern_matcher_query() BEGIN
DASNode::pattern_matcher_query() tokens.size(): 11
DASNode::pattern_matcher_query() context: 
DASNode::pattern_matcher_query() update_attention_broker: 1
DASNode::next_query_id(): 0.0.0.0:60999
DASNode::pattern_matcher_query() END
SynchronousGRPC listening on 0.0.0.0:60999

query-agent logs:
>>> 
PatternMatchingQuery::PatternMatchingQuery() BEGIN
PatternMatchingQuery::PatternMatchingQuery() tokens_count: 14
PatternMatchingQuery::PatternMatchingQuery() END
PatternMatchingQuery::act() BEGIN
PatternMatchingQuery::act() this->requestor_id: 0.0.0.0:60999
DASNode::next_query_id(): 0.0.0.0:60007
SynchronousGRPC listening on 0.0.0.0:60007
AttentionBrokerUpdater::AttentionBrokerUpdater() attention_broker_address: localhost:37007
LinkTemplate::setup_buffers() BEGIN
fetch_links() BEGIN
fetch_links() Pattern handle: 4b3c7f8a5765809e65c1842afb3729d9
fetch_links() ac: 2
fetch_links() END
LinkTemplate::setup_buffers() END
PatternMatchingQuery::act() END
RemoteSink::queue_processor_method() BEGIN
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1743108808.356445     603 wire_format_lite.cc:610] String field 'dasproto.HandleList.list' contains invalid UTF-8 data when serializing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes. 
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed GRPC command: AttentionBroker::correlate()
```