### PR TITLE
[#204] [BUGFIX] changing cache functions return types

### DIFF
--- a/src/atomdb/AtomDBCache.cc
+++ b/src/atomdb/AtomDBCache.cc
@@ -5,14 +5,14 @@
 using namespace std;
 using namespace atomdb;
 
-shared_ptr<atomdb_api_types::AtomDocument> AtomDBCache::get_atom_document(const char* handle) {
+AtomDBCache::GetAtomDocumentResult AtomDBCache::get_atom_document(const char* handle) {
     lock_guard<mutex> lock(atom_doc_cache_mutex);
     if (atom_doc_cache.find(handle) != atom_doc_cache.end()) {
         LOG_DEBUG("cache hit " << handle);
-        return atom_doc_cache[handle];
+        return {true, atom_doc_cache[handle]};
     }
     LOG_DEBUG("cache miss " << handle);
-    return nullptr;
+    return {false, nullptr};
 }
 
 void AtomDBCache::add_atom_document(const char* handle,
@@ -21,14 +21,14 @@ void AtomDBCache::add_atom_document(const char* handle,
     atom_doc_cache[handle] = document;
 }
 
-shared_ptr<atomdb_api_types::HandleSet> AtomDBCache::query_for_pattern(const char* pattern_handle) {
+AtomDBCache::QueryForPatternResult AtomDBCache::query_for_pattern(const char* pattern_handle) {
     lock_guard<mutex> lock(pattern_matching_cache_mutex);
     if (pattern_matching_cache.find(pattern_handle) != pattern_matching_cache.end()) {
         LOG_DEBUG("cache hit " << pattern_handle);
-        return pattern_matching_cache[pattern_handle];
+        return {true, pattern_matching_cache[pattern_handle]};
     }
     LOG_DEBUG("cache miss " << pattern_handle);
-    return nullptr;
+    return {false, nullptr};
 }
 
 void AtomDBCache::add_pattern_matching(const char* pattern_handle,
@@ -37,14 +37,14 @@ void AtomDBCache::add_pattern_matching(const char* pattern_handle,
     pattern_matching_cache[pattern_handle] = results;
 }
 
-shared_ptr<atomdb_api_types::HandleList> AtomDBCache::query_for_targets(const char* link_handle) {
+AtomDBCache::QueryForTargetsResult AtomDBCache::query_for_targets(const char* link_handle) {
     lock_guard<mutex> lock(handle_list_cache_mutex);
     if (handle_list_cache.find(link_handle) != handle_list_cache.end()) {
         LOG_DEBUG("cache hit " << link_handle);
-        return handle_list_cache[link_handle];
+        return {true, handle_list_cache[link_handle]};
     }
     LOG_DEBUG("cache miss " << link_handle);
-    return nullptr;
+    return {false, nullptr};
 }
 
 void AtomDBCache::add_handle_list(const char* link_handle,

--- a/src/atomdb/AtomDBCache.h
+++ b/src/atomdb/AtomDBCache.h
@@ -23,6 +23,30 @@ namespace atomdb {
 class AtomDBCache {
    public:
     /**
+     * @brief The result type for cached pattern matching.
+     */
+    typedef struct {
+        bool is_cache_hit;
+        shared_ptr<atomdb_api_types::HandleSet> result;
+    } QueryForPatternResult;
+
+    /**
+     * @brief The result type for cached atom documents.
+     */
+    typedef struct {
+        bool is_cache_hit;
+        shared_ptr<atomdb_api_types::AtomDocument> result;
+    } GetAtomDocumentResult;
+
+    /**
+     * @brief The result type for cached targets.
+     */
+    typedef struct {
+        bool is_cache_hit;
+        shared_ptr<atomdb_api_types::HandleList> result;
+    } QueryForTargetsResult;
+
+    /**
      * @brief Constructor.
      *
      * The constructor is private to ensure that the correct instance is created.
@@ -40,7 +64,7 @@ class AtomDBCache {
      * @param handle The handle of the atom document.
      * @return The atom document if it is cached, nullptr otherwise.
      */
-    shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle);
+    GetAtomDocumentResult get_atom_document(const char* handle);
 
     /**
      * @brief Add an atom document to the cache.
@@ -56,7 +80,7 @@ class AtomDBCache {
      * @param pattern_handle The handle of the pattern.
      * @return The result of the query if it is cached, nullptr otherwise.
      */
-    shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const char* pattern_handle);
+    QueryForPatternResult query_for_pattern(const char* pattern_handle);
 
     /**
      * @brief Add a pattern matching to the cache.
@@ -73,7 +97,7 @@ class AtomDBCache {
      * @param link_handle The handle of the link.
      * @return The list of targets if it is cached, nullptr otherwise.
      */
-    shared_ptr<atomdb_api_types::HandleList> query_for_targets(const char* link_handle);
+    QueryForTargetsResult query_for_targets(const char* link_handle);
 
     /**
      * @brief Add a handle list to the cache.


### PR DESCRIPTION
Progress on #204 

Realized that cached entries whose data is `nullptr`, even if they were found in the cache, they were being re-queried/re-fetched from [Redis|Mongo] because `RedisMongoDB` implementation was just checking if the cache result data was `nullptr` and considering it as a cache miss.

Now, the return from the cache funtions is a struct which has the result data but also a bool flag to indicate whether it is a cache hit or not. So now even a cached `nullptr` result data will be treated as a cache hit and won't be re-queried/re-fetched again.