### PR TITLE
[das-toolbox#190] Gatekeeper should support a command to reserve a range of ports instead of reserving only a single port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ build-all: build-image
 
 run-query-agent:
 	@PORT=$$(bash src/scripts/gkctl_auto_join_and_reserve.sh | tail -n 1); \
-	bash -x src/scripts/run.sh query_broker $$PORT 61000:61999
+	PORT_RANGE=$$(bash src/scripts/gkctl_auto_join_and_reserve.sh --range=999 | tail -n 1); \
+	bash -x src/scripts/run.sh query_broker $$PORT $$PORT_RANGE
 
 run-attention-broker:
 	@bash -x src/scripts/run.sh attention_broker_service 37007

--- a/src/scripts/gkctl_auto_join_and_reserve.sh
+++ b/src/scripts/gkctl_auto_join_and_reserve.sh
@@ -2,13 +2,24 @@
 
 set -uo pipefail
 
+RANGE_ARG="${1:-}"
+
+if [[ "$RANGE_ARG" =~ ^--range=([0-9]+)$ ]]; then
+  PORT_RANGE_SIZE="${BASH_REMATCH[1]}"
+  JOIN_CMD="gkctl instance join --range=${PORT_RANGE_SIZE}"
+  RESERVE_CMD="gkctl port reserve --range=${PORT_RANGE_SIZE}"
+else
+  JOIN_CMD="gkctl instance join"
+  RESERVE_CMD="gkctl port reserve"
+fi
+
 gkctl instance list --current > /dev/null 2>&1
 if [ $? -ne 0 ]; then
   echo "[INFO] Current instance not found. Joining..."
-  gkctl instance join
+  eval "$JOIN_CMD"
 else
   echo "[INFO] Current instance already exists."
 fi
 
 echo "[INFO] Reserving port..."
-gkctl port reserve
+eval "$RESERVE_CMD"


### PR DESCRIPTION
Closes https://github.com/singnet/das-toolbox/issues/190