### PR TITLE
Add rust_metta_bus_client space

### DIFF
--- a/3rd_party_slots/rust_metta_bus_client/Cargo.lock
+++ b/3rd_party_slots/rust_metta_bus_client/Cargo.lock
@@ -197,6 +197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,7 +879,7 @@ dependencies = [
 [[package]]
 name = "hyperon-atom"
 version = "0.2.5"
-source = "git+https://github.com/trueagi-io/hyperon-experimental.git#79325e309848c517ffea3288c12aa660e6f63fdd"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#da46ca1121b7fbd5bca5b594136a8a1d3aa1a8d5"
 dependencies = [
  "bitset",
  "hyperon-common",
@@ -884,10 +890,22 @@ dependencies = [
 [[package]]
 name = "hyperon-common"
 version = "0.2.5"
-source = "git+https://github.com/trueagi-io/hyperon-experimental.git#79325e309848c517ffea3288c12aa660e6f63fdd"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#da46ca1121b7fbd5bca5b594136a8a1d3aa1a8d5"
 dependencies = [
  "itertools 0.13.0",
  "log",
+]
+
+[[package]]
+name = "hyperon-space"
+version = "0.2.5"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#da46ca1121b7fbd5bca5b594136a8a1d3aa1a8d5"
+dependencies = [
+ "bimap",
+ "hyperon-atom",
+ "hyperon-common",
+ "log",
+ "smallvec",
 ]
 
 [[package]]
@@ -1227,6 +1245,8 @@ dependencies = [
  "bson",
  "env_logger",
  "hyperon-atom",
+ "hyperon-common",
+ "hyperon-space",
  "log",
  "mongodb",
  "prost",

--- a/3rd_party_slots/rust_metta_bus_client/Cargo.toml
+++ b/3rd_party_slots/rust_metta_bus_client/Cargo.toml
@@ -11,7 +11,9 @@ regex = "1.11.0"
 log = "0.4.0"
 env_logger = "0.8.4"
 
+hyperon-common = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.5" }
 hyperon-atom = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.5" }
+hyperon-space = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.5" }
 
 mongodb = "3.2.3"
 bson = "2.14.0"

--- a/3rd_party_slots/rust_metta_bus_client/src/lib.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/lib.rs
@@ -15,6 +15,8 @@ use service_bus::ServiceBus;
 use service_bus_singleton::ServiceBusSingleton;
 use types::BoxError;
 
+pub mod space;
+
 pub mod bus;
 pub mod bus_node;
 pub mod helpers;

--- a/3rd_party_slots/rust_metta_bus_client/src/space/mod.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/space/mod.rs
@@ -28,17 +28,15 @@ impl DistributedAtomSpace {
 	}
 
 	pub fn add(&mut self, atom: Atom) {
-		self.common.notify_all_observers(&SpaceEvent::Add(atom));
+		todo!()
 	}
 
 	pub fn remove(&mut self, atom: &Atom) -> bool {
-		self.common.notify_all_observers(&SpaceEvent::Remove(atom.clone()));
-		true
+		todo!()
 	}
 
 	pub fn replace(&mut self, from: &Atom, to: Atom) -> bool {
-		self.common.notify_all_observers(&SpaceEvent::Replace(from.clone(), to));
-		true
+		todo!()
 	}
 }
 

--- a/3rd_party_slots/rust_metta_bus_client/src/space/mod.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/space/mod.rs
@@ -1,0 +1,102 @@
+use std::{
+	fmt::{Debug, Display},
+	sync::{Arc, Mutex},
+};
+
+use hyperon_common::FlexRef;
+
+use hyperon_atom::{matcher::BindingsSet, Atom};
+
+use crate::{query_with_das, service_bus::ServiceBus};
+
+use hyperon_space::{Space, SpaceCommon, SpaceEvent, SpaceMut, SpaceVisitor};
+
+#[derive(Clone)]
+pub struct DistributedAtomSpace {
+	common: SpaceCommon,
+	service_bus: Arc<Mutex<ServiceBus>>,
+	name: Option<String>,
+}
+
+impl DistributedAtomSpace {
+	pub fn new(service_bus: Arc<Mutex<ServiceBus>>, name: Option<String>) -> Self {
+		Self { common: SpaceCommon::default(), service_bus, name }
+	}
+
+	pub fn query(&self, query: &Atom) -> BindingsSet {
+		query_with_das(self.name.clone(), self.service_bus.clone(), query).unwrap()
+	}
+
+	pub fn add(&mut self, atom: Atom) {
+		self.common.notify_all_observers(&SpaceEvent::Add(atom));
+	}
+
+	pub fn remove(&mut self, atom: &Atom) -> bool {
+		self.common.notify_all_observers(&SpaceEvent::Remove(atom.clone()));
+		true
+	}
+
+	pub fn replace(&mut self, from: &Atom, to: Atom) -> bool {
+		self.common.notify_all_observers(&SpaceEvent::Replace(from.clone(), to));
+		true
+	}
+}
+
+impl Space for DistributedAtomSpace {
+	fn common(&self) -> FlexRef<SpaceCommon> {
+		FlexRef::from_simple(&self.common)
+	}
+	fn query(&self, query: &Atom) -> BindingsSet {
+		self.query(query)
+	}
+	fn atom_count(&self) -> Option<usize> {
+		todo!()
+	}
+	fn visit(&self, _v: &mut dyn SpaceVisitor) -> Result<(), ()> {
+		todo!()
+	}
+	fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
+		self.query(pattern)
+			.drain(0..)
+			.map(|bindings| {
+				hyperon_atom::matcher::apply_bindings_to_atom_move(template.clone(), &bindings)
+			})
+			.collect()
+	}
+	fn as_any(&self) -> &dyn std::any::Any {
+		self
+	}
+}
+
+impl SpaceMut for DistributedAtomSpace {
+	fn add(&mut self, atom: Atom) {
+		self.add(atom)
+	}
+	fn remove(&mut self, atom: &Atom) -> bool {
+		self.remove(atom)
+	}
+	fn replace(&mut self, from: &Atom, to: Atom) -> bool {
+		self.replace(from, to)
+	}
+	fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+		todo!()
+	}
+}
+
+impl Debug for DistributedAtomSpace {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match &self.name {
+			Some(name) => write!(f, "DistributedAtomSpace-{name} ({self:p})"),
+			None => write!(f, "DistributedAtomSpace-{self:p}"),
+		}
+	}
+}
+
+impl Display for DistributedAtomSpace {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match &self.name {
+			Some(name) => write!(f, "DistributedAtomSpace-{name}"),
+			None => write!(f, "DistributedAtomSpace-{self:p}"),
+		}
+	}
+}


### PR DESCRIPTION
This PR moves the `DistributedAtomSpace` from `hyperon-experimental` code base to our `metta_bus_client` crate.

Heads up that I'm now using Rust's `todo!()` to signalize that we still need to implement the API for add/remove `Atom` to/from the space.