### PR TITLE
Use AtomDB::add_node(Node) and add_link(Link)

### DIFF
--- a/src/atom_space/AtomSpace.cc
+++ b/src/atom_space/AtomSpace.cc
@@ -130,14 +130,11 @@ void AtomSpace::commit_changes(Scope scope) {
     auto commit_changes_visit_lambda = [](HandleTrie::TrieNode* trie_node, void* user_data) -> bool {
         auto db = static_cast<AtomDB*>(user_data);
         if (const auto node = dynamic_cast<const Node*>(trie_node->value)) {
-            db->add_node(node->type.c_str(), node->name.c_str(), node->custom_attributes);
+            db->add_node(node);
         } else if (const auto link = dynamic_cast<const Link*>(trie_node->value)) {
             unique_ptr<char*[], TargetHandlesDeleter> targets_handles(
                 Link::targets_to_handles(link->targets), TargetHandlesDeleter(link->targets.size()));
-            db->add_link(link->type.c_str(),
-                         targets_handles.get(),
-                         link->targets.size(),
-                         link->custom_attributes);
+            db->add_link(link);
         } else {
             Utils::error("Unsupported Atom type for commit: " + trie_node->to_string());
             return true;  // Unsupported type, cannot commit

--- a/src/atom_space/AtomSpaceTypes.h
+++ b/src/atom_space/AtomSpaceTypes.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
-#include "AtomDBAPITypes.h"
 #include "HandleTrie.h"
 #include "Properties.h"
 #include "expression_hasher.h"
@@ -14,7 +14,6 @@
 
 using namespace std;
 using namespace commons;
-using namespace atomdb::atomdb_api_types;
 
 namespace atomspace {
 

--- a/src/atom_space/BUILD
+++ b/src/atom_space/BUILD
@@ -26,7 +26,6 @@ cc_library(
     hdrs = ["AtomSpaceTypes.h"],
     includes = ["."],
     deps = [
-        "//atomdb:atomdb_api_types",
         "//commons:handle_trie",
         "//hasher:hasher_lib",
     ],

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -22,11 +22,8 @@ class AtomDB {
     virtual shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle) = 0;
     virtual bool link_exists(const char* link_handle) = 0;
     virtual std::vector<std::string> links_exist(const std::vector<std::string>& link_handles) = 0;
-    virtual char* add_node(const char* type, const char* name, const Properties& custom_attributes) = 0;
-    virtual char* add_link(const char* type,
-                           char** targets,
-                           size_t targets_size,
-                           const Properties& custom_attributes) = 0;
+    virtual char* add_node(const atomspace::Node* node) = 0;
+    virtual char* add_link(const atomspace::Link* link) = 0;
     virtual vector<shared_ptr<atomdb_api_types::AtomDocument>> get_atom_documents(
         const vector<string>& handles, const vector<string>& fields) = 0;
 

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <optional>
 
+#include "AtomSpaceTypes.h"
 #include "LinkTemplateInterface.h"
 #include "Utils.h"
 

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -273,15 +273,12 @@ vector<string> RedisMongoDB::links_exist(const vector<string>& link_handles) {
     return existing_links;
 }
 
-char* RedisMongoDB::add_node(const char* type, const char* name, const Properties& custom_attributes) {
+char* RedisMongoDB::add_node(const atomspace::Node* node) {
     // TODO: Implement add_node logic
     return NULL;
 }
 
-char* RedisMongoDB::add_link(const char* type,
-                             char** targets,
-                             size_t targets_size,
-                             const Properties& custom_attributes) {
+char* RedisMongoDB::add_link(const atomspace::Link* link) {
     // TODO: Implement add_link logic
     return NULL;
 }

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -55,11 +55,8 @@ class RedisMongoDB : public AtomDB {
     shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle);
     bool link_exists(const char* link_handle);
     std::vector<std::string> links_exist(const std::vector<std::string>& link_handles);
-    char* add_node(const char* type, const char* name, const Properties& custom_attributes = {});
-    char* add_link(const char* type,
-                   char** targets,
-                   size_t targets_size,
-                   const Properties& custom_attributes = {});
+    char* add_node(const atomspace::Node* node);
+    char* add_link(const atomspace::Link* link);
     vector<shared_ptr<atomdb_api_types::AtomDocument>> get_atom_documents(const vector<string>& handles,
                                                                           const vector<string>& fields);
 

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -537,7 +537,6 @@ cc_test(
         "//agents/query_engine:query_engine_lib",
         "//atom_space:atom_space_lib",
         "//atom_space:atom_space_types",
-        "//atomdb:atomdb_api_types",
         "//commons:commons_lib",
         "//service_bus:service_bus_lib",
         "@com_github_google_googletest//:gtest_main",
@@ -546,7 +545,7 @@ cc_test(
 
 cc_test(
     name = "redis_mongodb_test",
-    size = "medium",
+    size = "small",
     srcs = [
         "redis_mongodb_test.cc",
         "test_utils.cc",


### PR DESCRIPTION
This PR modifies the parameters of `AtomDB::add_node()` and `AtomDB::add_link()` to facilitate their implementation.
A second PR will implement those methods.