### PR TITLE
[#418] Add support for remote error handling among peers

### DIFF
--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -159,20 +159,23 @@ void PatternMatchingQueryProxy::set_positive_importance_flag(bool flag) {
 // ---------------------------------------------------------------------------------------------
 // Virtual superclass API from_remote_peer() and the piggyback methods called by it
 
-void PatternMatchingQueryProxy::from_remote_peer(const string& command, const vector<string>& args) {
+bool PatternMatchingQueryProxy::from_remote_peer(const string& command, const vector<string>& args) {
     LOG_DEBUG("Proxy command: <" << command << "> from " << this->peer_id() << " received in "
                                  << this->my_id());
-    if (command == ANSWER_BUNDLE) {
-        answer_bundle(args);
-    } else if (command == COUNT) {
-        count_answer(args);
-    } else if (command == FINISHED) {
-        query_answers_finished(args);
-    } else if (command == ABORT) {
-        abort(args);
-    } else {
-        Utils::error("Invalid proxy command: <" + command + ">");
+    if (! BusCommandProxy::from_remote_peer(command, args)) {
+        if (command == ANSWER_BUNDLE) {
+            answer_bundle(args);
+        } else if (command == COUNT) {
+            count_answer(args);
+        } else if (command == FINISHED) {
+            query_answers_finished(args);
+        } else if (command == ABORT) {
+            abort(args);
+        } else {
+            Utils::error("Invalid proxy command: <" + command + ">");
+        }
     }
+    return true;
 }
 
 void PatternMatchingQueryProxy::answer_bundle(const vector<string>& args) {

--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -162,7 +162,7 @@ void PatternMatchingQueryProxy::set_positive_importance_flag(bool flag) {
 bool PatternMatchingQueryProxy::from_remote_peer(const string& command, const vector<string>& args) {
     LOG_DEBUG("Proxy command: <" << command << "> from " << this->peer_id() << " received in "
                                  << this->my_id());
-    if (! BusCommandProxy::from_remote_peer(command, args)) {
+    if (!BusCommandProxy::from_remote_peer(command, args)) {
         if (command == ANSWER_BUNDLE) {
             answer_bundle(args);
         } else if (command == COUNT) {

--- a/src/agents/query_engine/PatternMatchingQueryProxy.h
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.h
@@ -217,7 +217,7 @@ class PatternMatchingQueryProxy : public BusCommandProxy {
      * @param command RPC command
      * @param args RPC command's arguments
      */
-    void from_remote_peer(const string& command, const vector<string>& args) override;
+    bool from_remote_peer(const string& command, const vector<string>& args) override;
 
     /**
      * Piggyback method called by ABORT command

--- a/src/service_bus/BusCommandProxy.cc
+++ b/src/service_bus/BusCommandProxy.cc
@@ -89,7 +89,7 @@ string BusCommandProxy::peer_id() { return this->proxy_node->peer_id; }
 void BusCommandProxy::raise_error(const string& error_message, unsigned int error_code) {
     string prefix = "Error ";
     if (error_code > 0) {
-        prefix += std::to_string(error_code) + " "; 
+        prefix += std::to_string(error_code) + " ";
     }
     Utils::error(prefix + " on peer - " + error_message);
 }

--- a/src/service_bus/BusCommandProxy.cc
+++ b/src/service_bus/BusCommandProxy.cc
@@ -9,6 +9,7 @@
 using namespace service_bus;
 
 string ProxyNode::PROXY_COMMAND = "bus_command_proxy";
+string BusCommandProxy::PEER_ERROR = "peer_error";
 
 // -------------------------------------------------------------------------------------------------
 // Constructors and destructors
@@ -66,6 +67,15 @@ void BusCommandProxy::to_remote_peer(const string& command, const vector<string>
     this->proxy_node->to_remote_peer(command, args);
 }
 
+bool BusCommandProxy::from_remote_peer(const string& command, const vector<string>& args) {
+    if (command == PEER_ERROR) {
+        raise_error(args[0], stoi(args[1]));
+        return true;
+    } else {
+        return false;
+    }
+}
+
 const string& BusCommandProxy::get_command() { return this->command; }
 
 const vector<string>& BusCommandProxy::get_args() { return this->args; }
@@ -75,6 +85,18 @@ unsigned int BusCommandProxy::get_serial() { return this->serial; }
 string BusCommandProxy::my_id() { return this->proxy_node->node_id(); }
 
 string BusCommandProxy::peer_id() { return this->proxy_node->peer_id; }
+
+void BusCommandProxy::raise_error(const string& error_message, unsigned int error_code) {
+    string prefix = "Error ";
+    if (error_code > 0) {
+        prefix += std::to_string(error_code) + " "; 
+    }
+    Utils::error(prefix + " on peer - " + error_message);
+}
+
+void BusCommandProxy::raise_error_on_peer(const string& error_message, unsigned int error_code) {
+    to_remote_peer(PEER_ERROR, {error_message, std::to_string(error_code)});
+}
 
 // -------------------------------------------------------------------------------------------------
 // ProxyNode API

--- a/src/service_bus/BusCommandProxy.h
+++ b/src/service_bus/BusCommandProxy.h
@@ -84,9 +84,8 @@ class BusCommandProxy {
     friend class ServiceBus;
 
    public:
-
     // Commands allowed at the proxy level (caller <--> processor)
-    static string PEER_ERROR;          // Raise an error in peer
+    static string PEER_ERROR;  // Raise an error in peer
 
     /**
      * Basic constructor.

--- a/src/service_bus/BusCommandProxy.h
+++ b/src/service_bus/BusCommandProxy.h
@@ -84,6 +84,10 @@ class BusCommandProxy {
     friend class ServiceBus;
 
    public:
+
+    // Commands allowed at the proxy level (caller <--> processor)
+    static string PEER_ERROR;          // Raise an error in peer
+
     /**
      * Basic constructor.
      */
@@ -142,6 +146,11 @@ class BusCommandProxy {
      */
     string peer_id();
 
+    /**
+     * Piggyback method called when raise_error_on_peer() is called in peer's side.
+     */
+    virtual void raise_error(const string& error_message, unsigned int error_code = 0);
+
     // ---------------------------------------------------------------------------------------------
     // BusCommandProxy RPC
 
@@ -168,13 +177,23 @@ class BusCommandProxy {
      *
      * @param command RPC command
      * @param args RPC command's arguments
+     * @return true iff the command is supposed to be processed in this
+     * class (rather than in a subclass).
      */
-    virtual void from_remote_peer(const string& command, const vector<string>& args) = 0;
+    virtual bool from_remote_peer(const string& command, const vector<string>& args);
 
     /**
      * Pack specific command args (in concrete subclasses) into args vector
      */
     virtual void pack_custom_args() = 0;
+
+    /**
+     * Raise an error on remote peer by calling raise_error() passing the error code and message.
+     *
+     * Subclasses may override raise_error() to catch errors and prevent the exception from
+     * being actually raised.
+     */
+    void raise_error_on_peer(const string& error_message, unsigned int error_code = 0);
 
     string command;
     vector<string> args;

--- a/src/tests/cpp/service_bus_test.cc
+++ b/src/tests/cpp/service_bus_test.cc
@@ -12,9 +12,10 @@ class TestProxy : public BusCommandProxy {
     vector<string> remote_args;
     TestProxy() {}
     TestProxy(const string& command, vector<string>& args) : BusCommandProxy(command, args) {}
-    void from_remote_peer(const string& command, const vector<string>& args) {
+    bool from_remote_peer(const string& command, const vector<string>& args) {
         this->remote_command = command;
         this->remote_args = args;
+        return true;
     }
     void pack_custom_args() {}
 };


### PR DESCRIPTION
Progress towards #418 

In this PR we implement the support to remote error handling among peers using a new proxy-level command named PEER_ERROR. The command is managed by the proxy superclass (BusCommandProxy).

After this PR, callers may call a method in proxy, named `raise_error_on_peer()` which will trigger the proxy-level command mentioned above and will remotely call `raise_error()`, which is a virtual method that can be overridden in order to provide error handling in command subclasses.

In this PR only the mentioned method implementations were provided. No error handling is being performed in the concrete subclasses (i.e. PatternMatcherQueryProxy) yet. This is the subject of the next PR.