### PR TITLE
[#204][ROUND 1] Making `QueryElement` instances `shared_ptr`s instead of raw pointers 

### DIFF
--- a/src/query_engine/DASNode.cc
+++ b/src/query_engine/DASNode.cc
@@ -152,9 +152,8 @@ shared_ptr<Message> DASNode::message_factory(string& command, vector<string>& ar
     return std::shared_ptr<Message>{};
 }
 
-QueryElement* PatternMatchingQuery::build_link_template(vector<string>& tokens,
-                                                        unsigned int cursor,
-                                                        stack<QueryElement*>& element_stack) {
+shared_ptr<QueryElement> PatternMatchingQuery::build_link_template(
+    vector<string>& tokens, unsigned int cursor, stack<shared_ptr<QueryElement>>& element_stack) {
     unsigned int arity = std::stoi(tokens[cursor + 2]);
     if (element_stack.size() < arity) {
         Utils::error(
@@ -163,84 +162,84 @@ QueryElement* PatternMatchingQuery::build_link_template(vector<string>& tokens,
     switch (arity) {
         // TODO: consider replacing each "case" below by a pre-processor macro call
         case 1: {
-            array<QueryElement*, 1> targets;
+            array<shared_ptr<QueryElement>, 1> targets;
             for (unsigned int i = 0; i < 1; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<1>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<1>>(tokens[cursor + 1], targets, this->context);
         }
         case 2: {
-            array<QueryElement*, 2> targets;
+            array<shared_ptr<QueryElement>, 2> targets;
             for (unsigned int i = 0; i < 2; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<2>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<2>>(tokens[cursor + 1], targets, this->context);
         }
         case 3: {
-            array<QueryElement*, 3> targets;
+            array<shared_ptr<QueryElement>, 3> targets;
             for (unsigned int i = 0; i < 3; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<3>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<3>>(tokens[cursor + 1], targets, this->context);
         }
         case 4: {
-            array<QueryElement*, 4> targets;
+            array<shared_ptr<QueryElement>, 4> targets;
             for (unsigned int i = 0; i < 4; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<4>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<4>>(tokens[cursor + 1], targets, this->context);
         }
         case 5: {
-            array<QueryElement*, 5> targets;
+            array<shared_ptr<QueryElement>, 5> targets;
             for (unsigned int i = 0; i < 5; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<5>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<5>>(tokens[cursor + 1], targets, this->context);
         }
         case 6: {
-            array<QueryElement*, 6> targets;
+            array<shared_ptr<QueryElement>, 6> targets;
             for (unsigned int i = 0; i < 6; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<6>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<6>>(tokens[cursor + 1], targets, this->context);
         }
         case 7: {
-            array<QueryElement*, 7> targets;
+            array<shared_ptr<QueryElement>, 7> targets;
             for (unsigned int i = 0; i < 7; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<7>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<7>>(tokens[cursor + 1], targets, this->context);
         }
         case 8: {
-            array<QueryElement*, 8> targets;
+            array<shared_ptr<QueryElement>, 8> targets;
             for (unsigned int i = 0; i < 8; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<8>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<8>>(tokens[cursor + 1], targets, this->context);
         }
         case 9: {
-            array<QueryElement*, 9> targets;
+            array<shared_ptr<QueryElement>, 9> targets;
             for (unsigned int i = 0; i < 9; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<9>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<9>>(tokens[cursor + 1], targets, this->context);
         }
         case 10: {
-            array<QueryElement*, 10> targets;
+            array<shared_ptr<QueryElement>, 10> targets;
             for (unsigned int i = 0; i < 10; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new LinkTemplate<10>(tokens[cursor + 1], targets, this->context);
+            return make_shared<LinkTemplate<10>>(tokens[cursor + 1], targets, this->context);
         }
         default: {
             Utils::error("PatternMatchingQuery message: max supported arity for LINK_TEMPLATE: 10");
@@ -249,9 +248,8 @@ QueryElement* PatternMatchingQuery::build_link_template(vector<string>& tokens,
     return NULL;  // Just to avoid warnings. This is not actually reachable.
 }
 
-QueryElement* PatternMatchingQuery::build_and(vector<string>& tokens,
-                                              unsigned int cursor,
-                                              stack<QueryElement*>& element_stack) {
+shared_ptr<QueryElement> PatternMatchingQuery::build_and(
+    vector<string>& tokens, unsigned int cursor, stack<shared_ptr<QueryElement>>& element_stack) {
     unsigned int num_clauses = std::stoi(tokens[cursor + 1]);
     if (element_stack.size() < num_clauses) {
         Utils::error("PatternMatchingQuery message: parse error in tokens - too few arguments for AND");
@@ -259,84 +257,84 @@ QueryElement* PatternMatchingQuery::build_and(vector<string>& tokens,
     switch (num_clauses) {
         // TODO: consider replacing each "case" below by a pre-processor macro call
         case 1: {
-            array<QueryElement*, 1> clauses;
+            array<shared_ptr<QueryElement>, 1> clauses;
             for (unsigned int i = 0; i < 1; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<1>(clauses);
+            return make_shared<And<1>>(clauses);
         }
         case 2: {
-            array<QueryElement*, 2> clauses;
+            array<shared_ptr<QueryElement>, 2> clauses;
             for (unsigned int i = 0; i < 2; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<2>(clauses);
+            return make_shared<And<2>>(clauses);
         }
         case 3: {
-            array<QueryElement*, 3> clauses;
+            array<shared_ptr<QueryElement>, 3> clauses;
             for (unsigned int i = 0; i < 3; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<3>(clauses);
+            return make_shared<And<3>>(clauses);
         }
         case 4: {
-            array<QueryElement*, 4> clauses;
+            array<shared_ptr<QueryElement>, 4> clauses;
             for (unsigned int i = 0; i < 4; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<4>(clauses);
+            return make_shared<And<4>>(clauses);
         }
         case 5: {
-            array<QueryElement*, 5> clauses;
+            array<shared_ptr<QueryElement>, 5> clauses;
             for (unsigned int i = 0; i < 5; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<5>(clauses);
+            return make_shared<And<5>>(clauses);
         }
         case 6: {
-            array<QueryElement*, 6> clauses;
+            array<shared_ptr<QueryElement>, 6> clauses;
             for (unsigned int i = 0; i < 6; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<6>(clauses);
+            return make_shared<And<6>>(clauses);
         }
         case 7: {
-            array<QueryElement*, 7> clauses;
+            array<shared_ptr<QueryElement>, 7> clauses;
             for (unsigned int i = 0; i < 7; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<7>(clauses);
+            return make_shared<And<7>>(clauses);
         }
         case 8: {
-            array<QueryElement*, 8> clauses;
+            array<shared_ptr<QueryElement>, 8> clauses;
             for (unsigned int i = 0; i < 8; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<8>(clauses);
+            return make_shared<And<8>>(clauses);
         }
         case 9: {
-            array<QueryElement*, 9> clauses;
+            array<shared_ptr<QueryElement>, 9> clauses;
             for (unsigned int i = 0; i < 9; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<9>(clauses);
+            return make_shared<And<9>>(clauses);
         }
         case 10: {
-            array<QueryElement*, 10> clauses;
+            array<shared_ptr<QueryElement>, 10> clauses;
             for (unsigned int i = 0; i < 10; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new And<10>(clauses);
+            return make_shared<And<10>>(clauses);
         }
         default: {
             Utils::error("PatternMatchingQuery message: max supported num_clauses for AND: 10");
@@ -345,9 +343,9 @@ QueryElement* PatternMatchingQuery::build_and(vector<string>& tokens,
     return NULL;  // Just to avoid warnings. This is not actually reachable.
 }
 
-QueryElement* PatternMatchingQuery::build_or(vector<string>& tokens,
-                                             unsigned int cursor,
-                                             stack<QueryElement*>& element_stack) {
+shared_ptr<QueryElement> PatternMatchingQuery::build_or(vector<string>& tokens,
+                                                        unsigned int cursor,
+                                                        stack<shared_ptr<QueryElement>>& element_stack) {
     unsigned int num_clauses = std::stoi(tokens[cursor + 1]);
     if (element_stack.size() < num_clauses) {
         Utils::error("PatternMatchingQuery message: parse error in tokens - too few arguments for OR");
@@ -355,84 +353,84 @@ QueryElement* PatternMatchingQuery::build_or(vector<string>& tokens,
     switch (num_clauses) {
         // TODO: consider replacing each "case" below by a pre-processor macro call
         case 1: {
-            array<QueryElement*, 1> clauses;
+            array<shared_ptr<QueryElement>, 1> clauses;
             for (unsigned int i = 0; i < 1; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<1>(clauses);
+            return make_shared<Or<1>>(clauses);
         }
         case 2: {
-            array<QueryElement*, 2> clauses;
+            array<shared_ptr<QueryElement>, 2> clauses;
             for (unsigned int i = 0; i < 2; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<2>(clauses);
+            return make_shared<Or<2>>(clauses);
         }
         case 3: {
-            array<QueryElement*, 3> clauses;
+            array<shared_ptr<QueryElement>, 3> clauses;
             for (unsigned int i = 0; i < 3; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<3>(clauses);
+            return make_shared<Or<3>>(clauses);
         }
         case 4: {
-            array<QueryElement*, 4> clauses;
+            array<shared_ptr<QueryElement>, 4> clauses;
             for (unsigned int i = 0; i < 4; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<4>(clauses);
+            return make_shared<Or<4>>(clauses);
         }
         case 5: {
-            array<QueryElement*, 5> clauses;
+            array<shared_ptr<QueryElement>, 5> clauses;
             for (unsigned int i = 0; i < 5; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<5>(clauses);
+            return make_shared<Or<5>>(clauses);
         }
         case 6: {
-            array<QueryElement*, 6> clauses;
+            array<shared_ptr<QueryElement>, 6> clauses;
             for (unsigned int i = 0; i < 6; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<6>(clauses);
+            return make_shared<Or<6>>(clauses);
         }
         case 7: {
-            array<QueryElement*, 7> clauses;
+            array<shared_ptr<QueryElement>, 7> clauses;
             for (unsigned int i = 0; i < 7; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<7>(clauses);
+            return make_shared<Or<7>>(clauses);
         }
         case 8: {
-            array<QueryElement*, 8> clauses;
+            array<shared_ptr<QueryElement>, 8> clauses;
             for (unsigned int i = 0; i < 8; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<8>(clauses);
+            return make_shared<Or<8>>(clauses);
         }
         case 9: {
-            array<QueryElement*, 9> clauses;
+            array<shared_ptr<QueryElement>, 9> clauses;
             for (unsigned int i = 0; i < 9; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<9>(clauses);
+            return make_shared<Or<9>>(clauses);
         }
         case 10: {
-            array<QueryElement*, 10> clauses;
+            array<shared_ptr<QueryElement>, 10> clauses;
             for (unsigned int i = 0; i < 10; i++) {
                 clauses[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Or<10>(clauses);
+            return make_shared<Or<10>>(clauses);
         }
         default: {
             Utils::error("PatternMatchingQuery message: max supported num_clauses for OR: 10");
@@ -441,9 +439,8 @@ QueryElement* PatternMatchingQuery::build_or(vector<string>& tokens,
     return NULL;  // Just to avoid warnings. This is not actually reachable.
 }
 
-QueryElement* PatternMatchingQuery::build_link(vector<string>& tokens,
-                                               unsigned int cursor,
-                                               stack<QueryElement*>& element_stack) {
+shared_ptr<QueryElement> PatternMatchingQuery::build_link(
+    vector<string>& tokens, unsigned int cursor, stack<shared_ptr<QueryElement>>& element_stack) {
     unsigned int arity = std::stoi(tokens[cursor + 2]);
     if (element_stack.size() < arity) {
         Utils::error("PatternMatchingQuery message: parse error in tokens - too few arguments for LINK");
@@ -451,84 +448,84 @@ QueryElement* PatternMatchingQuery::build_link(vector<string>& tokens,
     switch (arity) {
         // TODO: consider replacing each "case" below by a pre-processor macro call
         case 1: {
-            array<QueryElement*, 1> targets;
+            array<shared_ptr<QueryElement>, 1> targets;
             for (unsigned int i = 0; i < 1; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<1>(tokens[cursor + 1], targets);
+            return make_shared<Link<1>>(tokens[cursor + 1], targets);
         }
         case 2: {
-            array<QueryElement*, 2> targets;
+            array<shared_ptr<QueryElement>, 2> targets;
             for (unsigned int i = 0; i < 2; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<2>(tokens[cursor + 1], targets);
+            return make_shared<Link<2>>(tokens[cursor + 1], targets);
         }
         case 3: {
-            array<QueryElement*, 3> targets;
+            array<shared_ptr<QueryElement>, 3> targets;
             for (unsigned int i = 0; i < 3; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<3>(tokens[cursor + 1], targets);
+            return make_shared<Link<3>>(tokens[cursor + 1], targets);
         }
         case 4: {
-            array<QueryElement*, 4> targets;
+            array<shared_ptr<QueryElement>, 4> targets;
             for (unsigned int i = 0; i < 4; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<4>(tokens[cursor + 1], targets);
+            return make_shared<Link<4>>(tokens[cursor + 1], targets);
         }
         case 5: {
-            array<QueryElement*, 5> targets;
+            array<shared_ptr<QueryElement>, 5> targets;
             for (unsigned int i = 0; i < 5; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<5>(tokens[cursor + 1], targets);
+            return make_shared<Link<5>>(tokens[cursor + 1], targets);
         }
         case 6: {
-            array<QueryElement*, 6> targets;
+            array<shared_ptr<QueryElement>, 6> targets;
             for (unsigned int i = 0; i < 6; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<6>(tokens[cursor + 1], targets);
+            return make_shared<Link<6>>(tokens[cursor + 1], targets);
         }
         case 7: {
-            array<QueryElement*, 7> targets;
+            array<shared_ptr<QueryElement>, 7> targets;
             for (unsigned int i = 0; i < 7; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<7>(tokens[cursor + 1], targets);
+            return make_shared<Link<7>>(tokens[cursor + 1], targets);
         }
         case 8: {
-            array<QueryElement*, 8> targets;
+            array<shared_ptr<QueryElement>, 8> targets;
             for (unsigned int i = 0; i < 8; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<8>(tokens[cursor + 1], targets);
+            return make_shared<Link<8>>(tokens[cursor + 1], targets);
         }
         case 9: {
-            array<QueryElement*, 9> targets;
+            array<shared_ptr<QueryElement>, 9> targets;
             for (unsigned int i = 0; i < 9; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<9>(tokens[cursor + 1], targets);
+            return make_shared<Link<9>>(tokens[cursor + 1], targets);
         }
         case 10: {
-            array<QueryElement*, 10> targets;
+            array<shared_ptr<QueryElement>, 10> targets;
             for (unsigned int i = 0; i < 10; i++) {
                 targets[i] = element_stack.top();
                 element_stack.pop();
             }
-            return new Link<10>(tokens[cursor + 1], targets);
+            return make_shared<Link<10>>(tokens[cursor + 1], targets);
         }
         default: {
             Utils::error("PatternMatchingQuery message: max supported arity for LINK: 10");
@@ -543,7 +540,7 @@ PatternMatchingQuery::PatternMatchingQuery(string command, vector<string>& token
 #endif
 
     stack<unsigned int> execution_stack;
-    stack<QueryElement*> element_stack;
+    stack<shared_ptr<QueryElement>> element_stack;
     this->requestor_id = tokens[0];
     this->context = tokens[1];
     this->command = command;
@@ -569,9 +566,9 @@ PatternMatchingQuery::PatternMatchingQuery(string command, vector<string>& token
     while (!execution_stack.empty()) {
         cursor = execution_stack.top();
         if (tokens[cursor] == "NODE") {
-            element_stack.push(new Node(tokens[cursor + 1], tokens[cursor + 2]));
+            element_stack.push(make_shared<Node>(tokens[cursor + 1], tokens[cursor + 2]));
         } else if (tokens[cursor] == "VARIABLE") {
-            element_stack.push(new Variable(tokens[cursor + 1]));
+            element_stack.push(make_shared<Variable>(tokens[cursor + 1]));
         } else if (tokens[cursor] == "LINK") {
             element_stack.push(build_link(tokens, cursor, element_stack));
         } else if (tokens[cursor] == "LINK_TEMPLATE") {
@@ -618,11 +615,8 @@ void PatternMatchingQuery::act(shared_ptr<MessageFactory> node) {
             query_answer_processors.push_back(make_unique<CountAnswerProcessor>(local_id, remote_id));
         }
 
-        PatternMatchingQuery::remote_sinks_deleter.add(new RemoteSink<HandlesAnswer>(
-            this->root_query_element,       // precedent
-            move(query_answer_processors),  // processors
-            true                            // delete_precedent_on_destructor
-            ));
+        PatternMatchingQuery::remote_sinks_deleter.add(
+            new RemoteSink<HandlesAnswer>(this->root_query_element, move(query_answer_processors)));
     } else {
         Utils::error("Invalid command " + this->command + " in PatternMatchingQuery message");
     }

--- a/src/query_engine/DASNode.h
+++ b/src/query_engine/DASNode.h
@@ -63,23 +63,23 @@ class PatternMatchingQuery : public Message {
     static LazyWorkerDeleter<RemoteSink<HandlesAnswer>> remote_sinks_deleter;
 
    private:
-    QueryElement* build_link_template(vector<string>& tokens,
+    shared_ptr<QueryElement> build_link_template(vector<string>& tokens,
+                                                 unsigned int cursor,
+                                                 stack<shared_ptr<QueryElement>>& element_stack);
+
+    shared_ptr<QueryElement> build_and(vector<string>& tokens,
+                                       unsigned int cursor,
+                                       stack<shared_ptr<QueryElement>>& element_stack);
+
+    shared_ptr<QueryElement> build_or(vector<string>& tokens,
                                       unsigned int cursor,
-                                      stack<QueryElement*>& element_stack);
+                                      stack<shared_ptr<QueryElement>>& element_stack);
 
-    QueryElement* build_and(vector<string>& tokens,
-                            unsigned int cursor,
-                            stack<QueryElement*>& element_stack);
+    shared_ptr<QueryElement> build_link(vector<string>& tokens,
+                                        unsigned int cursor,
+                                        stack<shared_ptr<QueryElement>>& element_stack);
 
-    QueryElement* build_or(vector<string>& tokens,
-                           unsigned int cursor,
-                           stack<QueryElement*>& element_stack);
-
-    QueryElement* build_link(vector<string>& tokens,
-                             unsigned int cursor,
-                             stack<QueryElement*>& element_stack);
-
-    QueryElement* root_query_element;
+    shared_ptr<QueryElement> root_query_element;
     string requestor_id;
     string context;
     string command;

--- a/src/query_engine/LazyWorkerDeleter.h
+++ b/src/query_engine/LazyWorkerDeleter.h
@@ -60,10 +60,15 @@ class LazyWorkerDeleter {
     void objects_deleter_method() {
         T* obj;
         while (!this->shutting_down_flag) {
+            // clang-format off
             {
                 lock_guard<mutex> lock(this->objects_mutex);
-                for (size_t count = 0; count < this->objects.size() && !this->shutting_down_flag;
-                     count++) {
+                
+                for (
+                    size_t count = 0;
+                    count < this->objects.size() && !this->shutting_down_flag;
+                    count++
+                ) {
                     obj = this->objects.front();
                     if (obj->is_work_done()) {
                         this->objects.erase(this->objects.begin());
@@ -71,10 +76,16 @@ class LazyWorkerDeleter {
                     }
                     commons::Utils::sleep(100);  // 100ms
                 }
+                
             }
-            for (size_t i = 0; i < 50 && !this->shutting_down_flag; i++) {
+            for (
+                size_t i = 0;
+                i < 50 && !this->shutting_down_flag;
+                i++
+            ) {
                 commons::Utils::sleep(100);  // 100ms x 50 = 5s
             }
+            // clang-format on
         }
     }
 };

--- a/src/query_engine/query_element/And.h
+++ b/src/query_engine/query_element/And.h
@@ -27,15 +27,8 @@ class And : public Operator<N> {
      *
      * @param clauses Array with N clauses (each clause is supposed to be a Source or an Operator).
      */
-    And(QueryElement** clauses) : Operator<N>(clauses) { initialize(clauses); }
-
-    /**
-     * Constructor.
-     *
-     * @param clauses Array with N clauses (each clause is supposed to be a Source or an Operator).
-     */
-    And(const array<QueryElement*, N>& clauses) : Operator<N>(clauses) {
-        initialize((QueryElement**) clauses.data());
+    And(const array<shared_ptr<QueryElement>, N>& clauses) : Operator<N>(clauses) {
+        initialize(clauses);
     }
 
     /**
@@ -130,7 +123,7 @@ class And : public Operator<N> {
     bool no_more_answers_to_arrive;
     thread* operator_thread;
 
-    void initialize(QueryElement** clauses) {
+    void initialize(const array<shared_ptr<QueryElement>, N>& clauses) {
         this->operator_thread = NULL;
         for (unsigned int i = 0; i < N; i++) {
             this->next_input_to_process[i] = 0;

--- a/src/query_engine/query_element/Iterator.cc
+++ b/src/query_engine/query_element/Iterator.cc
@@ -8,8 +8,8 @@ using namespace query_element;
 // Public methods
 
 template <class AnswerType>
-Iterator<AnswerType>::Iterator(QueryElement* precedent, bool delete_precedent_on_destructor)
-    : Sink<AnswerType>(precedent, "Iterator(" + precedent->id + ")", delete_precedent_on_destructor) {}
+Iterator<AnswerType>::Iterator(shared_ptr<QueryElement> precedent)
+    : Sink<AnswerType>(precedent, "Iterator(" + precedent->id + ")") {}
 
 template <class AnswerType>
 Iterator<AnswerType>::~Iterator() {}

--- a/src/query_engine/query_element/Iterator.h
+++ b/src/query_engine/query_element/Iterator.h
@@ -25,7 +25,7 @@ class Iterator : public Sink<AnswerType> {
     /**
      * Constructor expects that the QueryElement below in the tree is already constructed.
      */
-    Iterator(QueryElement* precedent, bool delete_precedent_on_destructor = false);
+    Iterator(shared_ptr<QueryElement> precedent);
     ~Iterator();
 
     // --------------------------------------------------------------------------------------------

--- a/src/query_engine/query_element/LinkTemplate.h
+++ b/src/query_engine/query_element/LinkTemplate.h
@@ -175,35 +175,51 @@ class LinkTemplate : public Source {
 #endif
         Source::setup_buffers();
         if (this->inner_template.size() > 0) {
+            // clang-format off
             switch (this->inner_template.size()) {
                 case 1: {
                     this->inner_template_iterator =
-                        make_shared<Iterator<HandlesAnswer>>(inner_template[0], true);
+                        make_shared<Iterator<HandlesAnswer>>(
+                            inner_template[0],
+                            true  // delete_precedent_on_destructor
+                        );
                     break;
                 }
                 case 2: {
-                    this->inner_template_iterator = make_shared<Iterator<HandlesAnswer>>(
-                        new And<2>({inner_template[0], inner_template[1]}), true);
+                    this->inner_template_iterator = 
+                        make_shared<Iterator<HandlesAnswer>>(
+                            new And<2>(
+                                {inner_template[0], inner_template[1]}
+                            ),
+                            true  // delete_precedent_on_destructor
+                        );
                     break;
                 }
                 case 3: {
-                    this->inner_template_iterator = make_shared<Iterator<HandlesAnswer>>(
-                        new And<3>({inner_template[0], inner_template[1], inner_template[2]}), true);
+                    this->inner_template_iterator = 
+                        make_shared<Iterator<HandlesAnswer>>(
+                            new And<3>(
+                                {inner_template[0], inner_template[1], inner_template[2]}
+                            ),
+                            true  // delete_precedent_on_destructor
+                        );
                     break;
                 }
                 case 4: {
                     this->inner_template_iterator =
-                        make_shared<Iterator<HandlesAnswer>>(new And<4>({inner_template[0],
-                                                                         inner_template[1],
-                                                                         inner_template[2],
-                                                                         inner_template[3]}),
-                                                             true);
+                        make_shared<Iterator<HandlesAnswer>>(
+                            new And<4>(
+                                {inner_template[0], inner_template[1], inner_template[2], inner_template[3]}
+                            ),
+                            true  // delete_precedent_on_destructor
+                        );
                     break;
                 }
                 default: {
                     Utils::error("Invalid number of inner templates (> 4) in link template.");
                 }
             }
+            // clang-format on
         }
         this->local_buffer_processor = new thread(&LinkTemplate::local_buffer_processor_method, this);
         fetch_links();

--- a/src/query_engine/query_element/LinkTemplate.h
+++ b/src/query_engine/query_element/LinkTemplate.h
@@ -79,7 +79,7 @@ class LinkTemplate : public Source {
      *        consider STI (short term importance).
      */
     LinkTemplate(const string& type,
-                 const array<QueryElement*, ARITY>& targets,
+                 const array<shared_ptr<QueryElement>, ARITY>& targets,
                  const string& context = "") {
         this->context = context;
         this->arity = ARITY;
@@ -97,7 +97,7 @@ class LinkTemplate : public Source {
             // It's safe to get stored shared_ptr's raw pointer here because handle_keys[]
             // is used solely in this scope so it's guaranteed that handle will not be freed.
             if (targets[i - 1]->is_terminal) {
-                this->handle_keys[i] = ((Terminal*) targets[i - 1])->handle.get();
+                this->handle_keys[i] = dynamic_pointer_cast<Terminal>(targets[i - 1])->handle.get();
             } else {
                 this->handle_keys[i] = (char*) AtomDB::WILDCARD.c_str();
                 this->inner_template.push_back(targets[i - 1]);
@@ -135,9 +135,6 @@ class LinkTemplate : public Source {
             if (answer) delete answer;
         }
         this->inner_answers.clear();
-        for (auto* clause : this->inner_template) {
-            if (clause) delete clause;
-        }
         this->inner_template.clear();
         this->inner_template_iterator.reset();
         local_answers_mutex.unlock();
@@ -180,38 +177,52 @@ class LinkTemplate : public Source {
                 case 1: {
                     this->inner_template_iterator =
                         make_shared<Iterator<HandlesAnswer>>(
-                            inner_template[0],
-                            true  // delete_precedent_on_destructor
+                            inner_template[0]
                         );
                     break;
                 }
                 case 2: {
                     this->inner_template_iterator = 
                         make_shared<Iterator<HandlesAnswer>>(
-                            new And<2>(
-                                {inner_template[0], inner_template[1]}
-                            ),
-                            true  // delete_precedent_on_destructor
+                            make_shared<And<2>>(
+                                array<shared_ptr<QueryElement>, 2>(
+                                    {
+                                        inner_template[0],
+                                        inner_template[1]
+                                    }
+                                )
+                            )
                         );
                     break;
                 }
                 case 3: {
                     this->inner_template_iterator = 
                         make_shared<Iterator<HandlesAnswer>>(
-                            new And<3>(
-                                {inner_template[0], inner_template[1], inner_template[2]}
-                            ),
-                            true  // delete_precedent_on_destructor
+                            make_shared<And<3>>(
+                                array<shared_ptr<QueryElement>, 3>(
+                                    {
+                                        inner_template[0],
+                                        inner_template[1],
+                                        inner_template[2]
+                                    }
+                                )
+                            )
                         );
                     break;
                 }
                 case 4: {
                     this->inner_template_iterator =
                         make_shared<Iterator<HandlesAnswer>>(
-                            new And<4>(
-                                {inner_template[0], inner_template[1], inner_template[2], inner_template[3]}
-                            ),
-                            true  // delete_precedent_on_destructor
+                            make_shared<And<4>>(
+                                array<shared_ptr<QueryElement>, 4>(
+                                    {
+                                        inner_template[0],
+                                        inner_template[1],
+                                        inner_template[2],
+                                        inner_template[3]
+                                    }
+                                )
+                            )
                         );
                     break;
                 }
@@ -330,7 +341,7 @@ class LinkTemplate : public Source {
                 const char* s = this->atom_document[i]->get("targets", 0);
                 for (unsigned int j = 0; j < this->arity; j++) {
                     if (this->target_template[j]->is_terminal) {
-                        Terminal* terminal = (Terminal*) this->target_template[j];
+                        auto terminal = dynamic_pointer_cast<Terminal>(this->target_template[j]);
                         if (terminal->is_variable) {
                             if (!query_answer->assignment.assign(
                                     terminal->name.c_str(), this->atom_document[i]->get("targets", j))) {
@@ -470,13 +481,13 @@ class LinkTemplate : public Source {
 
    private:
     string type;
-    array<QueryElement*, ARITY> target_template;
+    array<shared_ptr<QueryElement>, ARITY> target_template;
     unsigned int arity;
     shared_ptr<char> handle;
     char* handle_keys[ARITY + 1];
     vector<string> fetch_result;
     vector<shared_ptr<atomdb_api_types::AtomDocument>> atom_documents;
-    vector<QueryElement*> inner_template;
+    vector<shared_ptr<QueryElement>> inner_template;
     SharedQueue local_buffer;
     thread* local_buffer_processor;
     bool fetch_finished;

--- a/src/query_engine/query_element/Operator.h
+++ b/src/query_engine/query_element/Operator.h
@@ -32,14 +32,7 @@ class Operator : public QueryElement {
      *
      * @param clauses Array of QueryElement, each of them a clause in the operation.
      */
-    Operator(const array<QueryElement*, N>& clauses) { initialize((QueryElement**) clauses.data()); }
-
-    /**
-     * Constructor.
-     *
-     * @param clauses Array of QueryElement, each of them a clause in the operation.
-     */
-    Operator(QueryElement** clauses) { initialize(clauses); }
+    Operator(const array<shared_ptr<QueryElement>, N>& clauses) { initialize(clauses); }
 
     /**
      * Destructor.
@@ -49,12 +42,7 @@ class Operator : public QueryElement {
         cout << "Operator::Operator() DESTRUCTOR BEGIN" << endl;
 #endif
         this->graceful_shutdown();
-        for (size_t i = 0; i < N; i++) {
-            if (this->precedent[i]) {
-                delete this->precedent[i];
-                this->precedent[i] = nullptr;
-            }
-        }
+        for (size_t i = 0; i < N; i++) this->precedent[i] = nullptr;
 #ifdef DEBUG
         cout << "Operator::Operator() DESTRUCTOR END" << endl;
 #endif
@@ -106,12 +94,12 @@ class Operator : public QueryElement {
     }
 
    protected:
-    QueryElement* precedent[N];
+    shared_ptr<QueryElement> precedent[N];
     shared_ptr<QueryNodeServer<HandlesAnswer>> input_buffer[N];
     shared_ptr<QueryNodeClient<HandlesAnswer>> output_buffer;
 
    private:
-    void initialize(QueryElement** clauses) {
+    void initialize(const array<shared_ptr<QueryElement>, N>& clauses) {
         if (N > MAX_NUMBER_OF_OPERATION_CLAUSES) {
             Utils::error("Operation exceeds max number of clauses: " + to_string(N));
         }

--- a/src/query_engine/query_element/Or.h
+++ b/src/query_engine/query_element/Or.h
@@ -27,16 +27,7 @@ class Or : public Operator<N> {
      *
      * @param clauses Array with N clauses (each clause is supposed to be a Source or an Operator).
      */
-    Or(QueryElement** clauses) : Operator<N>(clauses) { initialize(clauses); }
-
-    /**
-     * Constructor.
-     *
-     * @param clauses Array with N clauses (each clause is supposed to be a Source or an Operator).
-     */
-    Or(const array<QueryElement*, N>& clauses) : Operator<N>(clauses) {
-        initialize((QueryElement**) clauses.data());
-    }
+    Or(const array<shared_ptr<QueryElement>, N>& clauses) : Operator<N>(clauses) { initialize(clauses); }
 
     /**
      * Destructor.
@@ -70,7 +61,7 @@ class Or : public Operator<N> {
     bool no_more_answers_to_arrive;
     thread* operator_thread;
 
-    void initialize(QueryElement** clauses) {
+    void initialize(const array<shared_ptr<QueryElement>, N>& clauses) {
         this->operator_thread = NULL;
         for (unsigned int i = 0; i < N; i++) {
             this->next_input_to_process[i] = 0;

--- a/src/query_engine/query_element/RemoteSink.cc
+++ b/src/query_engine/query_element/RemoteSink.cc
@@ -10,11 +10,9 @@ using namespace query_element;
 // Constructors and destructors
 
 template <class AnswerType>
-RemoteSink<AnswerType>::RemoteSink(QueryElement* precedent,
-                                   vector<unique_ptr<QueryAnswerProcessor>>&& query_answer_processors,
-                                   bool delete_precedent_on_destructor)
-    : Sink<AnswerType>(
-          precedent, "RemoteSink(" + precedent->id + ")", delete_precedent_on_destructor, true),
+RemoteSink<AnswerType>::RemoteSink(shared_ptr<QueryElement> precedent,
+                                   vector<unique_ptr<QueryAnswerProcessor>>&& query_answer_processors)
+    : Sink<AnswerType>(precedent, "RemoteSink(" + precedent->id + ")", true),
       queue_processor(new thread(&RemoteSink::queue_processor_method, this)),
       query_answer_processors(move(query_answer_processors)) {}
 

--- a/src/query_engine/query_element/RemoteSink.h
+++ b/src/query_engine/query_element/RemoteSink.h
@@ -23,12 +23,9 @@ class RemoteSink : public Sink<AnswerType>, public Worker {
      *
      * @param precedent QueryElement just below in the query tree.
      * @param query_answer_processors List of processors to be applied to the query answers.
-     * @param delete_precedent_on_destructor If true, the destructor of this QueryElement will
-     *        also destruct the passed precedent QueryElement (defaulted to false).
      */
-    RemoteSink(QueryElement* precedent,
-               vector<unique_ptr<QueryAnswerProcessor>>&& query_answer_processors,
-               bool delete_precedent_on_destructor = false);
+    RemoteSink(shared_ptr<QueryElement> precedent,
+               vector<unique_ptr<QueryAnswerProcessor>>&& query_answer_processors);
 
     /**
      * Destructor.

--- a/src/query_engine/query_element/Sink.cc
+++ b/src/query_engine/query_element/Sink.cc
@@ -8,13 +8,9 @@ using namespace query_element;
 // Constructors and destructors
 
 template <class AnswerType>
-Sink<AnswerType>::Sink(QueryElement* precedent,
-                       const string& id,
-                       bool delete_precedent_on_destructor,
-                       bool setup_buffers_flag) {
+Sink<AnswerType>::Sink(shared_ptr<QueryElement> precedent, const string& id, bool setup_buffers_flag) {
     this->precedent = precedent;
     this->id = id;
-    this->delete_precedent_on_destructor = delete_precedent_on_destructor;
     if (setup_buffers_flag) {
         setup_buffers();
     }
@@ -23,9 +19,6 @@ Sink<AnswerType>::Sink(QueryElement* precedent,
 template <class AnswerType>
 Sink<AnswerType>::~Sink() {
     this->input_buffer->graceful_shutdown();
-    if (this->delete_precedent_on_destructor) {
-        delete this->precedent;
-    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/src/query_engine/query_element/Sink.h
+++ b/src/query_engine/query_element/Sink.h
@@ -26,14 +26,9 @@ class Sink : public QueryElement {
      *
      * @param precedent QueryElement just below in the query tree.
      * @param id Unique id for this QueryElement.
-     * @param delete_precedent_on_destructor If true, the destructor of this QueryElement will
-     * also destruct the passed precedent QueryElement (defaulted to false).
      * @param setup_buffers_flag If true, the setup_buffers() method is called in the constructor.
      */
-    Sink(QueryElement* precedent,
-         const string& id,
-         bool delete_precedent_on_destructor = false,
-         bool setup_buffers_flag = true);
+    Sink(shared_ptr<QueryElement> precedent, const string& id, bool setup_buffers_flag = true);
 
     /**
      * Destructor.
@@ -49,17 +44,14 @@ class Sink : public QueryElement {
     virtual void graceful_shutdown();
 
     /**
-     * Setup a ServerQueryNode to commnunicate with one or more QueryElement just below in the
+     * Setup a ServerQueryNode to communicate with one or more QueryElement just below in the
      * query tree.
      */
     virtual void setup_buffers();
 
    protected:
     shared_ptr<QueryNode<AnswerType>> input_buffer;
-    QueryElement* precedent;
-
-   private:
-    bool delete_precedent_on_destructor;
+    shared_ptr<QueryElement> precedent;
 };
 
 }  // namespace query_element

--- a/src/query_engine/query_element/Source.h
+++ b/src/query_engine/query_element/Source.h
@@ -62,7 +62,7 @@ class Source : public QueryElement {
    protected:
     string attention_broker_address;
     shared_ptr<QueryNode<HandlesAnswer>> output_buffer;
-    QueryElement* subsequent;
+    shared_ptr<QueryElement> subsequent;
 };
 
 }  // namespace query_element

--- a/src/query_engine/query_element/Terminal.h
+++ b/src/query_engine/query_element/Terminal.h
@@ -28,7 +28,7 @@ class Terminal : public QueryElement {
     Terminal() : QueryElement() {
         this->handle = shared_ptr<char>{};
         this->is_variable = false;
-        this->is_terminal = true;  // overrrides QueryElement default
+        this->is_terminal = true;  // overrides QueryElement default
     }
 
    public:
@@ -122,7 +122,7 @@ class Link : public Terminal {
      * @params targets Array with targets of the Link. Targets are supposed to be
      *         handles (i.e. strings). No nesting of Nodes or other Links are allowed.
      */
-    Link(const string& type, const array<QueryElement*, ARITY>& targets) : Terminal() {
+    Link(const string& type, const array<shared_ptr<QueryElement>, ARITY>& targets) : Terminal() {
         this->name = "";
         this->type = type;
         this->targets = targets;
@@ -130,8 +130,9 @@ class Link : public Terminal {
         char* handle_keys[ARITY + 1];
         handle_keys[0] = (char*) named_type_hash((char*) type.c_str());
         for (unsigned int i = 1; i < (ARITY + 1); i++) {
-            if (targets[i - 1]->is_terminal && !((Terminal*) targets[i - 1])->is_variable) {
-                handle_keys[i] = ((Terminal*) targets[i - 1])->handle.get();
+            if (targets[i - 1]->is_terminal &&
+                !dynamic_pointer_cast<Terminal>(targets[i - 1])->is_variable) {
+                handle_keys[i] = dynamic_pointer_cast<Terminal>(targets[i - 1])->handle.get();
             } else {
                 Utils::error("Invalid Link definition");
             }
@@ -148,7 +149,7 @@ class Link : public Terminal {
     string to_string() {
         string answer = "(" + this->type + ", [";
         for (unsigned int i = 0; i < this->arity; i++) {
-            answer += ((Terminal*) this->targets[i])->to_string();
+            answer += dynamic_pointer_cast<Terminal>(this->targets[i])->to_string();
             if (i != (this->arity - 1)) {
                 answer += ", ";
             }
@@ -170,7 +171,7 @@ class Link : public Terminal {
     /**
      * Targets of the Link.
      */
-    array<QueryElement*, ARITY> targets;
+    array<shared_ptr<QueryElement>, ARITY> targets;
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/src/tests/cpp/iterator_test.cc
+++ b/src/tests/cpp/iterator_test.cc
@@ -22,8 +22,8 @@ class TestQueryElement : public QueryElement {
 
 TEST(Iterator, basics) {
     string client_id = "no_query_element";
-    TestQueryElement dummy(client_id);
-    Iterator<HandlesAnswer> query_answer_iterator(&dummy);
+    auto dummy = make_shared<TestQueryElement>(client_id);
+    Iterator<HandlesAnswer> query_answer_iterator(dummy);
     string server_id = query_answer_iterator.id;
     EXPECT_FALSE(server_id == "");
     QueryNodeClient<HandlesAnswer> client_node(client_id, query_answer_iterator.id);
@@ -81,14 +81,15 @@ TEST(Iterator, link_template_integration) {
     string expression = "Expression";
     string symbol = "Symbol";
 
-    Variable v1("v1");
-    Variable v2("v2");
-    Variable v3("v3");
-    Node similarity(symbol, "Similarity");
-    Node human(symbol, "\"human\"");
+    auto v1 = make_shared<Variable>("v1");
+    auto v2 = make_shared<Variable>("v2");
+    auto v3 = make_shared<Variable>("v3");
+    auto similarity = make_shared<Node>(symbol, "Similarity");
+    auto human = make_shared<Node>(symbol, "\"human\"");
 
-    LinkTemplate<3> link_template("Expression", {&similarity, &human, &v1});
-    Iterator<HandlesAnswer> query_answer_iterator(&link_template);
+    auto link_template = make_shared<LinkTemplate<3>>(
+        "Expression", array<shared_ptr<QueryElement>, 3>({similarity, human, v1}));
+    Iterator<HandlesAnswer> query_answer_iterator(link_template);
 
     string monkey_handle = string(terminal_hash((char*) symbol.c_str(), (char*) "\"monkey\""));
     string chimp_handle = string(terminal_hash((char*) symbol.c_str(), (char*) "\"chimp\""));

--- a/src/tests/cpp/link_template_test.cc
+++ b/src/tests/cpp/link_template_test.cc
@@ -26,13 +26,13 @@ TEST(LinkTemplate, basics) {
     string expression = "Expression";
     string symbol = "Symbol";
 
-    Variable v1("v1");
-    Variable v2("v2");
-    Variable v3("v3");
-    Node similarity(symbol, "Similarity");
-    Node human(symbol, "\"human\"");
+    auto v1 = make_shared<Variable>("v1");
+    auto v2 = make_shared<Variable>("v2");
+    auto v3 = make_shared<Variable>("v3");
+    auto similarity = make_shared<Node>(symbol, "Similarity");
+    auto human = make_shared<Node>(symbol, "\"human\"");
 
-    LinkTemplate<3> link_template1("Expression", {&similarity, &human, &v1});
+    LinkTemplate<3> link_template1("Expression", {similarity, human, v1});
     link_template1.subsequent_id = server_node_id;
     link_template1.setup_buffers();
     // link_template1.fetch_links();

--- a/src/tests/cpp/nested_link_template_test.cc
+++ b/src/tests/cpp/nested_link_template_test.cc
@@ -24,13 +24,15 @@ TEST(LinkTemplate, basics) {
     string expression = "Expression";
     string symbol = "Symbol";
 
-    auto v1 = new Variable("v1");
-    auto v2 = new Variable("v2");
-    auto similarity = new Node(symbol, "Similarity");
-    auto odd_link = new Node(symbol, "OddLink");
+    auto v1 = make_shared<Variable>("v1");
+    auto v2 = make_shared<Variable>("v2");
+    auto similarity = make_shared<Node>(symbol, "Similarity");
+    auto odd_link = make_shared<Node>(symbol, "OddLink");
 
-    auto inner_template = new LinkTemplate<3>(expression, {similarity, v1, v2});
-    auto outter_template = new LinkTemplate<2>(expression, {odd_link, inner_template});
+    auto inner_template = make_shared<LinkTemplate<3>>(
+        expression, array<shared_ptr<QueryElement>, 3>({similarity, v1, v2}));
+    auto outter_template = make_shared<LinkTemplate<2>>(
+        expression, array<shared_ptr<QueryElement>, 2>({odd_link, inner_template}));
     Iterator<HandlesAnswer> iterator(outter_template);
 
     HandlesAnswer* query_answer;
@@ -50,16 +52,20 @@ TEST(LinkTemplate, nested_variables) {
     string expression = "Expression";
     string symbol = "Symbol";
 
-    auto v1 = new Variable("v1");
-    auto v2 = new Variable("v2");
-    auto similarity = new Node(symbol, "Similarity");
-    auto odd_link = new Node(symbol, "OddLink");
-    auto human = new Node(symbol, "\"human\"");
+    auto v1 = make_shared<Variable>("v1");
+    auto v2 = make_shared<Variable>("v2");
+    auto similarity = make_shared<Node>(symbol, "Similarity");
+    auto odd_link = make_shared<Node>(symbol, "OddLink");
+    auto human = make_shared<Node>(symbol, "\"human\"");
 
-    auto inner_template = new LinkTemplate<3>(expression, {similarity, v1, v2});
-    auto outter_template = new LinkTemplate<2>(expression, {odd_link, inner_template});
-    auto human_template = new LinkTemplate<3>(expression, {similarity, v1, human});
-    auto and_operator = new And<2>({human_template, outter_template});
+    auto inner_template = make_shared<LinkTemplate<3>>(
+        expression, array<shared_ptr<QueryElement>, 3>({similarity, v1, v2}));
+    auto outter_template = make_shared<LinkTemplate<2>>(
+        expression, array<shared_ptr<QueryElement>, 2>({odd_link, inner_template}));
+    auto human_template = make_shared<LinkTemplate<3>>(
+        expression, array<shared_ptr<QueryElement>, 3>({similarity, v1, human}));
+    auto and_operator =
+        make_shared<And<2>>(array<shared_ptr<QueryElement>, 2>({human_template, outter_template}));
 
     Iterator<HandlesAnswer> iterator(and_operator);
 

--- a/src/tests/cpp/remote_sink_iterator_test.cc
+++ b/src/tests/cpp/remote_sink_iterator_test.cc
@@ -30,7 +30,7 @@ TEST(RemoteSinkIterator, basics) {
     string producer_id = "localhost:30801";
 
     string input_element_id = "test_source";
-    TestSource* input = new TestSource(input_element_id);
+    auto input = make_shared<TestSource>(input_element_id);
     RemoteIterator<HandlesAnswer> consumer(consumer_id);
     vector<unique_ptr<QueryAnswerProcessor>> query_answer_processors;
     query_answer_processors.push_back(make_unique<HandlesAnswerProcessor>(producer_id, consumer_id));


### PR DESCRIPTION
Progress on #204 

This is necessary to allow `LinkTemplate` to be shared and cached.
