### PR TITLE
[#328] Add HandleSet type

### DIFF
--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -13,7 +13,7 @@ class AtomDB {
 
     static inline string WILDCARD = "*";
 
-    virtual vector<string> query_for_pattern(shared_ptr<char> pattern_handle) = 0;
+    virtual shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(shared_ptr<char> pattern_handle) = 0;
     virtual shared_ptr<atomdb_api_types::HandleList> query_for_targets(shared_ptr<char> link_handle) = 0;
     virtual shared_ptr<atomdb_api_types::HandleList> query_for_targets(char* link_handle_ptr) = 0;
     virtual shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle) = 0;

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -13,7 +13,8 @@ class AtomDB {
 
     static inline string WILDCARD = "*";
 
-    virtual shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(shared_ptr<char> pattern_handle) = 0;
+    virtual shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(
+        shared_ptr<char> pattern_handle) = 0;
     virtual shared_ptr<atomdb_api_types::HandleList> query_for_targets(shared_ptr<char> link_handle) = 0;
     virtual shared_ptr<atomdb_api_types::HandleList> query_for_targets(char* link_handle_ptr) = 0;
     virtual shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle) = 0;

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -24,22 +24,22 @@ namespace atomdb_api_types {
 // -------------------------------------------------------------------------------------------------
 
 class HandleList {
-    public:
-     HandleList() {}
-     virtual ~HandleList() {}
- 
-     virtual const char* get_handle(unsigned int index) = 0;
-     virtual unsigned int size() = 0;
+   public:
+    HandleList() {}
+    virtual ~HandleList() {}
+
+    virtual const char* get_handle(unsigned int index) = 0;
+    virtual unsigned int size() = 0;
 };
 
 class HandleSet {
-    public:
-     HandleSet() {}
-     virtual ~HandleSet() {}
- 
-     virtual unsigned int size() = 0;
-     virtual void append(void* data) = 0;
-     virtual char* next() = 0;
+   public:
+    HandleSet() {}
+    virtual ~HandleSet() {}
+
+    virtual unsigned int size() = 0;
+    virtual void append(void* data) = 0;
+    virtual char* next() = 0;
 };
 
 class AtomDocument {

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -32,14 +32,19 @@ class HandleList {
     virtual unsigned int size() = 0;
 };
 
+class HandleSetIterator {
+    public:
+     virtual char* next() = 0;
+};
+
 class HandleSet {
    public:
     HandleSet() {}
     virtual ~HandleSet() {}
 
     virtual unsigned int size() = 0;
-    virtual void append(void* data) = 0;
-    virtual char* next() = 0;
+    virtual void append(shared_ptr<HandleSet> other) = 0;
+    virtual shared_ptr<HandleSetIterator> get_iterator() = 0;
 };
 
 class AtomDocument {

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -1,14 +1,4 @@
-#ifndef _QUERY_ENGINE_ATOMDBAPITYPES_H
-#define _QUERY_ENGINE_ATOMDBAPITYPES_H
-
-#include <hiredis_cluster/hircluster.h>
-
-#include <bsoncxx/builder/basic/document.hpp>
-#include <bsoncxx/json.hpp>
-#include <mongocxx/client.hpp>
-#include <mongocxx/exception/exception.hpp>
-#include <mongocxx/instance.hpp>
-#include <mongocxx/uri.hpp>
+#pragma once
 
 #include "Utils.h"
 
@@ -34,40 +24,22 @@ namespace atomdb_api_types {
 // -------------------------------------------------------------------------------------------------
 
 class HandleList {
-   public:
-    HandleList() {}
-    virtual ~HandleList() {}
-
-    virtual const char* get_handle(unsigned int index) = 0;
-    virtual unsigned int size() = 0;
+    public:
+     HandleList() {}
+     virtual ~HandleList() {}
+ 
+     virtual const char* get_handle(unsigned int index) = 0;
+     virtual unsigned int size() = 0;
 };
 
-class RedisSet : public HandleList {
-   public:
-    RedisSet(redisReply* reply);
-    ~RedisSet();
-
-    const char* get_handle(unsigned int index);
-    unsigned int size();
-
-   private:
-    unsigned int handles_size;
-    char** handles;
-    redisReply* redis_reply;
-};
-
-class RedisStringBundle : public HandleList {
-   public:
-    RedisStringBundle(redisReply* reply);
-    ~RedisStringBundle();
-
-    const char* get_handle(unsigned int index);
-    unsigned int size();
-
-   private:
-    unsigned int handles_size;
-    char** handles;
-    redisReply* redis_reply;
+class HandleSet {
+    public:
+     HandleSet() {}
+     virtual ~HandleSet() {}
+ 
+     virtual unsigned int size() = 0;
+     virtual void append(void* data) = 0;
+     virtual char* next() = 0;
 };
 
 class AtomDocument {
@@ -80,20 +52,5 @@ class AtomDocument {
     virtual unsigned int get_size(const string& array_key) = 0;
 };
 
-class MongodbDocument : public AtomDocument {
-   public:
-    MongodbDocument(core::v1::optional<bsoncxx::v_noabi::document::value>& document);
-    ~MongodbDocument();
-
-    const char* get(const string& key);
-    virtual const char* get(const string& array_key, unsigned int index);
-    virtual unsigned int get_size(const string& array_key);
-
-   private:
-    core::v1::optional<bsoncxx::v_noabi::document::value> document;
-};
-
 }  // namespace atomdb_api_types
 }  // namespace atomdb
-
-#endif  // _QUERY_ENGINE_ATOMDBAPITYPES_H

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -33,8 +33,8 @@ class HandleList {
 };
 
 class HandleSetIterator {
-    public:
-     virtual char* next() = 0;
+   public:
+    virtual char* next() = 0;
 };
 
 class HandleSet {

--- a/src/atomdb/BUILD
+++ b/src/atomdb/BUILD
@@ -10,11 +10,19 @@ cc_library(
 
 cc_library(
   name = "atomdb_api_types",
-  srcs = ["AtomDBAPITypes.cc"],
   hdrs = ["AtomDBAPITypes.h"],
   deps = [
     "//hasher:hasher_lib",
     "//commons:commons_lib",
+  ],
+)
+
+cc_library(
+  name = "redis_mongodb_api_types",
+  srcs = ["RedisMongoDBAPITypes.cc"],
+  hdrs = ["RedisMongoDBAPITypes.h"],
+  deps = [
+    ":atomdb_api_types",
   ],
 )
 
@@ -36,7 +44,7 @@ cc_library(
   includes = ["."],
   deps = [
     ":atomdb",
-    ":atomdb_api_types",
+    ":redis_mongodb_api_types",
     "//attention_broker:attention_broker_server_lib",
     "//commons:commons_lib",
   ],

--- a/src/atomdb/RedisMongoDB.cc
+++ b/src/atomdb/RedisMongoDB.cc
@@ -149,7 +149,7 @@ shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(
     redisReply* reply;
 
     shared_ptr<atomdb_api_types::HandleSetRedis> handle_set =
-        std::make_shared<atomdb_api_types::HandleSetRedis>();
+        make_shared<atomdb_api_types::HandleSetRedis>();
 
     while (redis_has_more) {
         command = ("ZRANGE " + REDIS_PATTERNS_PREFIX + ":" + pattern_handle.get() + " " +
@@ -171,7 +171,7 @@ shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(
         redis_cursor += REDIS_CHUNK_SIZE;
         redis_has_more = (reply->elements == REDIS_CHUNK_SIZE);
 
-        handle_set->append(reply);
+        handle_set->append(make_shared<atomdb_api_types::HandleSetRedis>(reply));
     }
 
     return handle_set;

--- a/src/atomdb/RedisMongoDB.cc
+++ b/src/atomdb/RedisMongoDB.cc
@@ -171,7 +171,7 @@ shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(
         redis_cursor += REDIS_CHUNK_SIZE;
         redis_has_more = (reply->elements == REDIS_CHUNK_SIZE);
 
-        handle_set->append(make_shared<atomdb_api_types::HandleSetRedis>(reply));
+        handle_set->append(make_shared<atomdb_api_types::HandleSetRedis>(reply, false));
     }
 
     return handle_set;

--- a/src/atomdb/RedisMongoDB.cc
+++ b/src/atomdb/RedisMongoDB.cc
@@ -141,13 +141,15 @@ void RedisMongoDB::mongodb_setup() {
     }
 }
 
-shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(std::shared_ptr<char> pattern_handle) {
+shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(
+    std::shared_ptr<char> pattern_handle) {
     unsigned int redis_cursor = 0;
     bool redis_has_more = true;
     string command;
     redisReply* reply;
 
-    shared_ptr<atomdb_api_types::HandleSetRedis> handle_set = std::make_shared<atomdb_api_types::HandleSetRedis>();
+    shared_ptr<atomdb_api_types::HandleSetRedis> handle_set =
+        std::make_shared<atomdb_api_types::HandleSetRedis>();
 
     while (redis_has_more) {
         command = ("ZRANGE " + REDIS_PATTERNS_PREFIX + ":" + pattern_handle.get() + " " +

--- a/src/atomdb/RedisMongoDB.h
+++ b/src/atomdb/RedisMongoDB.h
@@ -11,28 +11,13 @@
 #include <vector>
 
 #include "AtomDB.h"
-#include "AtomDBAPITypes.h"
+#include "RedisMongoDBAPITypes.h"
 
 using namespace std;
 
 namespace atomdb {
 
 enum MONGODB_FIELD { ID = 0, size };
-
-// -------------------------------------------------------------------------------------------------
-// NOTE TO REVIEWER:
-//
-// This class will be replaced/integrated by/with classes already implemented in das-atom-db.
-//
-// However, that classes will need to be revisited in order to allow the methods implemented here
-// because although the design of such methods is nasty, they have the string advantage of
-// allowing the reuse of structures allocated by the DBMS (Redis an MongoDB) withpout the need
-// of re-allocation of other dataclasses. Although this nasty behavior may not be desirable
-// outside the DAS bounds, it's quite appealing inside the query engine (and perhaps other
-// parts of internal stuff).
-//
-// I think it's pointless to make any further documentation while we don't make this integrfation.
-// -------------------------------------------------------------------------------------------------
 
 class RedisMongoDB : public AtomDB {
    public:
@@ -55,7 +40,7 @@ class RedisMongoDB : public AtomDB {
         MONGODB_FIELD_NAME[MONGODB_FIELD::ID] = "_id";
     }
 
-    vector<string> query_for_pattern(shared_ptr<char> pattern_handle);
+    shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(shared_ptr<char> pattern_handle);
     shared_ptr<atomdb_api_types::HandleList> query_for_targets(shared_ptr<char> link_handle);
     shared_ptr<atomdb_api_types::HandleList> query_for_targets(char* link_handle_ptr);
     shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle);

--- a/src/atomdb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/RedisMongoDBAPITypes.cc
@@ -90,7 +90,7 @@ const char* RedisStringBundle::get_handle(unsigned int index) {
         Utils::error("Handle index out of bounds: " + to_string(index) +
                      " Answer handles size: " + to_string(this->handles_size));
     }
-    // 
+    //
     return handles[index];
 }
 

--- a/src/atomdb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/RedisMongoDBAPITypes.cc
@@ -9,16 +9,22 @@ using namespace atomdb;
 using namespace atomdb_api_types;
 using namespace commons;
 
-HandleSetRedis::HandleSetRedis() : HandleSet() { this->handles_size = 0; }
+HandleSetRedis::HandleSetRedis(bool delete_replies_on_destruction) : HandleSet() {
+    this->handles_size = 0;
+    this->delete_replies_on_destruction = delete_replies_on_destruction;
+}
 
-HandleSetRedis::HandleSetRedis(redisReply* reply) : HandleSet() {
+HandleSetRedis::HandleSetRedis(redisReply* reply, bool delete_replies_on_destruction) : HandleSet() {
     this->replies.push_back(reply);
     this->handles_size = reply->elements;
+    this->delete_replies_on_destruction = delete_replies_on_destruction;
 }
 
 HandleSetRedis::~HandleSetRedis() {
-    for (auto reply : this->replies) {
-        freeReplyObject(reply);
+    if (this->delete_replies_on_destruction) {
+        for (auto reply : this->replies) {
+            freeReplyObject(reply);
+        }
     }
 }
 

--- a/src/atomdb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/RedisMongoDBAPITypes.cc
@@ -9,9 +9,7 @@ using namespace atomdb;
 using namespace atomdb_api_types;
 using namespace commons;
 
-HandleSetRedis::HandleSetRedis() : HandleSet() {
-    this->handles_size = 0;
-}
+HandleSetRedis::HandleSetRedis() : HandleSet() { this->handles_size = 0; }
 
 HandleSetRedis::HandleSetRedis(redisReply* reply) : HandleSet() {
     this->replies.push_back(reply);
@@ -28,7 +26,7 @@ void HandleSetRedis::append(shared_ptr<HandleSet> other) {
     auto handle_set_redis = dynamic_pointer_cast<HandleSetRedis>(other);
     for (auto reply : handle_set_redis->replies) {
         this->replies.push_back(reply);
-        this->handles_size += reply->elements;    
+        this->handles_size += reply->elements;
     }
 }
 
@@ -45,7 +43,7 @@ HandleSetRedisIterator::HandleSetRedisIterator(HandleSetRedis* handle_set) {
     this->inner_idx = 0;
 };
 
-HandleSetRedisIterator::~HandleSetRedisIterator() {};
+HandleSetRedisIterator::~HandleSetRedisIterator(){};
 
 char* HandleSetRedisIterator::next() {
     if (this->outer_idx >= this->handle_set->replies.size()) {

--- a/src/atomdb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/RedisMongoDBAPITypes.cc
@@ -1,4 +1,4 @@
-#include "AtomDBAPITypes.h"
+#include "RedisMongoDBAPITypes.h"
 
 #include <cstring>
 
@@ -9,29 +9,63 @@ using namespace atomdb;
 using namespace atomdb_api_types;
 using namespace commons;
 
-RedisSet::RedisSet(redisReply* reply) : HandleList() {
-    this->redis_reply = reply;
+HandleSetRedis::HandleSetRedis() : HandleSet() {
+    this->handles_size = 0;
+    this->outer_idx = 0;
+    this->inner_idx = 0;
+}
+
+HandleSetRedis::HandleSetRedis(redisReply* reply) : HandleSet() {
+    this->replies.push_back(reply);
     this->handles_size = reply->elements;
-    this->handles = new char*[this->handles_size];
-    for (unsigned int i = 0; i < this->handles_size; i++) {
-        handles[i] = reply->element[i]->str;
+    this->outer_idx = 0;
+    this->inner_idx = 0;
+}
+
+HandleSetRedis::~HandleSetRedis() {
+    for (auto reply : this->replies) {
+        freeReplyObject(reply);
     }
 }
 
-RedisSet::~RedisSet() {
-    delete[] this->handles;
-    freeReplyObject(this->redis_reply);
+void HandleSetRedis::append(void* data) {
+    redisReply* reply = static_cast<redisReply*>(data);
+    this->handles_size += reply->elements;
+    this->replies.push_back(reply);
 }
 
-const char* RedisSet::get_handle(unsigned int index) {
-    if (index > this->handles_size) {
-        Utils::error("Handle index out of bounds: " + to_string(index) +
-                     " Answer array size: " + to_string(this->handles_size));
+unsigned int HandleSetRedis::size() { return this->handles_size; }
+
+char* HandleSetRedis::next() {
+    if (this->outer_idx >= this->replies.size()) {
+        // No more elements, reset indexes and return nullptr.
+        this->outer_idx = 0;
+        this->inner_idx = 0;
+        return nullptr;
     }
-    return handles[index];
-}
 
-unsigned int RedisSet::size() { return this->handles_size; }
+    redisReply* reply = this->replies[this->outer_idx];
+
+    // If inner_idx exists, get its element and bump it.
+    if (this->inner_idx < reply->elements) {
+        return reply->element[this->inner_idx++]->str;
+    }
+
+    // If not, point to the next outer_idx (redisReply)
+    this->outer_idx++;
+    this->inner_idx = 0;
+
+    // Get first element of the next redisReply
+    if (this->outer_idx < this->replies.size()) {
+        reply = this->replies[this->outer_idx];
+        return reply->element[this->inner_idx++]->str;
+    }
+
+    // No more elements, reset indexes and return nullptr
+    this->outer_idx = 0;
+    this->inner_idx = 0;
+    return nullptr;
+}
 
 RedisStringBundle::RedisStringBundle(redisReply* reply) : HandleList() {
     unsigned int handle_length = (HANDLE_HASH_SIZE - 1);
@@ -56,6 +90,7 @@ const char* RedisStringBundle::get_handle(unsigned int index) {
         Utils::error("Handle index out of bounds: " + to_string(index) +
                      " Answer handles size: " + to_string(this->handles_size));
     }
+    // 
     return handles[index];
 }
 

--- a/src/atomdb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/RedisMongoDBAPITypes.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "AtomDBAPITypes.h"
+
+#include <hiredis_cluster/hircluster.h>
+
+#include <bsoncxx/builder/basic/document.hpp>
+#include <bsoncxx/json.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/exception/exception.hpp>
+#include <mongocxx/instance.hpp>
+#include <mongocxx/uri.hpp>
+
+#include <vector>
+
+#include "Utils.h"
+
+using namespace std;
+using namespace commons;
+
+namespace atomdb {
+namespace atomdb_api_types {
+        
+
+class HandleSetRedis : public HandleSet {
+    public:
+     HandleSetRedis();
+     HandleSetRedis(redisReply* reply);
+     ~HandleSetRedis();
+ 
+     unsigned int size();
+     void append(void* data);
+     char* next();
+
+    private:
+     unsigned int handles_size;
+     unsigned int outer_idx;
+     unsigned int inner_idx;
+     vector<redisReply*> replies;
+};
+
+class RedisStringBundle : public HandleList {
+   public:
+    RedisStringBundle(redisReply* reply);
+    ~RedisStringBundle();
+
+    const char* get_handle(unsigned int index);
+    unsigned int size();
+
+   private:
+    unsigned int handles_size;
+    char** handles;
+    redisReply* redis_reply;
+};
+
+class MongodbDocument : public AtomDocument {
+   public:
+    MongodbDocument(core::v1::optional<bsoncxx::v_noabi::document::value>& document);
+    ~MongodbDocument();
+
+    const char* get(const string& key);
+    virtual const char* get(const string& array_key, unsigned int index);
+    virtual unsigned int get_size(const string& array_key);
+
+   private:
+    core::v1::optional<bsoncxx::v_noabi::document::value> document;
+};
+
+}  // namespace atomdb_api_types
+}  // namespace atomdb

--- a/src/atomdb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/RedisMongoDBAPITypes.h
@@ -23,8 +23,8 @@ class HandleSetRedis : public HandleSet {
     friend class HandleSetRedisIterator;
 
    public:
-    HandleSetRedis();
-    HandleSetRedis(redisReply* reply);
+    HandleSetRedis(bool delete_replies_on_destruction = true);
+    HandleSetRedis(redisReply* reply, bool delete_replies_on_destruction = true);
     ~HandleSetRedis();
 
     unsigned int size();
@@ -34,6 +34,7 @@ class HandleSetRedis : public HandleSet {
    private:
     unsigned int handles_size;
     vector<redisReply*> replies;
+    bool delete_replies_on_destruction;
 };
 
 class HandleSetRedisIterator : public HandleSetIterator {

--- a/src/atomdb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/RedisMongoDBAPITypes.h
@@ -20,20 +20,34 @@ namespace atomdb {
 namespace atomdb_api_types {
 
 class HandleSetRedis : public HandleSet {
+
+   friend class HandleSetRedisIterator;
+
    public:
     HandleSetRedis();
     HandleSetRedis(redisReply* reply);
     ~HandleSetRedis();
 
     unsigned int size();
-    void append(void* data);
-    char* next();
+    void append(shared_ptr<HandleSet> other);
+    shared_ptr<HandleSetIterator> get_iterator();
 
    private:
     unsigned int handles_size;
-    unsigned int outer_idx;
-    unsigned int inner_idx;
     vector<redisReply*> replies;
+};
+
+class HandleSetRedisIterator : public HandleSetIterator {
+    public:
+     HandleSetRedisIterator(HandleSetRedis* handle_set);
+     ~HandleSetRedisIterator();
+
+     char* next();
+
+    private:
+     HandleSetRedis* handle_set;
+     unsigned int outer_idx;
+     unsigned int inner_idx;
 };
 
 class RedisStringBundle : public HandleList {

--- a/src/atomdb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/RedisMongoDBAPITypes.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "AtomDBAPITypes.h"
-
 #include <hiredis_cluster/hircluster.h>
 
 #include <bsoncxx/builder/basic/document.hpp>
@@ -10,9 +8,9 @@
 #include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
-
 #include <vector>
 
+#include "AtomDBAPITypes.h"
 #include "Utils.h"
 
 using namespace std;
@@ -20,23 +18,22 @@ using namespace commons;
 
 namespace atomdb {
 namespace atomdb_api_types {
-        
 
 class HandleSetRedis : public HandleSet {
-    public:
-     HandleSetRedis();
-     HandleSetRedis(redisReply* reply);
-     ~HandleSetRedis();
- 
-     unsigned int size();
-     void append(void* data);
-     char* next();
+   public:
+    HandleSetRedis();
+    HandleSetRedis(redisReply* reply);
+    ~HandleSetRedis();
 
-    private:
-     unsigned int handles_size;
-     unsigned int outer_idx;
-     unsigned int inner_idx;
-     vector<redisReply*> replies;
+    unsigned int size();
+    void append(void* data);
+    char* next();
+
+   private:
+    unsigned int handles_size;
+    unsigned int outer_idx;
+    unsigned int inner_idx;
+    vector<redisReply*> replies;
 };
 
 class RedisStringBundle : public HandleList {

--- a/src/atomdb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/RedisMongoDBAPITypes.h
@@ -20,8 +20,7 @@ namespace atomdb {
 namespace atomdb_api_types {
 
 class HandleSetRedis : public HandleSet {
-
-   friend class HandleSetRedisIterator;
+    friend class HandleSetRedisIterator;
 
    public:
     HandleSetRedis();
@@ -38,16 +37,16 @@ class HandleSetRedis : public HandleSet {
 };
 
 class HandleSetRedisIterator : public HandleSetIterator {
-    public:
-     HandleSetRedisIterator(HandleSetRedis* handle_set);
-     ~HandleSetRedisIterator();
+   public:
+    HandleSetRedisIterator(HandleSetRedis* handle_set);
+    ~HandleSetRedisIterator();
 
-     char* next();
+    char* next();
 
-    private:
-     HandleSetRedis* handle_set;
-     unsigned int outer_idx;
-     unsigned int inner_idx;
+   private:
+    HandleSetRedis* handle_set;
+    unsigned int outer_idx;
+    unsigned int inner_idx;
 };
 
 class RedisStringBundle : public HandleList {

--- a/src/query_engine/query_element/LinkTemplate.h
+++ b/src/query_engine/query_element/LinkTemplate.h
@@ -295,8 +295,9 @@ class LinkTemplate : public Source {
         if (answer_count > 0) {
             dasproto::HandleList handle_list;
             handle_list.set_context(this->context);
-            for (unsigned int i = 0; i < answer_count; i++) {
-                handle_list.add_list(this->fetch_result[i].c_str());
+            char* handle;
+            while ((handle = this->fetch_result->next()) != nullptr) {
+                handle_list.add_list(handle);
             }
             dasproto::ImportanceList importance_list;
             get_importance(handle_list, importance_list);
@@ -308,9 +309,10 @@ class LinkTemplate : public Source {
             this->atom_document = new shared_ptr<atomdb_api_types::AtomDocument>[answer_count];
             this->local_answers = new HandlesAnswer*[answer_count];
             this->next_inner_answer = new unsigned int[answer_count];
-            for (unsigned int i = 0; i < answer_count; i++) {
-                this->atom_document[i] = db->get_atom_document(this->fetch_result[i].c_str());
-                query_answer = new HandlesAnswer(this->fetch_result[i].c_str(), importance_list.list(i));
+            unsigned int i = 0;
+            while ((handle = this->fetch_result->next()) != nullptr) {
+                this->atom_document[i] = db->get_atom_document(handle);
+                query_answer = new HandlesAnswer(handle, importance_list.list(i));
                 const char* s = this->atom_document[i]->get("targets", 0);
                 for (unsigned int j = 0; j < this->arity; j++) {
                     if (this->target_template[j]->is_terminal) {
@@ -458,7 +460,7 @@ class LinkTemplate : public Source {
     unsigned int arity;
     shared_ptr<char> handle;
     char* handle_keys[ARITY + 1];
-    vector<string> fetch_result;
+    shared_ptr<atomdb_api_types::HandleSet> fetch_result;
     vector<shared_ptr<atomdb_api_types::AtomDocument>> atom_documents;
     vector<QueryElement*> inner_template;
     SharedQueue local_buffer;

--- a/src/query_engine/query_element/LinkTemplate.h
+++ b/src/query_engine/query_element/LinkTemplate.h
@@ -297,7 +297,7 @@ class LinkTemplate : public Source {
             handle_list.set_context(this->context);
             auto it = this->fetch_result->get_iterator();
             char* handle;
-            while ((handle = this->fetch_result->next()) != nullptr) {
+            while ((handle = it->next()) != nullptr) {
                 handle_list.add_list(handle);
             }
             dasproto::ImportanceList importance_list;

--- a/src/query_engine/query_element/LinkTemplate.h
+++ b/src/query_engine/query_element/LinkTemplate.h
@@ -328,6 +328,7 @@ class LinkTemplate : public Source {
                     }
                 }
                 fetched_answers.push_back(query_answer);
+                i++;
             }
             std::sort(fetched_answers.begin(), fetched_answers.end(), less_than_query_answer());
             for (unsigned int i = 0; i < answer_count; i++) {

--- a/src/query_engine/query_element/LinkTemplate.h
+++ b/src/query_engine/query_element/LinkTemplate.h
@@ -286,7 +286,7 @@ class LinkTemplate : public Source {
 #endif
         shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
         this->fetch_result = db->query_for_pattern(this->handle);
-        unsigned int answer_count = this->fetch_result.size();
+        unsigned int answer_count = this->fetch_result->size();
 #ifdef DEBUG
         cout << "fetch_links() ac: " << answer_count << endl;
 #endif

--- a/src/query_engine/query_element/LinkTemplate.h
+++ b/src/query_engine/query_element/LinkTemplate.h
@@ -295,6 +295,7 @@ class LinkTemplate : public Source {
         if (answer_count > 0) {
             dasproto::HandleList handle_list;
             handle_list.set_context(this->context);
+            auto it = this->fetch_result->get_iterator();
             char* handle;
             while ((handle = this->fetch_result->next()) != nullptr) {
                 handle_list.add_list(handle);
@@ -309,8 +310,9 @@ class LinkTemplate : public Source {
             this->atom_document = new shared_ptr<atomdb_api_types::AtomDocument>[answer_count];
             this->local_answers = new HandlesAnswer*[answer_count];
             this->next_inner_answer = new unsigned int[answer_count];
+            it = this->fetch_result->get_iterator();
             unsigned int i = 0;
-            while ((handle = this->fetch_result->next()) != nullptr) {
+            while ((handle = it->next()) != nullptr) {
                 this->atom_document[i] = db->get_atom_document(handle);
                 query_answer = new HandlesAnswer(handle, importance_list.list(i));
                 const char* s = this->atom_document[i]->get("targets", 0);


### PR DESCRIPTION
This PRs introduce a new `atomdb_api_types::HandleSet` abstract class that:
 - Holds multiple `data` via `append(void* data)`.
 - Returns total `data` length/size via `size()`.
 - Returns one element of `data` via `next()` (and a `nullptr` when there is no more elements).

It also implements a concrete class of it, called `HandleSetRedis`, that holds `redisReply*` elements.

This PR also moves Redis+MongoDB types and implementations to `RedisMongoDBAPITypes.h` and `RedisMongoDBAPITypes.cc`, leaving `AtomDBAPITypes.h` with abstracts classes only.