### PR TITLE
[#418] Implement remote error handling across peers in the ServiceBus

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
 [#386] Limits answer bundle size in query command processor
 [#421] Use an optional proxy parameter to filter QueryAnswers with zeroed importance
 [#433] Build a dynamic lib with all the libs from all the packages and add it to lib/das.os
+[#418] Implement remote error handling across peers in the ServiceBus

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -149,49 +149,55 @@ void PatternMatchingQueryProcessor::process_query_answers(
 
 void PatternMatchingQueryProcessor::thread_process_one_query(
     shared_ptr<StoppableThread> monitor, shared_ptr<PatternMatchingQueryProxy> proxy) {
-    if (proxy->args.size() < 2) {
-        Utils::error("Syntax error in query command. Missing implicit parameters.");
-    }
-    unsigned int skip_arg = 0;
-    proxy->set_context(proxy->args[skip_arg++]);
-    proxy->set_unique_assignment_flag(proxy->args[skip_arg++] == "1");
-    proxy->set_positive_importance_flag(proxy->args[skip_arg++] == "1");
-    proxy->set_attention_update_flag(proxy->args[skip_arg++] == "1");
-    proxy->set_count_flag(proxy->args[skip_arg++] == "1");
-    proxy->query_tokens.insert(
-        proxy->query_tokens.begin(), proxy->args.begin() + skip_arg, proxy->args.end());
-    LOG_DEBUG("Setting up query tree");
-    auto query_element_registry = make_unique<QueryElementRegistry>();
-    shared_ptr<QueryElement> root_query_element = setup_query_tree(proxy, query_element_registry.get());
-    set<string> joint_answer;  // used to stimulate attention broker
-    string command = proxy->get_command();
-    unsigned int sink_port_number;
-    if (command == ServiceBus::PATTERN_MATCHING_QUERY) {
-        sink_port_number = PortPool::get_port();
-        shared_ptr<Sink> query_sink = make_shared<Sink>(
-            root_query_element, "Sink_" + proxy->peer_id() + "_" + std::to_string(proxy->get_serial()));
-        unsigned int answer_count = 0;
-        LOG_DEBUG("Processing QueryAnswer objects");
-        while (!(query_sink->finished() || proxy->is_aborting())) {
-            process_query_answers(proxy, query_sink, joint_answer, answer_count);
-            Utils::sleep();
+    try {
+        if (proxy->args.size() < 2) {
+            Utils::error("Syntax error in query command. Missing implicit parameters.");
         }
-        if (proxy->get_count_flag() && (!proxy->is_aborting())) {
-            LOG_DEBUG("Answering count_only query");
-            proxy->to_remote_peer(PatternMatchingQueryProxy::COUNT, {std::to_string(answer_count)});
+        unsigned int skip_arg = 0;
+        proxy->set_context(proxy->args[skip_arg++]);
+        proxy->set_unique_assignment_flag(proxy->args[skip_arg++] == "1");
+        proxy->set_positive_importance_flag(proxy->args[skip_arg++] == "1");
+        proxy->set_attention_update_flag(proxy->args[skip_arg++] == "1");
+        proxy->set_count_flag(proxy->args[skip_arg++] == "1");
+        proxy->query_tokens.insert(
+            proxy->query_tokens.begin(), proxy->args.begin() + skip_arg, proxy->args.end());
+        LOG_DEBUG("Setting up query tree");
+        auto query_element_registry = make_unique<QueryElementRegistry>();
+        shared_ptr<QueryElement> root_query_element = setup_query_tree(proxy, query_element_registry.get());
+        set<string> joint_answer;  // used to stimulate attention broker
+        string command = proxy->get_command();
+        unsigned int sink_port_number;
+        if (command == ServiceBus::PATTERN_MATCHING_QUERY) {
+            sink_port_number = PortPool::get_port();
+            shared_ptr<Sink> query_sink = make_shared<Sink>(
+                root_query_element, "Sink_" + proxy->peer_id() + "_" + std::to_string(proxy->get_serial()));
+            unsigned int answer_count = 0;
+            LOG_DEBUG("Processing QueryAnswer objects");
+            while (!(query_sink->finished() || proxy->is_aborting())) {
+                process_query_answers(proxy, query_sink, joint_answer, answer_count);
+                Utils::sleep();
+            }
+            if (proxy->get_count_flag() && (!proxy->is_aborting())) {
+                LOG_DEBUG("Answering count_only query");
+                proxy->to_remote_peer(PatternMatchingQueryProxy::COUNT, {std::to_string(answer_count)});
+            }
+            Utils::sleep(500);
+            proxy->to_remote_peer(PatternMatchingQueryProxy::FINISHED, {});
+            if (proxy->get_attention_update_flag()) {
+                LOG_DEBUG("Updating AttentionBroker (stimulate)");
+                update_attention_broker_joint_answer(proxy, joint_answer);
+            }
+            Utils::sleep(500);
+            LOG_INFO("Total processed answers: " << answer_count);
+            query_sink->graceful_shutdown();
+            PortPool::return_port(sink_port_number);
+        } else {
+            Utils::error("Invalid command " + command + " in PatternMatchingQueryProcessor");
         }
-        Utils::sleep(500);
-        proxy->to_remote_peer(PatternMatchingQueryProxy::FINISHED, {});
-        if (proxy->get_attention_update_flag()) {
-            LOG_DEBUG("Updating AttentionBroker (stimulate)");
-            update_attention_broker_joint_answer(proxy, joint_answer);
-        }
-        Utils::sleep(500);
-        LOG_INFO("Total processed answers: " << answer_count);
-        query_sink->graceful_shutdown();
-        PortPool::return_port(sink_port_number);
-    } else {
-        Utils::error("Invalid command " + command + " in PatternMatchingQueryProcessor");
+    } catch (const std::runtime_error exception) {
+        proxy->raise_error_on_peer(exception.what());
+    } catch (const std::exception exception) {
+        proxy->raise_error_on_peer(exception.what());
     }
     LOG_DEBUG("Command finished: <" << proxy->get_command() << ">");
     // TODO add a call to remove_query_thread(monitor->get_id());

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -163,14 +163,16 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
             proxy->query_tokens.begin(), proxy->args.begin() + skip_arg, proxy->args.end());
         LOG_DEBUG("Setting up query tree");
         auto query_element_registry = make_unique<QueryElementRegistry>();
-        shared_ptr<QueryElement> root_query_element = setup_query_tree(proxy, query_element_registry.get());
+        shared_ptr<QueryElement> root_query_element =
+            setup_query_tree(proxy, query_element_registry.get());
         set<string> joint_answer;  // used to stimulate attention broker
         string command = proxy->get_command();
         unsigned int sink_port_number;
         if (command == ServiceBus::PATTERN_MATCHING_QUERY) {
             sink_port_number = PortPool::get_port();
             shared_ptr<Sink> query_sink = make_shared<Sink>(
-                root_query_element, "Sink_" + proxy->peer_id() + "_" + std::to_string(proxy->get_serial()));
+                root_query_element,
+                "Sink_" + proxy->peer_id() + "_" + std::to_string(proxy->get_serial()));
             unsigned int answer_count = 0;
             LOG_DEBUG("Processing QueryAnswer objects");
             while (!(query_sink->finished() || proxy->is_aborting())) {

--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -41,6 +41,7 @@ void PatternMatchingQueryProxy::init() {
     this->answer_flow_finished = false;
     this->abort_flag = false;
     this->answer_count = 0;
+    this->error_flag = false;
     set_default_query_parameters();
 }
 
@@ -157,7 +158,21 @@ void PatternMatchingQueryProxy::set_positive_importance_flag(bool flag) {
 }
 
 // ---------------------------------------------------------------------------------------------
-// Virtual superclass API from_remote_peer() and the piggyback methods called by it
+// Virtual superclass API and the piggyback methods called by it
+
+void PatternMatchingQueryProxy::raise_error(const string& error_message, unsigned int error_code) {
+    string error = "Exception thrown in command processor.";
+    if (error_code > 0) {
+        error += " Error code: " + std::to_string(error_code);
+    }
+    error += "\n";
+    error += error_message;
+    this->error_flag = true;
+    this->error_code = error_code;
+    this->error_message = error;
+    LOG_ERROR(error);
+    query_answers_finished({});
+}
 
 bool PatternMatchingQueryProxy::from_remote_peer(const string& command, const vector<string>& args) {
     LOG_DEBUG("Proxy command: <" << command << "> from " << this->peer_id() << " received in "

--- a/src/agents/query_engine/PatternMatchingQueryProxy.h
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.h
@@ -207,7 +207,14 @@ class PatternMatchingQueryProxy : public BusCommandProxy {
     void set_positive_importance_flag(bool flag);
 
     // ---------------------------------------------------------------------------------------------
-    // Virtual superclass API from_remote_peer() and the piggyback methods called by it
+    // Virtual superclass API and the piggyback methods called by it
+
+    /**
+     * Piggyback method called when raise_error_on_peer() is called in peer's side.
+     *
+     * error_code == 0 means that NO ERROR CODE has been provided
+     */
+    void raise_error(const string& error_message, unsigned int error_code = 0);
 
     /**
      * Receive a command and its arguments passed by the remote peer.
@@ -248,6 +255,9 @@ class PatternMatchingQueryProxy : public BusCommandProxy {
     void query_answers_finished(const vector<string>& args);
 
     vector<string> query_tokens;
+    bool error_flag;
+    unsigned int error_code;
+    string error_message;
 
    private:
     void init();

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <thread>
+
 #include "Logger.h"
 
 using namespace commons;
@@ -21,9 +22,9 @@ Utils::Utils() {}
 
 Utils::~Utils() {}
 
-void Utils::error(string msg) { 
+void Utils::error(string msg) {
     LOG_ERROR(msg);
-    throw runtime_error(msg); 
+    throw runtime_error(msg);
 }
 
 void Utils::warning(string msg) { cerr << msg << endl; }

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <thread>
+#include "Logger.h"
 
 using namespace commons;
 using namespace std;
@@ -20,7 +21,11 @@ Utils::Utils() {}
 
 Utils::~Utils() {}
 
-void Utils::error(string msg) { throw runtime_error(msg); }
+void Utils::error(string msg) { 
+    LOG_ERROR(msg);
+    throw runtime_error(msg); 
+}
+
 void Utils::warning(string msg) { cerr << msg << endl; }
 
 bool Utils::flip_coin(double true_probability) {

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -185,15 +185,22 @@ TEST(PatternMatchingQuery, queries) {
     // clang-format on
 
     // Regular queries
-    check_query(q1, q1_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(q3, q3_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(q4, q4_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(q5, q5_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(q6, q6_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false);
+    check_query(
+        q1, q1_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(
+        q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(
+        q3, q3_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(
+        q4, q4_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(
+        q5, q5_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(
+        q6, q6_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false);
 
     // Importance filtering
-    check_query(q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", true, false, false, false);
+    check_query(
+        q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", true, false, false, false);
     check_query(q1, 3, client_bus, "PatternMatchingQuery.queries", false, false, true, false);
 
     // Remote exception


### PR DESCRIPTION
Resolves #418 

The error is logged server side (CommandProcessor) and client side (command caller) and the query ends immediately.

On server side, the thread processing the query just ends, without actually raising  the exception.
On client side, the proxy interrupts query answers (the iterator will finish gracefully) but no
exception is thrown.

proxy.error_flag, proxy.error_code and proxy.error_message are set in the proxy object on client side.