### PR TITLE
[AtomDB] Replace char* with string

### DIFF
--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -73,7 +73,7 @@ void PatternMatchingQueryProcessor::update_attention_broker_single_answer(
         // Updates joint answer (stimulation)
         joint_answer.insert(handle);
         // Gets targets and stack them
-        auto query_result = db->query_for_targets(handle);
+        shared_ptr<atomdb_api_types::HandleList> query_result = db->query_for_targets(handle);
         if (query_result != NULL) {  // if handle is link
             unsigned int query_result_size = query_result->size();
             for (unsigned int i = 0; i < query_result_size; i++) {

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -73,8 +73,7 @@ void PatternMatchingQueryProcessor::update_attention_broker_single_answer(
         // Updates joint answer (stimulation)
         joint_answer.insert(handle);
         // Gets targets and stack them
-        shared_ptr<atomdb_api_types::HandleList> query_result =
-            db->query_for_targets((char*) handle.c_str());
+        auto query_result = db->query_for_targets(handle);
         if (query_result != NULL) {  // if handle is link
             unsigned int query_result_size = query_result->size();
             for (unsigned int i = 0; i < query_result_size; i++) {

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -24,13 +24,12 @@ class AtomDB : public HandleDecoder {
 
     virtual shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(
         const LinkTemplateInterface& link_template) = 0;
-    virtual shared_ptr<atomdb_api_types::HandleList> query_for_targets(shared_ptr<char> link_handle) = 0;
-    virtual shared_ptr<atomdb_api_types::HandleList> query_for_targets(char* link_handle_ptr) = 0;
-    virtual shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle) = 0;
-    virtual bool link_exists(const char* link_handle) = 0;
+    virtual shared_ptr<atomdb_api_types::HandleList> query_for_targets(const string& handle) = 0;
+    virtual shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const string& handle) = 0;
+    virtual bool link_exists(const string& link_handle) = 0;
     virtual set<string> links_exist(const vector<string>& link_handles) = 0;
-    virtual char* add_node(const atomspace::Node* node) = 0;
-    virtual char* add_link(const atomspace::Link* link) = 0;
+    virtual string add_node(const atomspace::Node* node) = 0;
+    virtual string add_link(const atomspace::Link* link) = 0;
     virtual vector<shared_ptr<atomdb_api_types::AtomDocument>> get_atom_documents(
         const vector<string>& handles, const vector<string>& fields) = 0;
 

--- a/src/atomdb/AtomDBCache.cc
+++ b/src/atomdb/AtomDBCache.cc
@@ -6,7 +6,7 @@
 using namespace std;
 using namespace atomdb;
 
-AtomDBCache::GetAtomDocumentResult AtomDBCache::get_atom_document(const char* handle) {
+AtomDBCache::GetAtomDocumentResult AtomDBCache::get_atom_document(const string& handle) {
     lock_guard<mutex> lock(atom_doc_cache_mutex);
     if (atom_doc_cache.find(handle) != atom_doc_cache.end()) {
         LOG_DEBUG("cache hit " << handle);
@@ -16,7 +16,7 @@ AtomDBCache::GetAtomDocumentResult AtomDBCache::get_atom_document(const char* ha
     return {false, nullptr};
 }
 
-void AtomDBCache::add_atom_document(const char* handle,
+void AtomDBCache::add_atom_document(const string& handle,
                                     shared_ptr<atomdb_api_types::AtomDocument> document) {
     lock_guard<mutex> lock(atom_doc_cache_mutex);
     atom_doc_cache[handle] = document;
@@ -34,13 +34,13 @@ AtomDBCache::QueryForPatternResult AtomDBCache::query_for_pattern(
     return {false, nullptr};
 }
 
-void AtomDBCache::add_pattern_matching(const char* pattern_handle,
+void AtomDBCache::add_pattern_matching(const string& pattern_handle,
                                        shared_ptr<atomdb_api_types::HandleSet> results) {
     lock_guard<mutex> lock(pattern_matching_cache_mutex);
     pattern_matching_cache[pattern_handle] = results;
 }
 
-AtomDBCache::QueryForTargetsResult AtomDBCache::query_for_targets(const char* link_handle) {
+AtomDBCache::QueryForTargetsResult AtomDBCache::query_for_targets(const string& link_handle) {
     lock_guard<mutex> lock(handle_list_cache_mutex);
     if (handle_list_cache.find(link_handle) != handle_list_cache.end()) {
         LOG_DEBUG("cache hit " << link_handle);
@@ -50,7 +50,7 @@ AtomDBCache::QueryForTargetsResult AtomDBCache::query_for_targets(const char* li
     return {false, nullptr};
 }
 
-void AtomDBCache::add_handle_list(const char* link_handle,
+void AtomDBCache::add_handle_list(const string& link_handle,
                                   shared_ptr<atomdb_api_types::HandleList> results) {
     lock_guard<mutex> lock(handle_list_cache_mutex);
     handle_list_cache[link_handle] = results;

--- a/src/atomdb/AtomDBCache.h
+++ b/src/atomdb/AtomDBCache.h
@@ -64,7 +64,7 @@ class AtomDBCache {
      * @param handle The handle of the atom document.
      * @return The atom document if it is cached, nullptr otherwise.
      */
-    GetAtomDocumentResult get_atom_document(const char* handle);
+    GetAtomDocumentResult get_atom_document(const string& handle);
 
     /**
      * @brief Add an atom document to the cache.
@@ -72,7 +72,7 @@ class AtomDBCache {
      * @param handle The handle of the atom document.
      * @param document The atom document to be cached.
      */
-    void add_atom_document(const char* handle, shared_ptr<atomdb_api_types::AtomDocument> document);
+    void add_atom_document(const string& handle, shared_ptr<atomdb_api_types::AtomDocument> document);
 
     /**
      * @brief Query for a pattern matching.
@@ -88,7 +88,7 @@ class AtomDBCache {
      * @param pattern_handle The handle of the pattern.
      * @param results The result of the query to be cached.
      */
-    void add_pattern_matching(const char* pattern_handle,
+    void add_pattern_matching(const string& pattern_handle,
                               shared_ptr<atomdb_api_types::HandleSet> results);
 
     /**
@@ -97,7 +97,7 @@ class AtomDBCache {
      * @param link_handle The handle of the link.
      * @return The list of targets if it is cached, nullptr otherwise.
      */
-    QueryForTargetsResult query_for_targets(const char* link_handle);
+    QueryForTargetsResult query_for_targets(const string& link_handle);
 
     /**
      * @brief Add a handle list to the cache.
@@ -105,7 +105,7 @@ class AtomDBCache {
      * @param link_handle The handle of the link.
      * @param results The result of the query to be cached.
      */
-    void add_handle_list(const char* link_handle, shared_ptr<atomdb_api_types::HandleList> results);
+    void add_handle_list(const string& link_handle, shared_ptr<atomdb_api_types::HandleList> results);
 
    private:
     /**

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -127,7 +127,7 @@ void RedisMongoDB::mongodb_setup() {
 }
 
 shared_ptr<Atom> RedisMongoDB::get_atom(const string& handle) {
-    shared_ptr<atomdb_api_types::AtomDocument> atom_document = get_atom_document(handle.c_str());
+    shared_ptr<atomdb_api_types::AtomDocument> atom_document = get_atom_document(handle);
     if (atom_document != NULL) {
         if (atom_document->contains(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS])) {
             unsigned int arity = atom_document->get_size(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS]);
@@ -200,20 +200,16 @@ shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(
     return handle_set;
 }
 
-shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(shared_ptr<char> link_handle) {
-    return query_for_targets(link_handle.get());
-}
-
-shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(char* link_handle_ptr) {
+shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(const string& handle) {
     if (this->atomdb_cache != nullptr) {
-        auto cache_result = this->atomdb_cache->query_for_targets(link_handle_ptr);
+        auto cache_result = this->atomdb_cache->query_for_targets(handle);
         if (cache_result.is_cache_hit) return cache_result.result;
     }
 
     redisReply* reply;
     try {
         auto ctx = this->redis_pool->acquire();
-        auto command = "GET " + REDIS_TARGETS_PREFIX + ":" + link_handle_ptr;
+        auto command = "GET " + REDIS_TARGETS_PREFIX + ":" + handle;
         reply = ctx->execute(command.c_str());
 
         if (reply == NULL) {
@@ -221,8 +217,7 @@ shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(char* l
         }
 
         if ((reply == NULL) || (reply->type == REDIS_REPLY_NIL)) {
-            if (this->atomdb_cache != nullptr)
-                this->atomdb_cache->add_handle_list(link_handle_ptr, nullptr);
+            if (this->atomdb_cache != nullptr) this->atomdb_cache->add_handle_list(handle, nullptr);
             return nullptr;
         }
 
@@ -239,11 +234,11 @@ shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(char* l
     // ~RedisSet().
     auto handle_list = make_shared<atomdb_api_types::RedisStringBundle>(reply);
 
-    if (this->atomdb_cache != nullptr) this->atomdb_cache->add_handle_list(link_handle_ptr, handle_list);
+    if (this->atomdb_cache != nullptr) this->atomdb_cache->add_handle_list(handle, handle_list);
     return handle_list;
 }
 
-shared_ptr<atomdb_api_types::AtomDocument> RedisMongoDB::get_atom_document(const char* handle) {
+shared_ptr<atomdb_api_types::AtomDocument> RedisMongoDB::get_atom_document(const string& handle) {
     if (this->atomdb_cache != nullptr) {
         auto cache_result = this->atomdb_cache->get_atom_document(handle);
         if (cache_result.is_cache_hit) return cache_result.result;
@@ -311,7 +306,7 @@ vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_atom_docume
     return atom_documents;
 }
 
-bool RedisMongoDB::link_exists(const char* link_handle) {
+bool RedisMongoDB::link_exists(const string& link_handle) {
     auto conn = this->mongodb_pool->acquire();
     auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
     auto reply = mongodb_collection.find_one(bsoncxx::v_noabi::builder::basic::make_document(
@@ -357,7 +352,7 @@ set<string> RedisMongoDB::links_exist(const vector<string>& link_handles) {
     return existing_links;
 }
 
-char* RedisMongoDB::add_node(const atomspace::Node* node) {
+string RedisMongoDB::add_node(const atomspace::Node* node) {
     auto conn = this->mongodb_pool->acquire();
     auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
 
@@ -393,7 +388,7 @@ vector<string> RedisMongoDB::add_nodes(const vector<atomspace::Node*>& nodes) {
     return handles;
 }
 
-char* RedisMongoDB::add_link(const atomspace::Link* link) {
+string RedisMongoDB::add_link(const atomspace::Link* link) {
     auto conn = this->mongodb_pool->acquire();
     auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
 
@@ -429,7 +424,7 @@ vector<string> RedisMongoDB::add_links(const vector<atomspace::Link*>& links) {
     return handles;
 }
 
-bool RedisMongoDB::delete_atom(const char* handle) {
+bool RedisMongoDB::delete_atom(const string& handle) {
     auto conn = this->mongodb_pool->acquire();
     auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_COLLECTION_NAME];
     auto reply = mongodb_collection.delete_one(bsoncxx::v_noabi::builder::basic::make_document(

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -55,23 +55,22 @@ class RedisMongoDB : public AtomDB {
     shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(
         const LinkTemplateInterface& link_template);
 
-    shared_ptr<atomdb_api_types::HandleList> query_for_targets(shared_ptr<char> link_handle);
-    shared_ptr<atomdb_api_types::HandleList> query_for_targets(char* link_handle_ptr);
+    shared_ptr<atomdb_api_types::HandleList> query_for_targets(const string& handle);
 
-    shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const char* handle);
+    shared_ptr<atomdb_api_types::AtomDocument> get_atom_document(const string& handle);
     vector<shared_ptr<atomdb_api_types::AtomDocument>> get_atom_documents(const vector<string>& handles,
                                                                           const vector<string>& fields);
 
-    bool link_exists(const char* link_handle);
+    bool link_exists(const string& link_handle);
     set<string> links_exist(const vector<string>& link_handles);
 
-    char* add_node(const atomspace::Node* node);
+    string add_node(const atomspace::Node* node);
     vector<string> add_nodes(const vector<atomspace::Node*>& nodes);
 
-    char* add_link(const atomspace::Link* link);
+    string add_link(const atomspace::Link* link);
     vector<string> add_links(const vector<atomspace::Link*>& links);
 
-    bool delete_atom(const char* handle);
+    bool delete_atom(const string& handle);
     uint delete_atoms(const vector<string>& handles);
 
    private:

--- a/src/main/link_creation_engine_main.cc
+++ b/src/main/link_creation_engine_main.cc
@@ -170,10 +170,10 @@ void build_link(const string& link_type_tag,
     }
 }
 
-string handle_to_atom(const char* handle) {
+string handle_to_atom(const string& handle) {
     shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
     shared_ptr<atomdb_api_types::AtomDocument> document = db->get_atom_document(handle);
-    shared_ptr<atomdb_api_types::HandleList> targets = db->query_for_targets((char*) handle);
+    shared_ptr<atomdb_api_types::HandleList> targets = db->query_for_targets(handle);
     string answer;
 
     if (targets != nullptr) {

--- a/src/main/word_query_evolution_main.cc
+++ b/src/main/word_query_evolution_main.cc
@@ -50,10 +50,10 @@ string highlight(const string& s, const set<string>& highlighted) {
     return answer;
 }
 
-string handle_to_atom(const char* handle) {
+string handle_to_atom(const string& handle) {
     shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
     shared_ptr<atomdb_api_types::AtomDocument> document = db->get_atom_document(handle);
-    shared_ptr<atomdb_api_types::HandleList> targets = db->query_for_targets((char*) handle);
+    shared_ptr<atomdb_api_types::HandleList> targets = db->query_for_targets(handle);
     string answer;
 
     if (targets != NULL) {

--- a/src/main/word_query_main.cc
+++ b/src/main/word_query_main.cc
@@ -53,10 +53,10 @@ string highlight(const string& s, const set<string>& highlighted) {
     return answer;
 }
 
-string handle_to_atom(const char* handle) {
+string handle_to_atom(const string& handle) {
     shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
     shared_ptr<atomdb_api_types::AtomDocument> document = db->get_atom_document(handle);
-    shared_ptr<atomdb_api_types::HandleList> targets = db->query_for_targets((char*) handle);
+    shared_ptr<atomdb_api_types::HandleList> targets = db->query_for_targets(handle);
     string answer;
 
     if (targets != NULL) {

--- a/src/tests/cpp/atom_space_test.cc
+++ b/src/tests/cpp/atom_space_test.cc
@@ -66,12 +66,11 @@ class MockAtomDB : public AtomDB {
 
     // AtomDB interface implementation
     shared_ptr<HandleSet> query_for_pattern(const LinkTemplateInterface&) override { return nullptr; }
-    shared_ptr<HandleList> query_for_targets(shared_ptr<char>) override { return nullptr; }
-    shared_ptr<HandleList> query_for_targets(char*) override { return nullptr; }
+    shared_ptr<HandleList> query_for_targets(const string&) override { return nullptr; }
 
     map<string, Atom*> atoms;
 
-    shared_ptr<AtomDocument> get_atom_document(const char* handle) override {
+    shared_ptr<AtomDocument> get_atom_document(const string& handle) override {
         get_atom_calls.push_back(handle);
         auto it = docs.find(handle);
         if (it != docs.end()) {
@@ -85,17 +84,17 @@ class MockAtomDB : public AtomDB {
         return {};  // Not implemented for this mock
     }
 
-    bool link_exists(const char*) override { return false; }
+    bool link_exists(const string&) override { return false; }
     set<string> links_exist(const vector<string>&) override { return {}; }
 
-    char* add_node(const atomspace::Node* node) override {
+    string add_node(const atomspace::Node* node) override {
         add_node_calls.push_back({node->type, node->name, node->custom_attributes});
         // string handle = string("node_") + node->type + "_" + node->name;
         atoms[node->handle()] = (Atom*) node;
         return strdup(node->handle().c_str());
     }
 
-    char* add_link(const atomspace::Link* link) override {
+    string add_link(const atomspace::Link* link) override {
         add_link_calls.push_back({link->type, link->targets, link->custom_attributes});
         atoms[link->handle()] = (Atom*) link;
         return strdup(link->handle().c_str());

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -11,10 +11,10 @@
 using namespace query_engine;
 using namespace atomdb;
 
-string handle_to_atom(const char* handle) {
+string handle_to_atom(const string& handle) {
     shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
     shared_ptr<atomdb_api_types::AtomDocument> document = db->get_atom_document(handle);
-    shared_ptr<atomdb_api_types::HandleList> targets = db->query_for_targets((char*) handle);
+    shared_ptr<atomdb_api_types::HandleList> targets = db->query_for_targets(handle);
     string answer;
 
     if (targets != nullptr) {


### PR DESCRIPTION
This PR aims to simplify the way callers use `AtomDB` by replacing the `char*` by `std::string` in its methods parameters and returns.