### PR TITLE
[HOTFIX] Fix bad use of freed QueryAnswer by AttentionBrokerUpdater

### DIFF
--- a/src/query_engine/answer_processor/AttentionBrokerUpdater.h
+++ b/src/query_engine/answer_processor/AttentionBrokerUpdater.h
@@ -125,6 +125,7 @@ class AttentionBrokerUpdater : public QueryAnswerProcessor {
                 for (unsigned int i = 0; i < queue_record->size; i++) {
                     execution_stack.push(string(queue_record->handles[i]));
                 }
+                delete queue_record;
                 while (!execution_stack.empty()) {
                     handle = execution_stack.top();
                     execution_stack.pop();

--- a/src/query_engine/answer_processor/AttentionBrokerUpdater.h
+++ b/src/query_engine/answer_processor/AttentionBrokerUpdater.h
@@ -31,16 +31,15 @@ class AttentionBrokerUpdater : public QueryAnswerProcessor {
     class QueueRecord {
        public:
         unsigned int size;
-        char **handles;
-        QueueRecord(HandlesAnswer *answer) {
+        char** handles;
+        QueueRecord(HandlesAnswer* answer) {
             this->size = answer->handles_size;
-            this->handles = (char **) malloc(answer->handles_size * sizeof(char *));
-            memcpy(this->handles, answer->handles, answer->handles_size * sizeof(char *));
+            this->handles = (char**) malloc(answer->handles_size * sizeof(char*));
+            memcpy(this->handles, answer->handles, answer->handles_size * sizeof(char*));
         }
-        ~QueueRecord() {
-            free(this->handles);
-        }
+        ~QueueRecord() { free(this->handles); }
     };
+
    public:
     AttentionBrokerUpdater(const string& query_context = "")
         : attention_broker_address(ATTENTION_BROKER_ADDRESS),
@@ -59,7 +58,7 @@ class AttentionBrokerUpdater : public QueryAnswerProcessor {
     }
     virtual ~AttentionBrokerUpdater() { this->graceful_shutdown(); };
     virtual void process_answer(QueryAnswer* query_answer) override {
-        QueueRecord *record = new QueueRecord((HandlesAnswer *) query_answer);
+        QueueRecord* record = new QueueRecord((HandlesAnswer*) query_answer);
         this->answers_queue.enqueue((void*) record);
     }
     virtual void query_answers_finished() override { this->set_flow_finished(); }

--- a/src/query_engine/answer_processor/AttentionBrokerUpdater.h
+++ b/src/query_engine/answer_processor/AttentionBrokerUpdater.h
@@ -27,6 +27,20 @@ namespace query_engine {
 constexpr char* ATTENTION_BROKER_ADDRESS = "localhost:37007";
 
 class AttentionBrokerUpdater : public QueryAnswerProcessor {
+   private:
+    class QueueRecord {
+       public:
+        unsigned int size;
+        char **handles;
+        QueueRecord(HandlesAnswer *answer) {
+            this->size = answer->handles_size;
+            this->handles = (char **) malloc(answer->handles_size * sizeof(char *));
+            memcpy(this->handles, answer->handles, answer->handles_size * sizeof(char *));
+        }
+        ~QueueRecord() {
+            free(this->handles);
+        }
+    };
    public:
     AttentionBrokerUpdater(const string& query_context = "")
         : attention_broker_address(ATTENTION_BROKER_ADDRESS),
@@ -45,7 +59,8 @@ class AttentionBrokerUpdater : public QueryAnswerProcessor {
     }
     virtual ~AttentionBrokerUpdater() { this->graceful_shutdown(); };
     virtual void process_answer(QueryAnswer* query_answer) override {
-        this->answers_queue.enqueue((void*) query_answer);
+        QueueRecord *record = new QueueRecord((HandlesAnswer *) query_answer);
+        this->answers_queue.enqueue((void*) record);
     }
     virtual void query_answers_finished() override { this->set_flow_finished(); }
     virtual void graceful_shutdown() override {
@@ -94,10 +109,10 @@ class AttentionBrokerUpdater : public QueryAnswerProcessor {
                 break;
             }
             bool idle_flag = true;
-            HandlesAnswer* handles_answer;
+            QueueRecord* queue_record;
             string handle;
             unsigned int count;
-            while ((handles_answer = (HandlesAnswer*) this->answers_queue.dequeue()) != NULL) {
+            while ((queue_record = ((QueueRecord*) (this->answers_queue.dequeue()))) != NULL) {
                 if (stimulated_count == MAX_STIMULATE_COUNT) {
                     continue;
                 }
@@ -108,8 +123,8 @@ class AttentionBrokerUpdater : public QueryAnswerProcessor {
                          << count_total_processed << endl;
                 }
 #endif
-                for (unsigned int i = 0; i < handles_answer->handles_size; i++) {
-                    execution_stack.push(string(handles_answer->handles[i]));
+                for (unsigned int i = 0; i < queue_record->size; i++) {
+                    execution_stack.push(string(queue_record->handles[i]));
                 }
                 while (!execution_stack.empty()) {
                     handle = execution_stack.top();

--- a/src/query_engine/query_element/And.h
+++ b/src/query_engine/query_element/And.h
@@ -201,7 +201,8 @@ class And : public Operator<N> {
             return false;
         } else {
             for (unsigned int i = 0; i < N; i++) {
-                if ((this->next_input_to_process[i] == this->query_answer[i].size()) && (this->all_answers_arrived[i])) {
+                if ((this->next_input_to_process[i] == this->query_answer[i].size()) &&
+                    (this->all_answers_arrived[i])) {
                     return true;
                 }
                 if (this->next_input_to_process[i] < this->query_answer[i].size()) {


### PR DESCRIPTION
The bug was reported here: https://github.com/singnet/das/pull/340

The problem is that the same QueryAnswer was being added to the queue of HandlesAnswerProcessor and AttentionBrokerUpdater. But the former relies on QueryNode to delete the QueryAnswer (which seems correct). When a pair of remote sink/iterator is being used, QueryNode deletes the QueryAnswer as soon as it tokenize it (which also seems correct, because only the tokens goes forward being queued to be sent to remote peer and the QueryAnswer is no longer required). But there's no guarantee that this QueryAnswer has already being processed by the AttentionBrokerUpdater. So we have a race condition here.

The more elegant fix would be to use some sort of signaling among the processors to guarantee that all processors have processed the answer before it's deleted. Such a more elegant fix would allow us implement other processors without this concern. However, I couldn't figure out a design which is elegant, simple to implement  AND implies in small overhead.

So I'm just copying the relevant data from QueryAnswers fed into the AttentionBrokerUpdater and storing this copy instead of the QueryAnswer itself. This copy has overhead, of course, but I kept it at a minimum.

I'm also adding a card so we can re-visit this issue in the future: https://github.com/orgs/singnet/projects/6/views/10?pane=issue&itemId=104048790&issue=singnet%7Cdas%7C341