### PR TITLE
[#499] Refactor Proxy classes to use commons:Properties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,3 +4,4 @@
 [#418] Implement remote error handling across peers in the ServiceBus
 [#505] Add a strength value to QueryAnswer
 [#511] Create a Properties class in commons by moving and renaming CustomAttributesMap from AtomDB package
+[#499] Refactor proxy classes to use commons:Properties

--- a/src/agents/BaseProxy.cc
+++ b/src/agents/BaseProxy.cc
@@ -52,9 +52,8 @@ void BaseProxy::untokenize(vector<string>& tokens) {
     unsigned int num_property_tokens = std::stoi(tokens[0]);
     if (num_property_tokens > 0) {
         vector<string> properties_tokens;
-        properties_tokens.insert(properties_tokens.begin(), 
-                                 tokens.begin() + 1, 
-                                 tokens.begin() + 1 + num_property_tokens);
+        properties_tokens.insert(
+            properties_tokens.begin(), tokens.begin() + 1, tokens.begin() + 1 + num_property_tokens);
         this->parameters.untokenize(properties_tokens);
         tokens.erase(tokens.begin(), tokens.begin() + 1 + num_property_tokens);
     }

--- a/src/agents/BaseProxy.cc
+++ b/src/agents/BaseProxy.cc
@@ -41,7 +41,7 @@ void BaseProxy::abort() {
 
 void BaseProxy::tokenize(vector<string>& output) {
     vector<string> parameters_tokens = this->parameters.tokenize();
-    parameters_tokens.insert(parameters_tokens.begin, std::to_string(parameters_tokens.size()));
+    parameters_tokens.insert(parameters_tokens.begin(), std::to_string(parameters_tokens.size()));
     output.insert(output.begin(), parameters_tokens.begin(), parameters_tokens.end());
 }
 
@@ -55,7 +55,7 @@ void BaseProxy::untokenize(vector<string>& tokens) {
         properties_tokens.insert(properties_tokens.begin(), 
                                  tokens.begin() + 1, 
                                  tokens.begin() + 1 + num_property_tokens);
-        this->properties.untokenize(properties_tokens);
+        this->parameters.untokenize(properties_tokens);
         tokens.erase(tokens.begin(), tokens.begin() + 1 + num_property_tokens);
     }
 }

--- a/src/agents/BaseProxy.cc
+++ b/src/agents/BaseProxy.cc
@@ -17,6 +17,7 @@ BaseProxy::BaseProxy() {
     lock_guard<mutex> semaphore(this->api_mutex);
     this->command_finished_flag = false;
     this->abort_flag = false;
+    this->error_flag = false;
 }
 
 BaseProxy::~BaseProxy() {}
@@ -38,12 +39,37 @@ void BaseProxy::abort() {
     this->abort_flag = true;
 }
 
+void BaseProxy::tokenize(vector<string>& output) {
+    vector<string> parameters_tokens = this->parameters.tokenize();
+    parameters_tokens.insert(parameters_tokens.begin, std::to_string(parameters_tokens.size()));
+    output.insert(output.begin(), parameters_tokens.begin(), parameters_tokens.end());
+}
+
 // -------------------------------------------------------------------------------------------------
 // Server-side API
+
+void BaseProxy::untokenize(vector<string>& tokens) {
+    unsigned int num_property_tokens = std::stoi(tokens[0]);
+    if (num_property_tokens > 0) {
+        vector<string> properties_tokens;
+        properties_tokens.insert(properties_tokens.begin(), 
+                                 tokens.begin() + 1, 
+                                 tokens.begin() + 1 + num_property_tokens);
+        this->properties.untokenize(properties_tokens);
+        tokens.erase(tokens.begin(), tokens.begin() + 1 + num_property_tokens);
+    }
+}
 
 bool BaseProxy::is_aborting() {
     lock_guard<mutex> semaphore(this->api_mutex);
     return this->abort_flag;
+}
+
+string BaseProxy::to_string() {
+    string answer = "{";
+    answer += "parameters: " + this->parameters.to_string();
+    answer += "}";
+    return answer;
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/src/agents/BaseProxy.h
+++ b/src/agents/BaseProxy.h
@@ -3,8 +3,8 @@
 #include <mutex>
 
 #include "BusCommandProxy.h"
-#include "Properties.h"
 #include "Message.h"
+#include "Properties.h"
 
 using namespace std;
 using namespace service_bus;

--- a/src/agents/BaseProxy.h
+++ b/src/agents/BaseProxy.h
@@ -3,6 +3,7 @@
 #include <mutex>
 
 #include "BusCommandProxy.h"
+#include "Properties.h"
 #include "Message.h"
 
 using namespace std;
@@ -40,8 +41,23 @@ class BaseProxy : public BusCommandProxy {
      */
     void abort();
 
+    /**
+     * Write a tokenized representation of this proxy in the passed `output` vector.
+     *
+     * @param output Vector where the tokens will be put.
+     */
+    virtual void tokenize(vector<string>& output);
+
     // ---------------------------------------------------------------------------------------------
     // Server-side API
+
+    /**
+     * Extrtact the tokens from the begining of the passed tokens vector (AND ERASE THEM) in order
+     * to build this proxy.
+     *
+     * @param tokens Tokens vector (CHANGED BY SIDE-EFFECT)
+     */
+    virtual void untokenize(vector<string>& tokens);
 
     /**
      * Returns true iff a request to abort has been issued by the caller.
@@ -49,6 +65,13 @@ class BaseProxy : public BusCommandProxy {
      * @return true iff a request to abort has been issued by the caller.
      */
     bool is_aborting();
+
+    /**
+     * Returns a string representation with all command parameter values.
+     *
+     * @return a string representation with all command parameter values.
+     */
+    virtual string to_string();
 
     // ---------------------------------------------------------------------------------------------
     // Virtual superclass API and the piggyback methods called by it
@@ -82,6 +105,7 @@ class BaseProxy : public BusCommandProxy {
      */
     void command_finished(const vector<string>& args);
 
+    Properties parameters;
     bool error_flag;
     unsigned int error_code;
     string error_message;

--- a/src/agents/BaseQueryProxy.cc
+++ b/src/agents/BaseQueryProxy.cc
@@ -76,9 +76,8 @@ void BaseQueryProxy::untokenize(vector<string>& tokens) {
     this->context = tokens[0];
     unsigned int num_query_tokens = std::stoi(tokens[1]);
 
-    this->query_tokens.insert(this->query_tokens.begin(), 
-                              tokens.begin() + 2,
-                              tokens.begin() + 2 + num_query_tokens);
+    this->query_tokens.insert(
+        this->query_tokens.begin(), tokens.begin() + 2, tokens.begin() + 2 + num_query_tokens);
     tokens.erase(tokens.begin(), tokens.begin() + 2 + num_query_tokens);
 }
 

--- a/src/agents/BaseQueryProxy.cc
+++ b/src/agents/BaseQueryProxy.cc
@@ -72,11 +72,12 @@ void BaseQueryProxy::tokenize(vector<string>& output) {
 // Server-side API
 
 void BaseQueryProxy::untokenize(vector<string>& tokens) {
-    BaseQuery::untokenize(tokens);
+    BaseProxy::untokenize(tokens);
     this->context = tokens[0];
     unsigned int num_query_tokens = std::stoi(tokens[1]);
+
     this->query_tokens.insert(this->query_tokens.begin(), 
-                              tokens.begin() + 2;
+                              tokens.begin() + 2,
                               tokens.begin() + 2 + num_query_tokens);
     tokens.erase(tokens.begin(), tokens.begin() + 2 + num_query_tokens);
 }
@@ -101,20 +102,6 @@ string BaseQueryProxy::to_string() {
 
 // ---------------------------------------------------------------------------------------------
 // Virtual superclass API and the piggyback methods called by it
-
-void BaseQueryProxy::raise_error(const string& error_message, unsigned int error_code) {
-    string error = "Exception thrown in command processor.";
-    if (error_code > 0) {
-        error += " Error code: " + std::to_string(error_code);
-    }
-    error += "\n";
-    error += error_message;
-    this->error_flag = true;
-    this->error_code = error_code;
-    this->error_message = error;
-    LOG_ERROR(error);
-    command_finished({});
-}
 
 bool BaseQueryProxy::from_remote_peer(const string& command, const vector<string>& args) {
     LOG_DEBUG("Proxy command: <" << command << "> from " << this->peer_id() << " received in "

--- a/src/agents/BaseQueryProxy.h
+++ b/src/agents/BaseQueryProxy.h
@@ -38,6 +38,13 @@ class BaseQueryProxy : public BaseProxy {
     static string ABORT;          // Abort current query
     static string FINISHED;       // Notification that all query results have alkready been delivered
 
+    // Query command's optional parameters
+    static string UNIQUE_ASSIGNMENT_FLAG; // When true, query operators (e.g. And, Or) don't output
+                                          // more than one QueryAnswer with the same variable
+                                          // assignment.
+    static string ATTENTION_UPDATE_FLAG;  // When true, queries issued to the pattern matcher will
+                                          // trigger attention update automatically.
+
     /**
      * Destructor.
      */
@@ -70,8 +77,23 @@ class BaseQueryProxy : public BaseProxy {
      */
     void set_count(unsigned int count);
 
+    /**
+     * Write a tokenized representation of this proxy in the passed `output` vector.
+     *
+     * @param output Vector where the tokens will be put.
+     */
+    virtual void tokenize(vector<string>& output);
+
     // ---------------------------------------------------------------------------------------------
     // Server-side API
+
+    /**
+     * Extrtact the tokens from the begining of the passed tokens vector (AND ERASE THEM) in order
+     * to build this proxy.
+     *
+     * @param tokens Tokens vector (CHANGED BY SIDE-EFFECT)
+     */
+    virtual void untokenize(vector<string>& tokens);
 
     /**
      * Push an answer to the proxy. This answer will end in the peer proxy but it may not happen
@@ -89,13 +111,6 @@ class BaseQueryProxy : public BaseProxy {
     const string& get_context();
 
     /**
-     * Setter for context
-     *
-     * @param context Context
-     */
-    void set_context(const string& context);
-
-    /**
      * Getter for query_tokens
      *
      * @return query_tokens
@@ -108,47 +123,6 @@ class BaseQueryProxy : public BaseProxy {
      * @return a string representation with all command parameter values.
      */
     virtual string to_string();
-
-    // ---------------------------------------------------------------------------------------------
-    // Query parameters getters and setters
-
-    /**
-     * Getter for unique_assignment_flag
-     *
-     * unique_assignment_flag prevents duplicated variable assignment in Operators' output
-     *
-     * @return unique_assignment_flag
-     */
-    bool get_unique_assignment_flag();
-
-    /**
-     * Setter for unique_assignment_flag
-     *
-     * unique_assignment_flag prevents duplicated variable assignment in Operators' output
-     *
-     * @param flag Flag
-     */
-    void set_unique_assignment_flag(bool flag);
-
-    /**
-     * Getter for attention_update_flag
-     *
-     * attention_update_flag Atutomatically trigger attention allocation update on pattern matcher
-     * queries.
-     *
-     * @return attention_update_flag
-     */
-    bool get_attention_update_flag();
-
-    /**
-     * Setter for attention_update_flag
-     *
-     * attention_update_flag Atutomatically trigger attention allocation update on pattern matcher
-     * queries.
-     *
-     * @param flag Flag
-     */
-    void set_attention_update_flag(bool flag);
 
     // ---------------------------------------------------------------------------------------------
     // Virtual superclass API and the piggyback methods called by it
@@ -184,7 +158,6 @@ class BaseQueryProxy : public BaseProxy {
      */
     void query_answers_finished(const vector<string>& args);
 
-    vector<string> query_tokens;
     bool error_flag;
     unsigned int error_code;
     string error_message;
@@ -195,20 +168,7 @@ class BaseQueryProxy : public BaseProxy {
     SharedQueue answer_queue;
     unsigned int answer_count;
     string context;
-
-    // ---------------------------------------------------------------------------------------------
-    // Query parameters
-
-    /**
-     * When true, query operators (e.g. And, Or) don't output more than one
-     * QueryAnswer with the same variable assignment.
-     * */
-    bool unique_assignment_flag;
-
-    /**
-     * When true, queries issued to the pattern matcher will trigger attention update automatically.
-     * */
-    bool attention_update_flag;
+    vector<string> query_tokens;
 };
 
 }  // namespace agents

--- a/src/agents/BaseQueryProxy.h
+++ b/src/agents/BaseQueryProxy.h
@@ -128,13 +128,6 @@ class BaseQueryProxy : public BaseProxy {
     // Virtual superclass API and the piggyback methods called by it
 
     /**
-     * Piggyback method called when raise_error_on_peer() is called in peer's side.
-     *
-     * error_code == 0 means that NO ERROR CODE has been provided
-     */
-    void raise_error(const string& error_message, unsigned int error_code = 0);
-
-    /**
      * Receive a command and its arguments passed by the remote peer.
      *
      * Concrete subclasses of BusCommandProxy need to implement this method.
@@ -157,10 +150,6 @@ class BaseQueryProxy : public BaseProxy {
      * @param args Command arguments (empty for FINISHED command)
      */
     void query_answers_finished(const vector<string>& args);
-
-    bool error_flag;
-    unsigned int error_code;
-    string error_message;
 
    private:
     void init();

--- a/src/agents/BaseQueryProxy.h
+++ b/src/agents/BaseQueryProxy.h
@@ -39,11 +39,11 @@ class BaseQueryProxy : public BaseProxy {
     static string FINISHED;       // Notification that all query results have alkready been delivered
 
     // Query command's optional parameters
-    static string UNIQUE_ASSIGNMENT_FLAG; // When true, query operators (e.g. And, Or) don't output
-                                          // more than one QueryAnswer with the same variable
-                                          // assignment.
-    static string ATTENTION_UPDATE_FLAG;  // When true, queries issued to the pattern matcher will
-                                          // trigger attention update automatically.
+    static string UNIQUE_ASSIGNMENT_FLAG;  // When true, query operators (e.g. And, Or) don't output
+                                           // more than one QueryAnswer with the same variable
+                                           // assignment.
+    static string ATTENTION_UPDATE_FLAG;   // When true, queries issued to the pattern matcher will
+                                           // trigger attention update automatically.
 
     /**
      * Destructor.

--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -72,7 +72,8 @@ void QueryEvolutionProcessor::sample_population(
     shared_ptr<StoppableThread> monitor,
     shared_ptr<QueryEvolutionProxy> proxy,
     vector<std::pair<shared_ptr<QueryAnswer>, float>>& population) {
-    unsigned int population_size = proxy->parameters.get<unsigned int>(QueryEvolutionProxy::POPULATION_SIZE);
+    unsigned int population_size =
+        proxy->parameters.get<unsigned int>(QueryEvolutionProxy::POPULATION_SIZE);
     auto pm = atom_space.pattern_matching_query(
         proxy->get_query_tokens(), population_size, proxy->get_context());
     while ((!pm->finished()) && (!monitor->stopped()) && (population.size() < population_size)) {

--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -50,13 +50,8 @@ void QueryEvolutionProcessor::thread_process_one_query(shared_ptr<StoppableThrea
         if (proxy->args.size() < 2) {
             Utils::error("Syntax error in query command. Missing implicit parameters.");
         }
-        unsigned int skip_arg = 0;
-        proxy->set_context(proxy->args[skip_arg++]);
-        proxy->set_unique_assignment_flag(proxy->args[skip_arg++] == "1");
-        proxy->set_fitness_function_tag(proxy->args[skip_arg++]);
-        proxy->set_population_size(std::stoi(proxy->args[skip_arg++]));
-        proxy->query_tokens.insert(
-            proxy->query_tokens.begin(), proxy->args.begin() + skip_arg, proxy->args.end());
+        proxy->untokenize(proxy->args);
+        LOG_DEBUG("proxy: " + proxy->to_string());
         string command = proxy->get_command();
         if (command == ServiceBus::QUERY_EVOLUTION) {
             LOG_DEBUG("QUERY_EVOLUTION proxy: " << proxy->to_string());
@@ -77,7 +72,7 @@ void QueryEvolutionProcessor::sample_population(
     shared_ptr<StoppableThread> monitor,
     shared_ptr<QueryEvolutionProxy> proxy,
     vector<std::pair<shared_ptr<QueryAnswer>, float>>& population) {
-    unsigned int population_size = proxy->get_population_size();
+    unsigned int population_size = proxy->parameters.get<unsigned int>(QueryEvolutionProxy::POPULATION_SIZE);
     auto pm = atom_space.pattern_matching_query(
         proxy->get_query_tokens(), population_size, proxy->get_context());
     while ((!pm->finished()) && (!monitor->stopped()) && (population.size() < population_size)) {

--- a/src/agents/evolution/QueryEvolutionProxy.cc
+++ b/src/agents/evolution/QueryEvolutionProxy.cc
@@ -29,9 +29,7 @@ QueryEvolutionProxy::QueryEvolutionProxy(const vector<string>& tokens,
     this->command = ServiceBus::QUERY_EVOLUTION;
 }
 
-void QueryEvolutionProxy::set_default_query_parameters() {
-    this->parameters[POPULATION_SIZE] = 1000;
-}
+void QueryEvolutionProxy::set_default_query_parameters() { this->parameters[POPULATION_SIZE] = 1000; }
 
 string QueryEvolutionProxy::to_string() {
     lock_guard<mutex> semaphore(this->api_mutex);
@@ -47,9 +45,7 @@ QueryEvolutionProxy::~QueryEvolutionProxy() {}
 // -------------------------------------------------------------------------------------------------
 // Client-side API
 
-void QueryEvolutionProxy::pack_command_line_args() {
-    tokenize(this->args);
-}
+void QueryEvolutionProxy::pack_command_line_args() { tokenize(this->args); }
 
 void QueryEvolutionProxy::tokenize(vector<string>& output) {
     lock_guard<mutex> semaphore(this->api_mutex);

--- a/src/agents/evolution/QueryEvolutionProxy.h
+++ b/src/agents/evolution/QueryEvolutionProxy.h
@@ -28,6 +28,9 @@ class QueryEvolutionProxy : public BaseQueryProxy {
     // ---------------------------------------------------------------------------------------------
     // Constructors, destructors and static state
 
+    // Query command's optional parameters
+    static string POPULATION_SIZE;
+
     /**
      * Empty constructor typically used on server side.
      */
@@ -43,20 +46,36 @@ class QueryEvolutionProxy : public BaseQueryProxy {
                         const string& fitness_function,
                         const string& context);
 
-    AQUI migrar para o design novo das properties
-
     /**
      * Destructor.
      */
     virtual ~QueryEvolutionProxy();
 
     // ---------------------------------------------------------------------------------------------
+    // Client-side API
+
+    /**
+     * Builds the args vector to be passed in the RPC
+     */
+    void pack_command_line_args();
+
+    /**
+     * Write a tokenized representation of this proxy in the passed `output` vector.
+     *
+     * @param output Vector where the tokens will be put.
+     */
+    virtual void tokenize(vector<string>& output);
+
+    // ---------------------------------------------------------------------------------------------
     // Server-side API
 
     /**
-     * Pack query arguments into args vector
+     * Extrtact the tokens from the begining of the passed tokens vector (AND ERASE THEM) in order
+     * to build this proxy.
+     *
+     * @param tokens Tokens vector (CHANGED BY SIDE-EFFECT)
      */
-    void pack_custom_args();
+    virtual void untokenize(vector<string>& tokens);
 
     /**
      * Compute the fitness value of the passed QueryAnswer.
@@ -74,45 +93,6 @@ class QueryEvolutionProxy : public BaseQueryProxy {
     virtual string to_string();
 
     // ---------------------------------------------------------------------------------------------
-    // Query parameters getters and setters
-
-    /**
-     * Getter for fitness_function_tag
-     *
-     * fitness_function_tag is the id for the fitness function to be used to evaluate query answers
-     *
-     * @return fitness_function_tag
-     */
-    const string& get_fitness_function_tag();
-
-    /**
-     * Setter for fitness_function_tag
-     *
-     * fitness_function_tag is the id for the fitness function to be used to evaluate query answers
-     *
-     * @param flag Flag
-     */
-    void set_fitness_function_tag(const string& tag);
-
-    /**
-     * Getter for population_size
-     *
-     * population_size Number of answers sampled every evolution cycle.
-     *
-     * @return population_size
-     */
-    unsigned int get_population_size();
-
-    /**
-     * Setter for population_size
-     *
-     * population_size Number of answers sampled every evolution cycle.
-     *
-     * @param population_size Population size
-     */
-    void set_population_size(unsigned int population_size);
-
-    // ---------------------------------------------------------------------------------------------
     // Virtual superclass API and the piggyback methods called by it
 
     /**
@@ -127,22 +107,11 @@ class QueryEvolutionProxy : public BaseQueryProxy {
 
    private:
     void set_default_query_parameters();
+    void set_fitness_function_tag(const string& tag);
 
     mutex api_mutex;
     shared_ptr<FitnessFunction> fitness_function_object;
-
-    // ---------------------------------------------------------------------------------------------
-    // Query parameters
-
-    /**
-     * Fitness function selector.
-     */
     string fitness_function_tag;
-
-    /**
-     * Number of answers sampled every evolution cycle.
-     */
-    unsigned int population_size;
 };
 
 }  // namespace evolution

--- a/src/agents/evolution/QueryEvolutionProxy.h
+++ b/src/agents/evolution/QueryEvolutionProxy.h
@@ -43,6 +43,8 @@ class QueryEvolutionProxy : public BaseQueryProxy {
                         const string& fitness_function,
                         const string& context);
 
+    AQUI migrar para o design novo das properties
+
     /**
      * Destructor.
      */

--- a/src/agents/link_creation_agent/LinkCreationAgent.cc
+++ b/src/agents/link_creation_agent/LinkCreationAgent.cc
@@ -117,7 +117,7 @@ shared_ptr<PatternMatchingQueryProxy> LinkCreationAgent::query(vector<string>& q
                                                                bool update_attention_broker) {
     shared_ptr<PatternMatchingQueryProxy> proxy =
         make_shared<PatternMatchingQueryProxy>(query_tokens, context);
-    proxy->set_attention_update_flag(update_attention_broker);
+    proxy->parameters[BaseQueryProxy::ATTENTION_UPDATE_FLAG] = update_attention_broker;
     ServiceBusSingleton::get_instance()->issue_bus_command(proxy);
     return proxy;
 }

--- a/src/agents/link_creation_agent/LinkProcessor.h
+++ b/src/agents/link_creation_agent/LinkProcessor.h
@@ -37,8 +37,8 @@ class LinkProcessor {
         try {
             shared_ptr<PatternMatchingQueryProxy> query_count_proxy =
                 make_shared<PatternMatchingQueryProxy>(query, context);
-            query_count_proxy->set_unique_assignment_flag(is_unique_assignment);
-            query_count_proxy->set_count_flag(true);
+            query_count_proxy->parameters[BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG] = is_unique_assignment;
+            query_count_proxy->parameters[PatternMatchingQueryProxy::COUNT_FLAG] = true;
             ServiceBusSingleton::get_instance()->issue_bus_command(query_count_proxy);
             while (!query_count_proxy->finished()) {
                 Utils::sleep(20);

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -173,7 +173,8 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
                     process_query_answers(proxy, query_sink, joint_answer, answer_count);
                     Utils::sleep();
                 }
-                if (proxy->parameters.get<bool>(PatternMatchingQueryProxy::COUNT_FLAG) && (!proxy->is_aborting())) {
+                if (proxy->parameters.get<bool>(PatternMatchingQueryProxy::COUNT_FLAG) &&
+                    (!proxy->is_aborting())) {
                     LOG_DEBUG("Answering count_only query");
                     proxy->to_remote_peer(PatternMatchingQueryProxy::COUNT,
                                           {std::to_string(answer_count)});
@@ -235,8 +236,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
     while (!execution_stack.empty()) {
         cursor = execution_stack.top();
         if (query_tokens[cursor] == "NODE") {
-            element_stack.push(
-                make_shared<Node>(query_tokens[cursor + 1], query_tokens[cursor + 2]));
+            element_stack.push(make_shared<Node>(query_tokens[cursor + 1], query_tokens[cursor + 2]));
         } else if (query_tokens[cursor] == "VARIABLE") {
             element_stack.push(make_shared<Variable>(query_tokens[cursor + 1]));
         } else if (query_tokens[cursor] == "LINK") {
@@ -257,8 +257,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
                 element_stack.push(build_unique_assignment_filter(proxy, cursor, element_stack));
             }
         } else {
-            Utils::error("Invalid token " + query_tokens[cursor] +
-                         " in PATTERN_MATCHING_QUERY message");
+            Utils::error("Invalid token " + query_tokens[cursor] + " in PATTERN_MATCHING_QUERY message");
         }
         execution_stack.pop();
     }
@@ -270,19 +269,18 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
     return element_stack.top();
 }
 
-#define BUILD_LINK_TEMPLATE(N)                                                                                                         \
-    {                                                                                                                                  \
-        array<shared_ptr<QueryElement>, N> targets;                                                                                    \
-        for (unsigned int i = 0; i < N; i++) {                                                                                         \
-            targets[i] = element_stack.top();                                                                                          \
-            element_stack.pop();                                                                                                       \
-        }                                                                                                                              \
-        auto link_template = make_shared<LinkTemplate<N>>(query_tokens[cursor + 1],                                                    \
-                                                          move(targets),                                                               \
-                                                          proxy->get_context(),                                                        \
-                                                          query_element_registry);                                                     \
-        link_template->set_positive_importance_flag(proxy->parameters.get<bool>(PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG)); \
-        return link_template;                                                                                                          \
+#define BUILD_LINK_TEMPLATE(N)                                                                      \
+    {                                                                                               \
+        array<shared_ptr<QueryElement>, N> targets;                                                 \
+        for (unsigned int i = 0; i < N; i++) {                                                      \
+            targets[i] = element_stack.top();                                                       \
+            element_stack.pop();                                                                    \
+        }                                                                                           \
+        auto link_template = make_shared<LinkTemplate<N>>(                                          \
+            query_tokens[cursor + 1], move(targets), proxy->get_context(), query_element_registry); \
+        link_template->set_positive_importance_flag(                                                \
+            proxy->parameters.get<bool>(PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG));      \
+        return link_template;                                                                       \
     }
 
 shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link_template(

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -132,7 +132,7 @@ void PatternMatchingQueryProcessor::process_query_answers(
         if (!proxy->get_count_flag()) {
             answer_bundle.push_back(answer->tokenize());
         }
-        if (proxy->get_attention_update_flag()) {
+        if (proxy->parameters[ATTENTION_UPDATE_FLAG]) {
             update_attention_broker_single_answer(proxy, answer, joint_answer);
         }
         if (answer_bundle.size() >= MAX_BUNDLE_SIZE) {
@@ -161,7 +161,7 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
         proxy->set_count_flag(proxy->args[skip_arg++] == "1");
         proxy->query_tokens.insert(
             proxy->query_tokens.begin(), proxy->args.begin() + skip_arg, proxy->args.end());
-        LOG_DEBUG("attention_update_flag: " << proxy->get_attention_update_flag());
+        LOG_DEBUG("attention_update_flag: " << proxy->parameters[ATTENTION_UPDATE_FLAG]);
         LOG_DEBUG("Setting up query tree");
         auto query_element_registry = make_unique<QueryElementRegistry>();
         shared_ptr<QueryElement> root_query_element =
@@ -190,7 +190,7 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
                 }
                 Utils::sleep(500);
                 proxy->to_remote_peer(PatternMatchingQueryProxy::FINISHED, {});
-                if (proxy->get_attention_update_flag()) {
+                if (proxy->parameters[ATTENTION_UPDATE_FLAG]) {
                     LOG_DEBUG("Updating AttentionBroker (stimulate)");
                     update_attention_broker_joint_answer(proxy, joint_answer);
                 }
@@ -257,12 +257,12 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
             element_stack.push(build_link_template2(proxy, cursor, element_stack));
         } else if (proxy->query_tokens[cursor] == "AND") {
             element_stack.push(build_and(proxy, cursor, element_stack));
-            if (proxy->get_unique_assignment_flag()) {
+            if (proxy->parameters[UNIQUE_ASSIGNMENT_FLAG]) {
                 element_stack.push(build_unique_assignment_filter(proxy, cursor, element_stack));
             }
         } else if (proxy->query_tokens[cursor] == "OR") {
             element_stack.push(build_or(proxy, cursor, element_stack));
-            if (proxy->get_unique_assignment_flag()) {
+            if (proxy->parameters[UNIQUE_ASSIGNMENT_FLAG]) {
                 element_stack.push(build_unique_assignment_filter(proxy, cursor, element_stack));
             }
         } else {

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -129,10 +129,10 @@ void PatternMatchingQueryProcessor::process_query_answers(
     while ((answer = query_sink->input_buffer->pop_query_answer()) != NULL) {
         answer_count++;
         bundle_count++;
-        if (!proxy->get_count_flag()) {
+        if (!proxy->parameters.get<bool>(PatternMatchingQueryProxy::COUNT_FLAG)) {
             answer_bundle.push_back(answer->tokenize());
         }
-        if (proxy->parameters[ATTENTION_UPDATE_FLAG]) {
+        if (proxy->parameters.get<bool>(BaseQueryProxy::ATTENTION_UPDATE_FLAG)) {
             update_attention_broker_single_answer(proxy, answer, joint_answer);
         }
         if (answer_bundle.size() >= MAX_BUNDLE_SIZE) {
@@ -150,18 +150,8 @@ void PatternMatchingQueryProcessor::process_query_answers(
 void PatternMatchingQueryProcessor::thread_process_one_query(
     shared_ptr<StoppableThread> monitor, shared_ptr<PatternMatchingQueryProxy> proxy) {
     try {
-        if (proxy->args.size() < 2) {
-            Utils::error("Syntax error in query command. Missing implicit parameters.");
-        }
-        unsigned int skip_arg = 0;
-        proxy->set_context(proxy->args[skip_arg++]);
-        proxy->set_unique_assignment_flag(proxy->args[skip_arg++] == "1");
-        proxy->set_positive_importance_flag(proxy->args[skip_arg++] == "1");
-        proxy->set_attention_update_flag(proxy->args[skip_arg++] == "1");
-        proxy->set_count_flag(proxy->args[skip_arg++] == "1");
-        proxy->query_tokens.insert(
-            proxy->query_tokens.begin(), proxy->args.begin() + skip_arg, proxy->args.end());
-        LOG_DEBUG("attention_update_flag: " << proxy->parameters[ATTENTION_UPDATE_FLAG]);
+        proxy->untokenize(proxy->args);
+        LOG_DEBUG("proxy: " + proxy->to_string());
         LOG_DEBUG("Setting up query tree");
         auto query_element_registry = make_unique<QueryElementRegistry>();
         shared_ptr<QueryElement> root_query_element =
@@ -183,14 +173,14 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
                     process_query_answers(proxy, query_sink, joint_answer, answer_count);
                     Utils::sleep();
                 }
-                if (proxy->get_count_flag() && (!proxy->is_aborting())) {
+                if (proxy->parameters.get<bool>(PatternMatchingQueryProxy::COUNT_FLAG) && (!proxy->is_aborting())) {
                     LOG_DEBUG("Answering count_only query");
                     proxy->to_remote_peer(PatternMatchingQueryProxy::COUNT,
                                           {std::to_string(answer_count)});
                 }
                 Utils::sleep(500);
                 proxy->to_remote_peer(PatternMatchingQueryProxy::FINISHED, {});
-                if (proxy->parameters[ATTENTION_UPDATE_FLAG]) {
+                if (proxy->parameters.get<bool>(BaseQueryProxy::ATTENTION_UPDATE_FLAG)) {
                     LOG_DEBUG("Updating AttentionBroker (stimulate)");
                     update_attention_broker_joint_answer(proxy, joint_answer);
                 }
@@ -224,12 +214,13 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
     stack<unsigned int> execution_stack;
     stack<shared_ptr<QueryElement>> element_stack;
     unsigned int cursor = 0;
-    unsigned int tokens_count = proxy->query_tokens.size();
+    const vector<string> query_tokens = proxy->get_query_tokens();
+    unsigned int tokens_count = query_tokens.size();
 
     while (cursor < tokens_count) {
         execution_stack.push(cursor);
-        if ((proxy->query_tokens[cursor] == "VARIABLE") || (proxy->query_tokens[cursor] == "AND") ||
-            ((proxy->query_tokens[cursor] == "OR"))) {
+        if ((query_tokens[cursor] == "VARIABLE") || (query_tokens[cursor] == "AND") ||
+            ((query_tokens[cursor] == "OR"))) {
             cursor += 2;
         } else {
             cursor += 3;
@@ -243,30 +234,30 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
 
     while (!execution_stack.empty()) {
         cursor = execution_stack.top();
-        if (proxy->query_tokens[cursor] == "NODE") {
+        if (query_tokens[cursor] == "NODE") {
             element_stack.push(
-                make_shared<Node>(proxy->query_tokens[cursor + 1], proxy->query_tokens[cursor + 2]));
-        } else if (proxy->query_tokens[cursor] == "VARIABLE") {
-            element_stack.push(make_shared<Variable>(proxy->query_tokens[cursor + 1]));
-        } else if (proxy->query_tokens[cursor] == "LINK") {
+                make_shared<Node>(query_tokens[cursor + 1], query_tokens[cursor + 2]));
+        } else if (query_tokens[cursor] == "VARIABLE") {
+            element_stack.push(make_shared<Variable>(query_tokens[cursor + 1]));
+        } else if (query_tokens[cursor] == "LINK") {
             element_stack.push(build_link(proxy, cursor, element_stack));
-        } else if (proxy->query_tokens[cursor] == "LINK_TEMPLATE") {
+        } else if (query_tokens[cursor] == "LINK_TEMPLATE") {
             element_stack.push(
                 build_link_template(proxy, cursor, element_stack, query_element_registry));
-        } else if (proxy->query_tokens[cursor] == "LINK_TEMPLATE2") {
+        } else if (query_tokens[cursor] == "LINK_TEMPLATE2") {
             element_stack.push(build_link_template2(proxy, cursor, element_stack));
-        } else if (proxy->query_tokens[cursor] == "AND") {
+        } else if (query_tokens[cursor] == "AND") {
             element_stack.push(build_and(proxy, cursor, element_stack));
-            if (proxy->parameters[UNIQUE_ASSIGNMENT_FLAG]) {
+            if (proxy->parameters.get<bool>(BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG)) {
                 element_stack.push(build_unique_assignment_filter(proxy, cursor, element_stack));
             }
-        } else if (proxy->query_tokens[cursor] == "OR") {
+        } else if (query_tokens[cursor] == "OR") {
             element_stack.push(build_or(proxy, cursor, element_stack));
-            if (proxy->parameters[UNIQUE_ASSIGNMENT_FLAG]) {
+            if (proxy->parameters.get<bool>(BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG)) {
                 element_stack.push(build_unique_assignment_filter(proxy, cursor, element_stack));
             }
         } else {
-            Utils::error("Invalid token " + proxy->query_tokens[cursor] +
+            Utils::error("Invalid token " + query_tokens[cursor] +
                          " in PATTERN_MATCHING_QUERY message");
         }
         execution_stack.pop();
@@ -279,19 +270,19 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
     return element_stack.top();
 }
 
-#define BUILD_LINK_TEMPLATE(N)                                                              \
-    {                                                                                       \
-        array<shared_ptr<QueryElement>, N> targets;                                         \
-        for (unsigned int i = 0; i < N; i++) {                                              \
-            targets[i] = element_stack.top();                                               \
-            element_stack.pop();                                                            \
-        }                                                                                   \
-        auto link_template = make_shared<LinkTemplate<N>>(proxy->query_tokens[cursor + 1],  \
-                                                          move(targets),                    \
-                                                          proxy->get_context(),             \
-                                                          query_element_registry);          \
-        link_template->set_positive_importance_flag(proxy->get_positive_importance_flag()); \
-        return link_template;                                                               \
+#define BUILD_LINK_TEMPLATE(N)                                                                                                         \
+    {                                                                                                                                  \
+        array<shared_ptr<QueryElement>, N> targets;                                                                                    \
+        for (unsigned int i = 0; i < N; i++) {                                                                                         \
+            targets[i] = element_stack.top();                                                                                          \
+            element_stack.pop();                                                                                                       \
+        }                                                                                                                              \
+        auto link_template = make_shared<LinkTemplate<N>>(query_tokens[cursor + 1],                                                    \
+                                                          move(targets),                                                               \
+                                                          proxy->get_context(),                                                        \
+                                                          query_element_registry);                                                     \
+        link_template->set_positive_importance_flag(proxy->parameters.get<bool>(PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG)); \
+        return link_template;                                                                                                          \
     }
 
 shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link_template(
@@ -299,7 +290,8 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link_template(
     unsigned int cursor,
     stack<shared_ptr<QueryElement>>& element_stack,
     QueryElementRegistry* query_element_registry) {
-    unsigned int arity = std::stoi(proxy->query_tokens[cursor + 2]);
+    const vector<string> query_tokens = proxy->get_query_tokens();
+    unsigned int arity = std::stoi(query_tokens[cursor + 2]);
     if (element_stack.size() < arity) {
         Utils::error(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for "
@@ -325,21 +317,22 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link_template(
     return NULL;  // Just to avoid warnings. This is not actually reachable.
 }
 
-#define BUILD_LINK_TEMPLATE2(N)                                                               \
-    {                                                                                         \
-        array<shared_ptr<QueryElement>, N> targets;                                           \
-        for (unsigned int i = 0; i < N; i++) {                                                \
-            targets[i] = element_stack.top();                                                 \
-            element_stack.pop();                                                              \
-        }                                                                                     \
-        return make_shared<LinkTemplate2<N>>(proxy->query_tokens[cursor + 1], move(targets)); \
+#define BUILD_LINK_TEMPLATE2(N)                                                        \
+    {                                                                                  \
+        array<shared_ptr<QueryElement>, N> targets;                                    \
+        for (unsigned int i = 0; i < N; i++) {                                         \
+            targets[i] = element_stack.top();                                          \
+            element_stack.pop();                                                       \
+        }                                                                              \
+        return make_shared<LinkTemplate2<N>>(query_tokens[cursor + 1], move(targets)); \
     }
 
 shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link_template2(
     shared_ptr<PatternMatchingQueryProxy> proxy,
     unsigned int cursor,
     stack<shared_ptr<QueryElement>>& element_stack) {
-    unsigned int arity = std::stoi(proxy->query_tokens[cursor + 2]);
+    const vector<string> query_tokens = proxy->get_query_tokens();
+    unsigned int arity = std::stoi(query_tokens[cursor + 2]);
     if (element_stack.size() < arity) {
         Utils::error(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for "
@@ -379,7 +372,8 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_and(
     shared_ptr<PatternMatchingQueryProxy> proxy,
     unsigned int cursor,
     stack<shared_ptr<QueryElement>>& element_stack) {
-    unsigned int num_clauses = std::stoi(proxy->query_tokens[cursor + 1]);
+    const vector<string> query_tokens = proxy->get_query_tokens();
+    unsigned int num_clauses = std::stoi(query_tokens[cursor + 1]);
     if (element_stack.size() < num_clauses) {
         Utils::error(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for AND");
@@ -418,7 +412,8 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_or(
     shared_ptr<PatternMatchingQueryProxy> proxy,
     unsigned int cursor,
     stack<shared_ptr<QueryElement>>& element_stack) {
-    unsigned int num_clauses = std::stoi(proxy->query_tokens[cursor + 1]);
+    const vector<string> query_tokens = proxy->get_query_tokens();
+    unsigned int num_clauses = std::stoi(query_tokens[cursor + 1]);
     if (element_stack.size() < num_clauses) {
         Utils::error("PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for OR");
     }
@@ -442,21 +437,22 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_or(
     return NULL;  // Just to avoid warnings. This is not actually reachable.
 }
 
-#define BUILD_LINK(N)                                                                \
-    {                                                                                \
-        array<shared_ptr<QueryElement>, N> targets;                                  \
-        for (unsigned int i = 0; i < N; i++) {                                       \
-            targets[i] = element_stack.top();                                        \
-            element_stack.pop();                                                     \
-        }                                                                            \
-        return make_shared<Link<N>>(proxy->query_tokens[cursor + 1], move(targets)); \
+#define BUILD_LINK(N)                                                         \
+    {                                                                         \
+        array<shared_ptr<QueryElement>, N> targets;                           \
+        for (unsigned int i = 0; i < N; i++) {                                \
+            targets[i] = element_stack.top();                                 \
+            element_stack.pop();                                              \
+        }                                                                     \
+        return make_shared<Link<N>>(query_tokens[cursor + 1], move(targets)); \
     }
 
 shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link(
     shared_ptr<PatternMatchingQueryProxy> proxy,
     unsigned int cursor,
     stack<shared_ptr<QueryElement>>& element_stack) {
-    unsigned int arity = std::stoi(proxy->query_tokens[cursor + 2]);
+    const vector<string> query_tokens = proxy->get_query_tokens();
+    unsigned int arity = std::stoi(query_tokens[cursor + 2]);
     if (element_stack.size() < arity) {
         Utils::error(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for LINK");

--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -30,8 +30,8 @@ PatternMatchingQueryProxy::PatternMatchingQueryProxy(const vector<string>& token
 }
 
 void PatternMatchingQueryProxy::set_default_parameters() {
-    this->parameters["POSITIVE_IMPORTANCE_FLAG"] = false;
-    this->parameters["COUNT_FLAG"] = false;
+    this->parameters[POSITIVE_IMPORTANCE_FLAG] = false;
+    this->parameters[COUNT_FLAG] = false;
 }
 
 PatternMatchingQueryProxy::~PatternMatchingQueryProxy() {}
@@ -41,7 +41,7 @@ PatternMatchingQueryProxy::~PatternMatchingQueryProxy() {}
 
 shared_ptr<QueryAnswer> PatternMatchingQueryProxy::pop() {
     lock_guard<mutex> semaphore(this->api_mutex);
-    if (this->count_flag) {
+    if (this->parameters.get<bool>(COUNT_FLAG)) {
         Utils::error("Can't pop QueryAnswers from count_only queries.");
         return shared_ptr<QueryAnswer>(NULL);
     } else {
@@ -54,14 +54,6 @@ shared_ptr<QueryAnswer> PatternMatchingQueryProxy::pop() {
 
 void PatternMatchingQueryProxy::pack_command_line_args() {
     tokenize(this->args);
-    /*
-    vector<string> custom_args = {this->get_context(),
-                                  std::to_string(this->get_unique_assignment_flag()),
-                                  std::to_string(this->positive_importance_flag),
-                                  std::to_string(this->get_attention_update_flag()),
-                                  std::to_string(this->count_flag)};
-    this->args.insert(this->args.begin(), custom_args.begin(), custom_args.end());
-    */
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -90,7 +82,7 @@ void PatternMatchingQueryProxy::count_answer(const vector<string>& args) {
         if (args.size() != 1) {
             Utils::error("Invalid args for count command");
         }
-        if (!this->count_flag) {
+        if (!this->parameters.get<bool>(COUNT_FLAG)) {
             Utils::error("Invalid count command. Query is not count_only.");
         } else {
             this->set_count(stoi(args[0]));

--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -12,28 +12,26 @@ using namespace query_engine;
 
 string PatternMatchingQueryProxy::COUNT = "count";
 
+string PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG = "positive_importance_flag";
+string PatternMatchingQueryProxy::COUNT_FLAG = "count_flag";
+
 PatternMatchingQueryProxy::PatternMatchingQueryProxy() {
     // constructor typically used in processor
     lock_guard<mutex> semaphore(this->api_mutex);
-    init();
+    set_default_parameters();
 }
 
 PatternMatchingQueryProxy::PatternMatchingQueryProxy(const vector<string>& tokens, const string& context)
     : BaseQueryProxy(tokens, context) {
     // constructor typically used in requestor
     lock_guard<mutex> semaphore(this->api_mutex);
-    init();
+    set_default_parameters();
     this->command = ServiceBus::PATTERN_MATCHING_QUERY;
 }
 
-void PatternMatchingQueryProxy::set_default_query_parameters() {
-    this->positive_importance_flag = false;
-    this->count_flag = false;
-}
-
-void PatternMatchingQueryProxy::init() {
-    this->error_flag = false;
-    set_default_query_parameters();
+void PatternMatchingQueryProxy::set_default_parameters() {
+    this->parameters["POSITIVE_IMPORTANCE_FLAG"] = false;
+    this->parameters["COUNT_FLAG"] = false;
 }
 
 PatternMatchingQueryProxy::~PatternMatchingQueryProxy() {}
@@ -54,46 +52,16 @@ shared_ptr<QueryAnswer> PatternMatchingQueryProxy::pop() {
 // -------------------------------------------------------------------------------------------------
 // Server-side API
 
-void PatternMatchingQueryProxy::pack_custom_args() {
+void PatternMatchingQueryProxy::pack_command_line_args() {
+    tokenize(this->args);
+    /*
     vector<string> custom_args = {this->get_context(),
                                   std::to_string(this->get_unique_assignment_flag()),
                                   std::to_string(this->positive_importance_flag),
                                   std::to_string(this->get_attention_update_flag()),
                                   std::to_string(this->count_flag)};
     this->args.insert(this->args.begin(), custom_args.begin(), custom_args.end());
-}
-
-string PatternMatchingQueryProxy::to_string() {
-    string answer = "{";
-    answer += BaseQueryProxy::to_string();
-    answer += " count_flag: " + string(this->get_count_flag() ? "true" : "false");
-    answer +=
-        " positive_importance_flag: " + string(this->get_positive_importance_flag() ? "true" : "false");
-    answer += "}";
-    return answer;
-}
-
-// -------------------------------------------------------------------------------------------------
-// Query parameters getters and setters
-
-bool PatternMatchingQueryProxy::get_count_flag() {
-    lock_guard<mutex> semaphore(this->api_mutex);
-    return this->count_flag;
-}
-
-void PatternMatchingQueryProxy::set_count_flag(bool flag) {
-    lock_guard<mutex> semaphore(this->api_mutex);
-    this->count_flag = flag;
-}
-
-bool PatternMatchingQueryProxy::get_positive_importance_flag() {
-    lock_guard<mutex> semaphore(this->api_mutex);
-    return this->positive_importance_flag;
-}
-
-void PatternMatchingQueryProxy::set_positive_importance_flag(bool flag) {
-    lock_guard<mutex> semaphore(this->api_mutex);
-    this->positive_importance_flag = flag;
+    */
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -52,9 +52,7 @@ shared_ptr<QueryAnswer> PatternMatchingQueryProxy::pop() {
 // -------------------------------------------------------------------------------------------------
 // Server-side API
 
-void PatternMatchingQueryProxy::pack_command_line_args() {
-    tokenize(this->args);
-}
+void PatternMatchingQueryProxy::pack_command_line_args() { tokenize(this->args); }
 
 // ---------------------------------------------------------------------------------------------
 // Virtual superclass API and the piggyback methods called by it

--- a/src/agents/query_engine/PatternMatchingQueryProxy.h
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.h
@@ -32,12 +32,12 @@ class PatternMatchingQueryProxy : public BaseQueryProxy {
     static string COUNT;  // Delivery of the final result of a count_only query
 
     // Query command's optional parameters
-    static string POSITIVE_IMPORTANCE_FLAG; // Indicates that only answres whose importance > 0
-                                            // are supposed to be returned
+    static string POSITIVE_IMPORTANCE_FLAG;  // Indicates that only answres whose importance > 0
+                                             // are supposed to be returned
 
-    static string COUNT_FLAG; // indicates that this query is supposed to count the results and not
-                              // actually provide the query answers (i.e. no QueryAnswer is sent
-                              // from the command executor and the caller of the query).
+    static string COUNT_FLAG;  // indicates that this query is supposed to count the results and not
+                               // actually provide the query answers (i.e. no QueryAnswer is sent
+                               // from the command executor and the caller of the query).
     /**
      * Empty constructor typically used on server side.
      */
@@ -104,4 +104,4 @@ class PatternMatchingQueryProxy : public BaseQueryProxy {
     mutex api_mutex;
 };
 
-} // namespace query_engine
+}  // namespace query_engine

--- a/src/agents/query_engine/PatternMatchingQueryProxy.h
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.h
@@ -31,6 +31,13 @@ class PatternMatchingQueryProxy : public BaseQueryProxy {
     // Commands allowed at the proxy level (caller <--> processor)
     static string COUNT;  // Delivery of the final result of a count_only query
 
+    // Query command's optional parameters
+    static string POSITIVE_IMPORTANCE_FLAG; // Indicates that only answres whose importance > 0
+                                            // are supposed to be returned
+
+    static string COUNT_FLAG; // indicates that this query is supposed to count the results and not
+                              // actually provide the query answers (i.e. no QueryAnswer is sent
+                              // from the command executor and the caller of the query).
     /**
      * Empty constructor typically used on server side.
      */
@@ -66,55 +73,9 @@ class PatternMatchingQueryProxy : public BaseQueryProxy {
     // Server-side API
 
     /**
-     * Pack query arguments into args vector
+     * Builds the args vector to be passed in the RPC
      */
-    void pack_custom_args();
-
-    /**
-     * Returns a string representation with all command parameter values.
-     *
-     * @return a string representation with all command parameter values.
-     */
-    virtual string to_string();
-
-    // ---------------------------------------------------------------------------------------------
-    // Query parameters getters and setters
-
-    /**
-     * Getter for count_flag
-     *
-     * count_flag tells the processor whether the query is count_only
-     *
-     * @return count_flag
-     */
-    bool get_count_flag();
-
-    /**
-     * Setter for count_flag
-     *
-     * count_flag tells the processor whether the query is count_only
-     *
-     * @param flag Flag
-     */
-    void set_count_flag(bool flag);
-
-    /**
-     * Getter for positive_importance_flag
-     *
-     * positive_importance_flag indicates that only answers whose importance > 0 are to be returned
-     *
-     * @return positive_importance_flag
-     */
-    bool get_positive_importance_flag();
-
-    /**
-     * Setter for positive_importance_flag
-     *
-     * positive_importance_flag indicates that only answers whose importance > 0 are to be returned
-     *
-     * @param flag Flag
-     */
-    void set_positive_importance_flag(bool flag);
+    void pack_command_line_args();
 
     // ---------------------------------------------------------------------------------------------
     // Virtual superclass API and the piggyback methods called by it
@@ -138,20 +99,9 @@ class PatternMatchingQueryProxy : public BaseQueryProxy {
 
    private:
     void init();
-    void set_default_query_parameters();
+    void set_default_parameters();
 
     mutex api_mutex;
-
-    // ---------------------------------------------------------------------------------------------
-    // Query parameters
-
-    // Indicates that only answres whose importance > 0 are supposed to be returned
-    bool positive_importance_flag;
-
-    // indicates that this query is supposed to count the results and not
-    // actually provide the query answers (i.e. no QueryAnswer is sent from the
-    // command executor and the caller of the query).
-    bool count_flag;
 };
 
-}  // namespace query_engine
+} // namespace query_engine

--- a/src/atom_space/AtomSpace.cc
+++ b/src/atom_space/AtomSpace.cc
@@ -65,9 +65,9 @@ shared_ptr<PatternMatchingQueryProxy> AtomSpace::pattern_matching_query(const ve
     // TODO: Use `answers_count` parameter to limit the number of answers once the functionality is
     // implemented on the server side.
     auto proxy = make_shared<PatternMatchingQueryProxy>(query, context);
-    proxy->set_unique_assignment_flag(unique_assignment);
-    proxy->set_attention_update_flag(update_attention_broker);
-    proxy->set_count_flag(count_only);
+    proxy->parameters[BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG] = unique_assignment;
+    proxy->parameters[BaseQueryProxy::ATTENTION_UPDATE_FLAG] = update_attention_broker;
+    proxy->parameters[PatternMatchingQueryProxy::COUNT_FLAG] = count_only;
 
     this->bus->issue_bus_command(proxy);
     return proxy;

--- a/src/commons/Properties.h
+++ b/src/commons/Properties.h
@@ -122,13 +122,15 @@ class Properties : public unordered_map<string, PropertyValue> {
 
     /**
      * @brief Convert the Properties to a representation as a vector of tokens (strings)
-     * @return A string representation of the map in the form {key1, type1, value1, key2, type2, value2, ...}.
+     * @return A string representation of the map in the form {key1, type1, value1, key2, type2, value2,
+     * ...}.
      */
     vector<string> tokenize() const {
         vector<string> result;
-        if (! this->empty()) {
+        if (!this->empty()) {
             // Sort keys for consistent output
-            // Note: This is not strictly necessary, but it makes the output predictable and easier to read.
+            // Note: This is not strictly necessary, but it makes the output predictable and easier to
+            // read.
             vector<string> keys;
             for (const auto& pair : *this) {
                 keys.push_back(pair.first);

--- a/src/commons/Properties.h
+++ b/src/commons/Properties.h
@@ -175,9 +175,9 @@ class Properties : public unordered_map<string, PropertyValue> {
                 if (type == "string") {
                     (*this)[key] = value;
                 } else if (type == "long") {
-                    (*this)[key] = stoi(value);
+                    (*this)[key] = (long) stoi(value);
                 } else if (type == "unsigned_int") {
-                    (*this)[key] = stoi(value);
+                    (*this)[key] = (unsigned int) stoi(value);
                 } else if (type == "double") {
                     (*this)[key] = stod(value);
                 } else if (type == "bool") {

--- a/src/commons/Properties.h
+++ b/src/commons/Properties.h
@@ -6,11 +6,13 @@
 #include <variant>
 #include <vector>
 
+#include "Utils.h"
+
 using namespace std;
 
 namespace commons {
 
-using PropertyValue = variant<string, long, double, bool>;
+using PropertyValue = variant<string, long, unsigned int, double, bool>;
 
 /**
  * @brief A specialization of std::unordered_map using string as key and
@@ -46,7 +48,7 @@ class Properties : public unordered_map<string, PropertyValue> {
      * @return Pointer to the value if present and of the correct type, otherwise nullptr.
      */
     template <typename T>
-    const T* get(const string& key) const {
+    const T* get_ptr(const string& key) const {
         auto it = this->find(key);
         if (it != this->end()) {
             if (auto attr = std::get_if<T>(&it->second)) {
@@ -56,6 +58,26 @@ class Properties : public unordered_map<string, PropertyValue> {
         return nullptr;
     }
 
+    /**
+     * @brief Get the value associated with a key, cast to the requested type.
+     *
+     * If the key exists and the value can be cast to type T, returns the value.
+     * Otherwise, raises an error.
+     *
+     * @tparam T The type to cast the value to (must match the variant type).
+     * @param key The key to look up in the map.
+     * @return The value if present and of the correct type, otherwise raises an error.
+     */
+    template <typename T>
+    const T get(const string& key) const {
+        auto it = this->find(key);
+        if (it != this->end()) {
+            if (auto attr = std::get_if<T>(&it->second)) {
+                return *attr;
+            }
+        }
+        Utils::error("Unkown property key: " + key);
+    }
     /**
      * @brief Convert the Properties to a string representation.
      * @return A string representation of the map in the form {key1: value1, key2: value2, ...}.
@@ -79,8 +101,10 @@ class Properties : public unordered_map<string, PropertyValue> {
             result += key + ": ";
             if (auto str = std::get_if<string>(&value)) {
                 result += "'" + *str + "'";
-            } else if (auto integer = std::get_if<long>(&value)) {
-                result += std::to_string(*integer);
+            } else if (auto longint = std::get_if<long>(&value)) {
+                result += std::to_string(*longint);
+            } else if (auto uinteger = std::get_if<unsigned int>(&value)) {
+                result += std::to_string(*uinteger);
             } else if (auto floating = std::get_if<double>(&value)) {
                 result += std::to_string(*floating);
             } else if (auto boolean = std::get_if<bool>(&value)) {
@@ -94,6 +118,83 @@ class Properties : public unordered_map<string, PropertyValue> {
         result.pop_back();
 
         return result + "}";
+    }
+
+    /**
+     * @brief Convert the Properties to a representation as a vector of tokens (strings)
+     * @return A string representation of the map in the form {key1, type1, value1, key2, type2, value2, ...}.
+     */
+    vector<string> tokenize() const {
+        vector<string> result;
+        if (! this->empty()) {
+            // Sort keys for consistent output
+            // Note: This is not strictly necessary, but it makes the output predictable and easier to read.
+            vector<string> keys;
+            for (const auto& pair : *this) {
+                keys.push_back(pair.first);
+            }
+            std::sort(keys.begin(), keys.end());
+
+            for (const auto& key : keys) {
+                result.push_back(key);
+                const auto& value = this->at(key);
+                if (auto str = std::get_if<string>(&value)) {
+                    result.push_back("string");
+                    result.push_back(*str);
+                } else if (auto longint = std::get_if<long>(&value)) {
+                    result.push_back("long");
+                    result.push_back(std::to_string(*longint));
+                } else if (auto uinteger = std::get_if<unsigned int>(&value)) {
+                    result.push_back("unsigned_int");
+                    result.push_back(std::to_string(*uinteger));
+                } else if (auto floating = std::get_if<double>(&value)) {
+                    result.push_back("double");
+                    result.push_back(std::to_string(*floating));
+                } else if (auto boolean = std::get_if<bool>(&value)) {
+                    result.push_back("bool");
+                    result.push_back(*boolean ? "true" : "false");
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @brief Build a Properties object based on a vector of string tokens like
+     * {key1, type1, value1, key2, type2, value2, ...}.
+     *
+     * @return The Properties object with keys and values as defined in the tokens.
+     */
+    void untokenize(const vector<string>& tokens) {
+        if ((tokens.size() % 3) == 0) {
+            unsigned int cursor = 0;
+            while (cursor != tokens.size()) {
+                string key = tokens[cursor++];
+                string type = tokens[cursor++];
+                string value = tokens[cursor++];
+                if (type == "string") {
+                    (*this)[key] = value;
+                } else if (type == "long") {
+                    (*this)[key] = stoi(value);
+                } else if (type == "unsigned_int") {
+                    (*this)[key] = stoi(value);
+                } else if (type == "double") {
+                    (*this)[key] = stod(value);
+                } else if (type == "bool") {
+                    if (value == "true") {
+                        (*this)[key] = true;
+                    } else if (value == "false") {
+                        (*this)[key] = false;
+                    } else {
+                        Utils::error("Invalid 'bool' string value: " + value);
+                    }
+                } else {
+                    Utils::error("Invalid token type: " + type);
+                }
+            }
+        } else {
+            Utils::error("Invalid tokens vector size: " + std::to_string(tokens.size()));
+        }
     }
 };
 

--- a/src/main/word_query_evolution_main.cc
+++ b/src/main/word_query_evolution_main.cc
@@ -7,6 +7,7 @@
 #include "QueryAnswer.h"
 #include "QueryEvolutionProxy.h"
 #include "ServiceBusSingleton.h"
+#include "FitnessFunctionRegistry.h"
 #include "Utils.h"
 
 #define MAX_QUERY_ANSWERS ((unsigned int) 100000)
@@ -85,6 +86,7 @@ void run(const string& context, const string& word_tag1, const string& word_tag2
     AtomDBSingleton::init();
     shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
     ServiceBusSingleton::init(client_id, server_id, 63000, 63999);
+    FitnessFunctionRegistry::initialize_statics();
 
     shared_ptr<ServiceBus> service_bus = ServiceBusSingleton::get_instance();
 
@@ -124,7 +126,7 @@ void run(const string& context, const string& word_tag1, const string& word_tag2
 
     shared_ptr<QueryEvolutionProxy> proxy =
         make_shared<QueryEvolutionProxy>(or_two_words, "unit_test", context);
-    proxy->set_population_size(100);
+    proxy->parameters[QueryEvolutionProxy::POPULATION_SIZE] = (unsigned int) 100;
     service_bus->issue_bus_command(proxy);
 
     shared_ptr<QueryAnswer> query_answer;

--- a/src/main/word_query_evolution_main.cc
+++ b/src/main/word_query_evolution_main.cc
@@ -4,10 +4,10 @@
 #include <string>
 
 #include "AtomDBSingleton.h"
+#include "FitnessFunctionRegistry.h"
 #include "QueryAnswer.h"
 #include "QueryEvolutionProxy.h"
 #include "ServiceBusSingleton.h"
-#include "FitnessFunctionRegistry.h"
 #include "Utils.h"
 
 #define MAX_QUERY_ANSWERS ((unsigned int) 100000)

--- a/src/main/word_query_main.cc
+++ b/src/main/word_query_main.cc
@@ -127,7 +127,7 @@ void run(const string& context, const string& word_tag) {
 
     shared_ptr<PatternMatchingQueryProxy> proxy =
         make_shared<PatternMatchingQueryProxy>(query_word, context);
-    proxy->set_attention_update_flag(true);
+    proxy->parameters[BaseQueryProxy::ATTENTION_UPDATE_FLAG] = true;
     service_bus->issue_bus_command(proxy);
 
     shared_ptr<QueryAnswer> query_answer;
@@ -172,8 +172,8 @@ void run(const string& context, const string& word_tag) {
 
     shared_ptr<PatternMatchingQueryProxy> proxy2 =
         make_shared<PatternMatchingQueryProxy>(query_word, context);
-    proxy2->set_unique_assignment_flag(true);
-    proxy2->set_attention_update_flag(true);
+    proxy2->parameters[BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG] = true;
+    proxy2->parameters[BaseQueryProxy::ATTENTION_UPDATE_FLAG] = true;
     service_bus->issue_bus_command(proxy2);
     while (!proxy2->finished()) {
         Utils::sleep();

--- a/src/service_bus/BusCommandProxy.h
+++ b/src/service_bus/BusCommandProxy.h
@@ -184,7 +184,7 @@ class BusCommandProxy {
     /**
      * Pack specific command args (in concrete subclasses) into args vector
      */
-    virtual void pack_custom_args() = 0;
+    virtual void pack_command_line_args() = 0;
 
     /**
      * Raise an error on remote peer by calling raise_error() passing the error code and message.

--- a/src/service_bus/ServiceBus.cc
+++ b/src/service_bus/ServiceBus.cc
@@ -78,7 +78,7 @@ void ServiceBus::issue_bus_command(shared_ptr<BusCommandProxy> proxy) {
         args.push_back(proxy->requestor_id);
         args.push_back(to_string(proxy->serial));
         args.push_back(proxy->proxy_node->node_id());
-        proxy->pack_custom_args();
+        proxy->pack_command_line_args();
         for (auto arg : proxy->args) {
             args.push_back(arg);
         }

--- a/src/tests/cpp/atom_space_types_test.cc
+++ b/src/tests/cpp/atom_space_types_test.cc
@@ -100,8 +100,8 @@ TEST(NodeTest, NodeWithCustomAttributes) {
     attrs["foo"] = std::string("bar");
     attrs["num"] = 42L;
     Node n("Type", "Name", attrs);
-    EXPECT_EQ(n.custom_attributes.get<std::string>("foo") != nullptr, true);
-    EXPECT_EQ(n.custom_attributes.get<long>("num") != nullptr, true);
+    EXPECT_EQ(n.custom_attributes.get_ptr<std::string>("foo") != nullptr, true);
+    EXPECT_EQ(n.custom_attributes.get_ptr<long>("num") != nullptr, true);
     std::string s = n.to_string();
     EXPECT_EQ(s, "Node(type: 'Type', name: 'Name', custom_attributes: {foo: 'bar', num: 42})");
 }
@@ -111,7 +111,7 @@ TEST(LinkTest, LinkWithCustomAttributes) {
     Node n2("Type2", "Name2");
     std::vector<const Atom*> targets = {&n1, &n2};
     Link l("LinkType", targets, {{"flag", true}, {"count", 10}});
-    EXPECT_EQ(l.custom_attributes.get<bool>("flag") != nullptr, true);
+    EXPECT_EQ(l.custom_attributes.get_ptr<bool>("flag") != nullptr, true);
     std::string s = l.to_string();
     // clang-format off
     EXPECT_EQ(

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -50,15 +50,17 @@ void check_query(const vector<string>& query,
                  bool positive_importance,
                  bool error_flag) {
     shared_ptr<PatternMatchingQueryProxy> proxy1(new PatternMatchingQueryProxy(query, context));
-    proxy1->set_unique_assignment_flag(unique_assignment);
-    proxy1->set_attention_update_flag(update_attention_broker);
-    proxy1->set_positive_importance_flag(positive_importance);
+    proxy1->parameters[BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG] = unique_assignment;
+    proxy1->parameters[BaseQueryProxy::ATTENTION_UPDATE_FLAG] = update_attention_broker;
+    proxy1->parameters[PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG] = positive_importance;
+    LOG_INFO("proxy1: " + proxy1->to_string());
 
     shared_ptr<PatternMatchingQueryProxy> proxy2(new PatternMatchingQueryProxy(query, context));
-    proxy2->set_unique_assignment_flag(unique_assignment);
-    proxy2->set_attention_update_flag(update_attention_broker);
-    proxy2->set_count_flag(true);
-    proxy2->set_positive_importance_flag(positive_importance);
+    proxy2->parameters[BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG] = unique_assignment;
+    proxy2->parameters[BaseQueryProxy::ATTENTION_UPDATE_FLAG] = update_attention_broker;
+    proxy2->parameters[PatternMatchingQueryProxy::COUNT_FLAG] = true;
+    proxy2->parameters[PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG] = positive_importance;
+    LOG_INFO("proxy2: " + proxy2->to_string());
 
     client_bus->issue_bus_command(proxy1);
     unsigned int count = 0;
@@ -182,29 +184,22 @@ TEST(PatternMatchingQuery, queries) {
                 "NODE", "Symbol", "\"chimp\""
     };
     int q6_expected_count = 4;
-    // clang-format on
 
     // Regular queries
-    check_query(
-        q1, q1_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(
-        q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(
-        q3, q3_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(
-        q4, q4_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(
-        q5, q5_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
-    check_query(
-        q6, q6_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false);
+    check_query(q1, q1_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(q3, q3_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(q4, q4_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(q5, q5_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
+    check_query(q6, q6_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false);
 
     // Importance filtering
-    check_query(
-        q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", true, false, false, false);
+    check_query(q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", true, false, false, false);
     check_query(q1, 3, client_bus, "PatternMatchingQuery.queries", false, false, true, false);
 
     // Remote exception
     check_query({"BLAH"}, 0, client_bus, "PatternMatchingQuery.queries", false, false, false, true);
 
     Utils::sleep(2000);
+    // clang-format on
 }

--- a/src/tests/cpp/properties_test.cc
+++ b/src/tests/cpp/properties_test.cc
@@ -11,7 +11,7 @@ using namespace commons;
 TEST(PropertiesTest, InsertAndGetString) {
     Properties map;
     map["foo"] = string("bar");
-    const string* value = map.get<string>("foo");
+    const string* value = map.get_ptr<string>("foo");
     ASSERT_NE(value, nullptr);
     EXPECT_EQ(*value, "bar");
 }
@@ -19,7 +19,7 @@ TEST(PropertiesTest, InsertAndGetString) {
 TEST(PropertiesTest, InsertAndGetLong) {
     Properties map;
     map["num"] = 42L;
-    const long* value = map.get<long>("num");
+    const long* value = map.get_ptr<long>("num");
     ASSERT_NE(value, nullptr);
     EXPECT_EQ(*value, 42L);
 }
@@ -27,7 +27,7 @@ TEST(PropertiesTest, InsertAndGetLong) {
 TEST(PropertiesTest, InsertAndGetDouble) {
     Properties map;
     map["pi"] = 3.14;
-    const double* value = map.get<double>("pi");
+    const double* value = map.get_ptr<double>("pi");
     ASSERT_NE(value, nullptr);
     EXPECT_DOUBLE_EQ(*value, 3.14);
 }
@@ -35,7 +35,7 @@ TEST(PropertiesTest, InsertAndGetDouble) {
 TEST(PropertiesTest, InsertAndGetBool) {
     Properties map;
     map["flag"] = true;
-    const bool* value = map.get<bool>("flag");
+    const bool* value = map.get_ptr<bool>("flag");
     ASSERT_NE(value, nullptr);
     EXPECT_TRUE(*value);
 }
@@ -43,13 +43,13 @@ TEST(PropertiesTest, InsertAndGetBool) {
 TEST(PropertiesTest, GetWrongTypeReturnsNullptr) {
     Properties map;
     map["foo"] = string("bar");
-    const long* value = map.get<long>("foo");
+    const long* value = map.get_ptr<long>("foo");
     EXPECT_EQ(value, nullptr);
 }
 
 TEST(PropertiesTest, GetNonexistentKeyReturnsNullptr) {
     Properties map;
-    const string* value = map.get<string>("missing");
+    const string* value = map.get_ptr<string>("missing");
     EXPECT_EQ(value, nullptr);
 }
 
@@ -57,9 +57,45 @@ TEST(PropertiesTest, ToStringRepresentation) {
     Properties map;
     map["foo"] = string("bar");
     map["num"] = 42L;
+    map["uint"] = 1;
     map["pi"] = 3.14;
     map["flag"] = false;
     string str = map.to_string();
     // Order is guaranteed: flag, foo, num, pi
-    EXPECT_EQ(str, "{flag: false, foo: 'bar', num: 42, pi: 3.140000}");
+    EXPECT_EQ(str, "{flag: false, foo: 'bar', num: 42, pi: 3.140000, uint: 1}");
+}
+
+TEST(PropertiesTest, Tokenization) {
+    Properties map;
+    map["foo"] = string("bar");
+    map["num"] = 42L;
+    map["uint"] = 1;
+    map["pi"] = 3.14;
+    map["flag"] = false;
+    vector<string> v = map.tokenize();
+    // Order is guaranteed: flag, foo, num, pi
+    EXPECT_EQ(v.size(), 12);
+    unsigned int cursor = 0;
+    EXPECT_EQ(v[cursor++], "flag");
+    EXPECT_EQ(v[cursor++], "bool");
+    EXPECT_EQ(v[cursor++], "false");
+    EXPECT_EQ(v[cursor++], "foo");
+    EXPECT_EQ(v[cursor++], "string");
+    EXPECT_EQ(v[cursor++], "bar");
+    EXPECT_EQ(v[cursor++], "num");
+    EXPECT_EQ(v[cursor++], "long");
+    EXPECT_EQ(v[cursor++], "42");
+    EXPECT_EQ(v[cursor++], "pi");
+    EXPECT_EQ(v[cursor++], "double");
+    EXPECT_EQ(v[cursor++], "3.140000");
+    EXPECT_EQ(v[cursor++], "uint");
+    EXPECT_EQ(v[cursor++], "unsigned_int");
+    EXPECT_EQ(v[cursor++], "1");
+    Properties map2;
+    map2.untokenize(v);
+    EXPECT_EQ(map2.get<string>("foo"), string("bar"));
+    EXPECT_EQ(map2.get<long>("num"), 42L);
+    EXPECT_EQ(map2.get<double>("pi"), 3.14);
+    EXPECT_EQ(map2.get<bool>("flag"), false);
+    EXPECT_EQ(map2.get<unsigned int>("uint"), 1);
 }

--- a/src/tests/cpp/properties_test.cc
+++ b/src/tests/cpp/properties_test.cc
@@ -57,24 +57,31 @@ TEST(PropertiesTest, ToStringRepresentation) {
     Properties map;
     map["foo"] = string("bar");
     map["num"] = 42L;
-    map["uint"] = 1;
+    map["uint"] = (unsigned int) 1;
     map["pi"] = 3.14;
     map["flag"] = false;
     string str = map.to_string();
-    // Order is guaranteed: flag, foo, num, pi
+    // Order is guaranteed: flag, foo, num, pi, uint
     EXPECT_EQ(str, "{flag: false, foo: 'bar', num: 42, pi: 3.140000, uint: 1}");
 }
 
 TEST(PropertiesTest, Tokenization) {
-    Properties map;
-    map["foo"] = string("bar");
-    map["num"] = 42L;
-    map["uint"] = 1;
-    map["pi"] = 3.14;
-    map["flag"] = false;
-    vector<string> v = map.tokenize();
-    // Order is guaranteed: flag, foo, num, pi
-    EXPECT_EQ(v.size(), 12);
+    Properties map1;
+    map1["foo"] = string("bar");
+    map1["num"] = 42L;
+    map1["uint"] = (unsigned int) 1;
+    map1["pi"] = 3.14;
+    map1["flag"] = false;
+    vector<string> v = map1.tokenize();
+
+    EXPECT_EQ(map1.get<string>("foo"), string("bar"));
+    EXPECT_EQ(map1.get<long>("num"), 42L);
+    EXPECT_EQ(map1.get<unsigned int>("uint"), (unsigned int) 1);
+    EXPECT_EQ(map1.get<double>("pi"), 3.14);
+    EXPECT_EQ(map1.get<bool>("flag"), false);
+
+    // Order is guaranteed: flag, foo, num, pi, uint
+    EXPECT_EQ(v.size(), 15);
     unsigned int cursor = 0;
     EXPECT_EQ(v[cursor++], "flag");
     EXPECT_EQ(v[cursor++], "bool");
@@ -91,11 +98,13 @@ TEST(PropertiesTest, Tokenization) {
     EXPECT_EQ(v[cursor++], "uint");
     EXPECT_EQ(v[cursor++], "unsigned_int");
     EXPECT_EQ(v[cursor++], "1");
+
     Properties map2;
     map2.untokenize(v);
+
     EXPECT_EQ(map2.get<string>("foo"), string("bar"));
     EXPECT_EQ(map2.get<long>("num"), 42L);
     EXPECT_EQ(map2.get<double>("pi"), 3.14);
     EXPECT_EQ(map2.get<bool>("flag"), false);
-    EXPECT_EQ(map2.get<unsigned int>("uint"), 1);
+    EXPECT_EQ(map2.get<unsigned int>("uint"), (unsigned int) 1);
 }

--- a/src/tests/cpp/query_evolution_test.cc
+++ b/src/tests/cpp/query_evolution_test.cc
@@ -62,5 +62,5 @@ TEST(QueryEvolution, protected_methods) {
 
     auto proxy = make_shared<QueryEvolutionProxy>(query, "unit_test", "query_evolution_test");
     vector<std::pair<shared_ptr<QueryAnswer>, float>> population;
-    // processor->sample_population(proxy, population);
+    //processor->sample_population(proxy, population);
 }

--- a/src/tests/cpp/query_evolution_test.cc
+++ b/src/tests/cpp/query_evolution_test.cc
@@ -62,5 +62,5 @@ TEST(QueryEvolution, protected_methods) {
 
     auto proxy = make_shared<QueryEvolutionProxy>(query, "unit_test", "query_evolution_test");
     vector<std::pair<shared_ptr<QueryAnswer>, float>> population;
-    //processor->sample_population(proxy, population);
+    // processor->sample_population(proxy, population);
 }

--- a/src/tests/cpp/service_bus_test.cc
+++ b/src/tests/cpp/service_bus_test.cc
@@ -17,7 +17,7 @@ class TestProxy : public BusCommandProxy {
         this->remote_args = args;
         return true;
     }
-    void pack_custom_args() {}
+    void pack_command_line_args() {}
 };
 
 class TestProcessor : public BusCommandProcessor {


### PR DESCRIPTION
Add a couple of features to the Properties class itself:

* Support to unsigned int
* Added get<type>() to return the actual value and renamed the previous get<type>() to get_ptr<type>()
* Added tokenize/untokenize methods