### PR TITLE
Implement add and delete logic.

### DIFF
--- a/src/MODULE.bazel.lock
+++ b/src/MODULE.bazel.lock
@@ -42,8 +42,9 @@
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.2.0/MODULE.bazel": "122b2b606622afbaa498913d54f52d9bcd2d19a5edd1bd6d6c5aa17441c4d5f9",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
-    "https://bcr.bazel.build/modules/bazel_features/1.21.0/source.json": "3e8379efaaef53ce35b7b8ba419df829315a880cb0a030e5bb45c96d6d5ecb5f",
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
@@ -145,7 +146,8 @@
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/MODULE.bazel": "b3925269f63561b8b880ae7cf62ccf81f6ece55b62cd791eda9925147ae116ec",
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/source.json": "da1cb1add160f5e5074b7272e9db6fd8f1b3336c15032cd0a653af9d2f484aed",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
-    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
@@ -200,12 +202,13 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.5/MODULE.bazel": "be41f87587998fe8890cd82ea4e848ed8eb799e053c224f78f3ff7fe1a1d9b74",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/MODULE.bazel": "b9527010e5fef060af92b6724edb3691970a5b1f76f74b21d39f7d433641be60",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/source.json": "9300e71df0cdde0952f10afff1401fa664e9fc5d9ae6204660ba1b158d90d6a6",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
@@ -237,8 +240,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.4.0/MODULE.bazel": "a592852f8a3dd539e82ee6542013bf2cadfc4c6946be8941e189d224500a8934",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
+    "https://bcr.bazel.build/modules/rules_java/8.12.0/MODULE.bazel": "8e6590b961f2defdfc2811c089c75716cb2f06c8a4edeb9a8d85eaa64ee2a761",
+    "https://bcr.bazel.build/modules/rules_java/8.12.0/source.json": "cbd5d55d9d38d4008a7d00bee5b5a5a4b6031fcd4a56515c9accbcd42c7be2ba",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
@@ -325,7 +328,8 @@
     "https://bcr.bazel.build/modules/zlib/1.2.13/MODULE.bazel": "aa6deb1b83c18ffecd940c4119aff9567cd0a671d7bba756741cb2ef043a29d5",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.1/MODULE.bazel": "6a9fe6e3fc865715a7be9823ce694ceb01e364c35f7a846bf0d2b34762bc066b",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198",
     "https://bcr.bazel.build/modules/zlib/1.3/MODULE.bazel": "6a9c02f19a24dcedb05572b2381446e27c272cd383aed11d41d99da9e3167a72"
   },
@@ -333,7 +337,7 @@
   "moduleExtensions": {
     "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "Ync9nL0AbHC6ondeEY7fBjBjLxojTsiXcJh65ZDTRlA=",
+        "bzlTransitiveDigest": "xcBTf2+GaloFpg7YEh/Bv+1yAczRkiCt3DGws4K7kSk=",
         "usagesDigest": "cSIhmW7KxthN0OEsinvaLtzw/1vt+FYxH2KEzLdjRHo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -364,7 +368,7 @@
     },
     "@@buildifier_prebuilt+//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "YG9b6AzHuIdOM5begt59eoHL6Xy3A/8U8VYJqdUJVEo=",
+        "bzlTransitiveDigest": "X67aPQER7Ge9vxgB16pXU8HvbgAOOUzmz+S0EgyRtNc=",
         "usagesDigest": "E92htUw9elHOT0ZHIEdwgPVnslFqL2iu3pcplYXXAxk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -735,25 +739,9 @@
         ]
       }
     },
-    "@@platforms//host:extension.bzl%host_platform": {
-      "general": {
-        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "6v1pzl9bOYnK0LhTceVpV/w3o/NwbbHwuORIyhzuWdk=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "host_platform": {
-            "repoRuleId": "@@platforms//host:extension.bzl%host_platform_repo",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
     "@@rules_buf+//buf:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "3jGepUu1j86kWsTP3Fgogw/XfktHd4UIQt8zj494n/Y=",
+        "bzlTransitiveDigest": "Fk4QK5kj/HKxKVGAfyZEJNUAOC+Ic+kKMcXb20jecDE=",
         "usagesDigest": "RTc2BMQ2b0wGU8CRvN3EoPz34m3LMe+K/oSkFkN83+M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -777,7 +765,7 @@
     },
     "@@rules_foreign_cc+//foreign_cc:extensions.bzl%tools": {
       "general": {
-        "bzlTransitiveDigest": "FApcIcVN43WOEs7g8eg7Cy1hrfRbVNEoUu8IiF+8WOc=",
+        "bzlTransitiveDigest": "ginC3lIGOKKivBi0nyv2igKvSiz42Thm8yaX2RwVaHg=",
         "usagesDigest": "9LXdVp01HkdYQT8gYPjYLO6VLVJHo9uFfxWaU1ymiRE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1091,7 +1079,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
+        "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1155,7 +1143,7 @@
     },
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
-        "bzlTransitiveDigest": "btnelILPo3ngQN9vWtsQMclvJZPf3X2vcGTjmW7Owy8=",
+        "bzlTransitiveDigest": "hb4P9W+UouOR3GTf2pDXbhhQFSTElj+EgJVbrB5U+cQ=",
         "usagesDigest": "8OoyQ05AfTDe1T/jKkylUFidWxQge7e3HN2eOIIA6xM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -6494,7 +6482,7 @@
     },
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
-        "bzlTransitiveDigest": "2eLMaPh4QKrn3wPljYBu5jSkkp9DfCf4yGKTR9lBN3c=",
+        "bzlTransitiveDigest": "c7CepP0Yj264OYMqO5rjhtkrLqAnrHo+oagUNiAYKVw=",
         "usagesDigest": "IzLZJo6jscH0wDdOUqR2z5ZKOHfkhS4PKLUmCbhjU2I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <set>
+#include <vector>
+
 #include "AtomDBAPITypes.h"
 #include "Properties.h"
 
@@ -21,7 +24,7 @@ class AtomDB {
     virtual shared_ptr<atomdb_api_types::HandleList> query_for_targets(char* link_handle_ptr) = 0;
     virtual shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle) = 0;
     virtual bool link_exists(const char* link_handle) = 0;
-    virtual std::vector<std::string> links_exist(const std::vector<std::string>& link_handles) = 0;
+    virtual set<string> links_exist(const vector<string>& link_handles) = 0;
     virtual char* add_node(const atomspace::Node* node) = 0;
     virtual char* add_link(const atomspace::Link* link) = 0;
     virtual vector<shared_ptr<atomdb_api_types::AtomDocument>> get_atom_documents(

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -233,56 +233,6 @@ shared_ptr<atomdb_api_types::AtomDocument> RedisMongoDB::get_atom_document(const
     return atom_document;
 }
 
-bool RedisMongoDB::link_exists(const char* link_handle) {
-    auto conn = this->mongodb_pool->acquire();
-    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
-    auto reply = mongodb_collection.find_one(bsoncxx::v_noabi::builder::basic::make_document(
-        bsoncxx::v_noabi::builder::basic::kvp(MONGODB_FIELD_NAME[MONGODB_FIELD::ID], link_handle)));
-    return (reply != bsoncxx::v_noabi::stdx::nullopt &&
-            reply->view().find(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS]) != reply->view().end());
-}
-
-vector<string> RedisMongoDB::links_exist(const vector<string>& link_handles) {
-    if (link_handles.empty()) return {};
-
-    auto conn = this->mongodb_pool->acquire();
-    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
-
-    bsoncxx::builder::basic::array handle_ids;
-    for (const auto& handle : link_handles) {
-        handle_ids.append(handle);
-    }
-
-    bsoncxx::builder::basic::document filter_builder;
-    filter_builder.append(bsoncxx::builder::basic::kvp(
-        MONGODB_FIELD_NAME[MONGODB_FIELD::ID],
-        bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("$in", handle_ids))));
-
-    auto filter = filter_builder.extract();
-
-    auto cursor = mongodb_collection.distinct(MONGODB_FIELD_NAME[MONGODB_FIELD::ID], filter.view());
-
-    vector<string> existing_links;
-    for (const auto& doc : cursor) {
-        auto values = doc["values"].get_array().value;
-        for (auto&& val : values) {
-            existing_links.push_back(val.get_string().value.data());
-        }
-    }
-
-    return existing_links;
-}
-
-char* RedisMongoDB::add_node(const atomspace::Node* node) {
-    // TODO: Implement add_node logic
-    return NULL;
-}
-
-char* RedisMongoDB::add_link(const atomspace::Link* link) {
-    // TODO: Implement add_link logic
-    return NULL;
-}
-
 vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_atom_documents(
     const vector<string>& handles, const vector<string>& fields) {
     // TODO Add cache support for this method
@@ -331,4 +281,143 @@ vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_atom_docume
     }
 
     return atom_documents;
+}
+
+bool RedisMongoDB::link_exists(const char* link_handle) {
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
+    auto reply = mongodb_collection.find_one(bsoncxx::v_noabi::builder::basic::make_document(
+        bsoncxx::v_noabi::builder::basic::kvp(MONGODB_FIELD_NAME[MONGODB_FIELD::ID], link_handle)));
+    return (reply != bsoncxx::v_noabi::stdx::nullopt &&
+            reply->view().find(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS]) != reply->view().end());
+}
+
+vector<string> RedisMongoDB::links_exist(const vector<string>& link_handles) {
+    if (link_handles.empty()) return {};
+
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
+
+    bsoncxx::builder::basic::array handle_ids;
+    for (const auto& handle : link_handles) {
+        handle_ids.append(handle);
+    }
+
+    bsoncxx::builder::basic::document filter_builder;
+    filter_builder.append(bsoncxx::builder::basic::kvp(
+        MONGODB_FIELD_NAME[MONGODB_FIELD::ID],
+        bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("$in", handle_ids))));
+
+    auto filter = filter_builder.extract();
+
+    auto cursor = mongodb_collection.distinct(MONGODB_FIELD_NAME[MONGODB_FIELD::ID], filter.view());
+
+    vector<string> existing_links;
+    for (const auto& doc : cursor) {
+        auto values = doc["values"].get_array().value;
+        for (auto&& val : values) {
+            existing_links.push_back(val.get_string().value.data());
+        }
+    }
+
+    return existing_links;
+}
+
+char* RedisMongoDB::add_node(const atomspace::Node* node) {
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
+
+    auto mongodb_doc = atomdb_api_types::MongodbDocument(node);
+    auto reply = mongodb_collection.insert_one(mongodb_doc.value());
+
+    if (!reply) {
+        Utils::error("Failed to insert node into MongoDB");
+    }
+
+    auto handle = atomspace::Node::compute_handle(node->type, node->name);
+    return handle;
+}
+
+vector<string> RedisMongoDB::add_nodes(const vector<atomspace::Node*>& nodes) {
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
+
+    vector<bsoncxx::v_noabi::document::value> docs;
+    vector<string> handles;
+    for (const auto& node : nodes) {
+        auto mongodb_doc = atomdb_api_types::MongodbDocument(node);
+        handles.push_back(atomspace::Node::compute_handle(node->type, node->name));
+        docs.push_back(mongodb_doc.value());
+    }
+
+    auto reply = mongodb_collection.insert_many(docs);
+
+    if (!reply) {
+        Utils::error("Failed to insert nodes into MongoDB");
+    }
+
+    return handles;
+}
+
+char* RedisMongoDB::add_link(const atomspace::Link* link) {
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
+
+    auto mongodb_doc = atomdb_api_types::MongodbDocument(link);
+    auto reply = mongodb_collection.insert_one(mongodb_doc.value());
+
+    if (!reply) {
+        Utils::error("Failed to insert link into MongoDB");
+    }
+
+    auto handle = atomspace::Link::compute_handle(link->type, link->targets);
+    return handle;
+}
+
+vector<string> RedisMongoDB::add_links(const vector<atomspace::Link*>& links) {
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
+
+    vector<bsoncxx::v_noabi::document::value> docs;
+    vector<string> handles;
+    for (const auto& link : links) {
+        auto mongodb_doc = atomdb_api_types::MongodbDocument(link);
+        handles.push_back(atomspace::Link::compute_handle(link->type, link->targets));
+        docs.push_back(mongodb_doc.value());
+    }
+
+    auto reply = mongodb_collection.insert_many(docs);
+
+    if (!reply) {
+        Utils::error("Failed to insert links into MongoDB");
+    }
+
+    return handles;
+}
+
+bool RedisMongoDB::delete_atom(const char* handle) {
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
+    auto reply = mongodb_collection.delete_one(bsoncxx::v_noabi::builder::basic::make_document(
+        bsoncxx::v_noabi::builder::basic::kvp(MONGODB_FIELD_NAME[MONGODB_FIELD::ID], handle)));
+    return reply->deleted_count() > 0;
+}
+
+uint RedisMongoDB::delete_atoms(const vector<string>& handles) {
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
+
+    bsoncxx::builder::basic::array handle_ids;
+    for (const auto& handle : handles) {
+        handle_ids.append(handle);
+    }
+
+    bsoncxx::builder::basic::document filter_builder;
+    filter_builder.append(bsoncxx::builder::basic::kvp(
+        MONGODB_FIELD_NAME[MONGODB_FIELD::ID],
+        bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("$in", handle_ids))));
+
+    auto filter = filter_builder.extract();
+    auto reply = mongodb_collection.delete_many(filter.view());
+    return reply->deleted_count();
 }

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -50,15 +50,25 @@ class RedisMongoDB : public AtomDB {
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(
         const LinkTemplateInterface& link_template);
+
     shared_ptr<atomdb_api_types::HandleList> query_for_targets(shared_ptr<char> link_handle);
     shared_ptr<atomdb_api_types::HandleList> query_for_targets(char* link_handle_ptr);
+
     shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle);
-    bool link_exists(const char* link_handle);
-    std::vector<std::string> links_exist(const std::vector<std::string>& link_handles);
-    char* add_node(const atomspace::Node* node);
-    char* add_link(const atomspace::Link* link);
     vector<shared_ptr<atomdb_api_types::AtomDocument>> get_atom_documents(const vector<string>& handles,
                                                                           const vector<string>& fields);
+
+    bool link_exists(const char* link_handle);
+    vector<string> links_exist(const vector<string>& link_handles);
+
+    char* add_node(const atomspace::Node* node);
+    vector<string> add_nodes(const vector<atomspace::Node*>& nodes);
+
+    char* add_link(const atomspace::Link* link);
+    vector<string> add_links(const vector<atomspace::Link*>& links);
+
+    bool delete_atom(const char* handle);
+    uint delete_atoms(const vector<string>& handles);
 
    private:
     bool cluster_flag;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -11,6 +11,7 @@
 #include <mongocxx/options/find.hpp>
 #include <mongocxx/pool.hpp>
 #include <mutex>
+#include <set>
 #include <vector>
 
 #include "AtomDB.h"
@@ -59,7 +60,7 @@ class RedisMongoDB : public AtomDB {
                                                                           const vector<string>& fields);
 
     bool link_exists(const char* link_handle);
-    vector<string> links_exist(const vector<string>& link_handles);
+    set<string> links_exist(const vector<string>& link_handles);
 
     char* add_node(const atomspace::Node* node);
     vector<string> add_nodes(const vector<atomspace::Node*>& nodes);

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
@@ -67,12 +67,15 @@ class RedisStringBundle : public HandleList {
 class MongodbDocument : public AtomDocument {
    public:
     MongodbDocument(bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value>& document);
+    MongodbDocument(const atomspace::Node* node);
+    MongodbDocument(const atomspace::Link* link);
     ~MongodbDocument();
 
     const char* get(const string& key);
     virtual const char* get(const string& array_key, unsigned int index);
     virtual unsigned int get_size(const string& array_key);
     virtual bool contains(const string& key);
+    bsoncxx::v_noabi::document::value value();
 
    private:
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> document;

--- a/src/tests/cpp/atom_space_test.cc
+++ b/src/tests/cpp/atom_space_test.cc
@@ -84,7 +84,7 @@ class MockAtomDB : public AtomDB {
     }
 
     bool link_exists(const char*) override { return false; }
-    vector<string> links_exist(const vector<string>&) override { return {}; }
+    set<string> links_exist(const vector<string>&) override { return {}; }
 
     char* add_node(const atomspace::Node* node) override {
         add_node_calls.push_back({node->type, node->name, node->custom_attributes});

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -292,8 +292,8 @@ TEST_F(RedisMongoDBTest, AddAndDeleteNode) {
     auto node_handle = Node::compute_handle(node->type, node->name);
 
     // Check if node exists, if so, delete it
-    auto node_exists = db->link_exists(node_handle);
-    if (node_exists) {
+    auto node_document = db->get_atom_document(node_handle);
+    if (node_document != nullptr) {
         auto deleted = db->delete_atom(node_handle);
         EXPECT_TRUE(deleted);
     }
@@ -314,14 +314,14 @@ TEST_F(RedisMongoDBTest, AddAndDeleteNodes) {
     auto handles = db->add_nodes(nodes);
     EXPECT_EQ(handles.size(), 10);
 
-    auto links_exist = db->links_exist(handles);
-    EXPECT_EQ(links_exist.size(), 10);
+    auto nodes_documents = db->get_atom_documents(handles, {"_id"});
+    EXPECT_EQ(nodes_documents.size(), 10);
 
     auto deleted = db->delete_atoms(handles);
     EXPECT_EQ(deleted, 10);
 
-    auto links_exist_after_delete = db->links_exist(handles);
-    EXPECT_EQ(links_exist_after_delete.size(), 0);
+    auto nodes_documents_after_delete = db->get_atom_documents(handles, {"_id"});
+    EXPECT_EQ(nodes_documents_after_delete.size(), 0);
 }
 
 TEST_F(RedisMongoDBTest, AddAndDeleteLink) {

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -13,6 +13,7 @@
 #include "expression_hasher.h"
 
 using namespace atomdb;
+using namespace atomspace;
 using namespace std;
 
 class RedisMongoDBTestEnvironment : public ::testing::Environment {
@@ -255,10 +256,10 @@ TEST_F(RedisMongoDBTest, ConcurrentLinksExist) {
 
     auto worker = [&](int thread_id) {
         try {
-            auto link_exists = db->links_exist({"68ea071c32d4dbf0a7d8e8e00f2fb823",
+            auto links_exist = db->links_exist({"68ea071c32d4dbf0a7d8e8e00f2fb823",
                                                 "00000000000000000000000000000000",
                                                 "7ec8526b8c8f15a6ac55273fedbf694f"});
-            ASSERT_EQ(link_exists.size(), 2);
+            ASSERT_EQ(links_exist.size(), 2);
             success_count++;
         } catch (const exception& e) {
             cout << "Thread " << thread_id << " failed with error: " << e.what() << endl;
@@ -276,10 +277,99 @@ TEST_F(RedisMongoDBTest, ConcurrentLinksExist) {
     EXPECT_EQ(success_count, num_threads);
 
     // Test non-existing link
-    auto link_exists = db->links_exist({"00000000000000000000000000000000",
+    auto links_exist = db->links_exist({"00000000000000000000000000000000",
                                         "00000000000000000000000000000001",
                                         "00000000000000000000000000000002"});
-    EXPECT_EQ(link_exists.size(), 0);
+    EXPECT_EQ(links_exist.size(), 0);
+}
+
+TEST_F(RedisMongoDBTest, AddAndDeleteNode) {
+    Properties custom_attributes;
+    custom_attributes["is_literal"] = true;
+
+    auto node = new Node("Symbol", "\"test-1\"", custom_attributes);
+
+    auto node_handle = Node::compute_handle(node->type, node->name);
+
+    // Check if node exists, if so, delete it
+    auto node_exists = db->link_exists(node_handle);
+    if (node_exists) {
+        auto deleted = db->delete_atom(node_handle);
+        EXPECT_TRUE(deleted);
+    }
+
+    auto handle = db->add_node(node);
+    EXPECT_NE(handle, nullptr);
+
+    auto deleted = db->delete_atom(handle);
+    EXPECT_TRUE(deleted);
+}
+
+TEST_F(RedisMongoDBTest, AddAndDeleteNodes) {
+    vector<Node*> nodes;
+    for (int i = 0; i < 10; i++) {
+        nodes.push_back(new Node("Symbol", "add-nodes-" + to_string(i)));
+    }
+
+    auto handles = db->add_nodes(nodes);
+    EXPECT_EQ(handles.size(), 10);
+
+    auto links_exist = db->links_exist(handles);
+    EXPECT_EQ(links_exist.size(), 10);
+
+    auto deleted = db->delete_atoms(handles);
+    EXPECT_EQ(deleted, 10);
+
+    auto links_exist_after_delete = db->links_exist(handles);
+    EXPECT_EQ(links_exist_after_delete.size(), 0);
+}
+
+TEST_F(RedisMongoDBTest, AddAndDeleteLink) {
+    Properties custom_attributes;
+    custom_attributes["is_toplevel"] = true;
+
+    auto similarity_node = new Node("Symbol", "Similarity");
+    auto test_1_node = new Node("Symbol", "\"test-1\"");
+    auto test_2_node = new Node("Symbol", "\"test-2\"");
+
+    auto link = new Link("Expression", {similarity_node, test_1_node, test_2_node}, custom_attributes);
+
+    auto link_handle = Link::compute_handle(link->type, link->targets);
+
+    // Check if link exists, if so, delete it
+    auto node_exists = db->link_exists(link_handle);
+    if (node_exists) {
+        auto deleted = db->delete_atom(link_handle);
+        EXPECT_TRUE(deleted);
+    }
+
+    auto handle = db->add_link(link);
+    EXPECT_NE(handle, nullptr);
+
+    auto deleted = db->delete_atom(handle);
+    EXPECT_TRUE(deleted);
+}
+
+TEST_F(RedisMongoDBTest, AddAndDeleteLinks) {
+    vector<Link*> links;
+    for (int i = 0; i < 10; i++) {
+        auto similarity_node = new Node("Symbol", "Similarity");
+        auto test_1_node = new Node("Symbol", "add-links-1-" + to_string(i));
+        auto test_2_node = new Node("Symbol", "add-links-2-" + to_string(i));
+        links.push_back(new Link("Expression", {similarity_node, test_1_node, test_2_node}));
+    }
+
+    auto handles = db->add_links(links);
+    EXPECT_EQ(handles.size(), 10);
+
+    auto links_exist = db->links_exist(handles);
+    EXPECT_EQ(links_exist.size(), 10);
+
+    auto deleted = db->delete_atoms(handles);
+    EXPECT_EQ(deleted, 10);
+
+    auto links_exist_after_delete = db->links_exist(handles);
+    EXPECT_EQ(links_exist_after_delete.size(), 0);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This PR implements the following methods of `RedisMongoDB` class:
```
add_node(const atomspace::Node* node)
add_nodes(const vector<atomspace::Node*>& nodes)

add_link(const atomspace::Link* node)
add_links(const vector<atomspace::Link*>& links)

delete_atom(const char* handle)
delete_atoms(const vector<string>& handles)
```
With the `delete` methods we are now able to proper unit test all the methods by adding documents, checking if they exist and then deleting them.

It also creates two new ways to construct a `MongodbDocument` object (from a `Node` and from a `Link`):
```
MongodbDocument(const atomspace::Node* node)
MongodbDocument(const atomspace::Link* link)
```

A following PR will add the Redis logic to the `add_link()` and `add_links()`