### PR TITLE
[RedisMongoDB] Add ConcurrentAddNodesAndLinks test

### DIFF
--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -452,8 +452,8 @@ string RedisMongoDB::add_node(const atoms::Node* node) {
 }
 
 string RedisMongoDB::add_link(const atoms::Link* link) {
-    auto existing_targets = get_atom_documents(link->targets, {MONGODB_FIELD_NAME[MONGODB_FIELD::ID]});
-    auto existing_targets_count = existing_targets.size();
+    auto existing_targets_count =
+        get_atom_documents(link->targets, {MONGODB_FIELD_NAME[MONGODB_FIELD::ID]}).size();
 
     if (existing_targets_count != link->targets.size()) {
         Utils::error("Failed to insert link: " + link->handle() + " has " +

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -336,7 +336,14 @@ vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_atom_docume
     if (documents.size() == handles.size()) {
         return documents;
     }
-    auto link_documents = get_link_documents(handles, fields);
+    vector<string> missing_handles;
+    for (const auto& document : documents) {
+        auto handle = document->get(MONGODB_FIELD_NAME[MONGODB_FIELD::ID]);
+        if (find(handles.begin(), handles.end(), handle) == handles.end())
+            missing_handles.push_back(handle);
+    }
+    if (missing_handles.empty()) return documents;
+    auto link_documents = get_link_documents(missing_handles, fields);
     documents.insert(documents.end(), link_documents.begin(), link_documents.end());
     return documents;
 }
@@ -445,17 +452,17 @@ string RedisMongoDB::add_node(const atoms::Node* node) {
 }
 
 string RedisMongoDB::add_link(const atoms::Link* link) {
-    auto conn = this->mongodb_pool->acquire();
-    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_LINKS_COLLECTION_NAME];
+    auto existing_targets = get_atom_documents(link->targets, {MONGODB_FIELD_NAME[MONGODB_FIELD::ID]});
+    auto existing_targets_count = existing_targets.size();
 
-    auto existing_targets_count =
-        get_atom_documents(link->targets, {MONGODB_FIELD_NAME[MONGODB_FIELD::ID]}).size();
     if (existing_targets_count != link->targets.size()) {
         Utils::error("Failed to insert link: " + link->handle() + " has " +
                      to_string(link->targets.size() - existing_targets_count) + " missing targets");
         return "";
     }
 
+    auto conn = this->mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_LINKS_COLLECTION_NAME];
     auto mongodb_doc = atomdb_api_types::MongodbDocument(link, *this);
     auto reply = mongodb_collection.insert_one(mongodb_doc.value());
 

--- a/src/hasher/expression_hasher.cc
+++ b/src/hasher/expression_hasher.cc
@@ -7,37 +7,37 @@
 #include "mbedtls/md5.h"
 
 char* compute_hash(char* input) {
-    unsigned char MD5_BUFFER[16];
-    char HASH[HANDLE_HASH_SIZE];
+    unsigned char md5_buffer[16];
+    char* hash = new char[HANDLE_HASH_SIZE];
 
     mbedtls_md5_context context;
     mbedtls_md5_init(&context);
     mbedtls_md5_starts(&context);
     mbedtls_md5_update(&context, (const unsigned char*) input, strlen(input));
-    mbedtls_md5_finish(&context, MD5_BUFFER);
+    mbedtls_md5_finish(&context, md5_buffer);
     mbedtls_md5_free(&context);
     for (unsigned int i = 0; i < 16; i++) {
-        sprintf((char*) ((unsigned long) HASH + 2 * i), "%02x", MD5_BUFFER[i]);
+        sprintf((char*) ((unsigned long) hash + 2 * i), "%02x", md5_buffer[i]);
     }
-    HASH[32] = '\0';
-    return strdup(HASH);
+    hash[32] = '\0';
+    return hash;
 }
 
 char* named_type_hash(char* name) { return compute_hash(name); }
 
 char* terminal_hash(char* type, char* name) {
-    char HASHABLE_STRING[MAX_HASHABLE_STRING_SIZE];
+    char hashable_string[MAX_HASHABLE_STRING_SIZE];
 
     if (strlen(type) + strlen(name) >= MAX_HASHABLE_STRING_SIZE) {
         fprintf(stderr, "Invalid (too large) terminal name");
         exit(1);
     }
-    sprintf(HASHABLE_STRING, "%s%c%s", type, JOINING_CHAR, name);
-    return compute_hash(HASHABLE_STRING);
+    sprintf(hashable_string, "%s%c%s", type, JOINING_CHAR, name);
+    return compute_hash(hashable_string);
 }
 
 char* composite_hash(char** elements, unsigned int nelements) {
-    char HASHABLE_STRING[MAX_HASHABLE_STRING_SIZE];
+    char hashable_string[MAX_HASHABLE_STRING_SIZE];
     unsigned int total_size = 0;
     unsigned int element_size[nelements];
 
@@ -58,15 +58,15 @@ char* composite_hash(char** elements, unsigned int nelements) {
     unsigned long cursor = 0;
     for (unsigned int i = 0; i < nelements; i++) {
         if (i == (nelements - 1)) {
-            strcpy((char*) (HASHABLE_STRING + cursor), elements[i]);
+            strcpy((char*) (hashable_string + cursor), elements[i]);
         } else {
-            sprintf((char*) (HASHABLE_STRING + cursor), "%s%c", elements[i], JOINING_CHAR);
+            sprintf((char*) (hashable_string + cursor), "%s%c", elements[i], JOINING_CHAR);
             cursor += 1;
         }
         cursor += element_size[i];
     }
 
-    return compute_hash(HASHABLE_STRING);
+    return compute_hash(hashable_string);
 }
 
 char* expression_hash(char* type_hash, char** elements, unsigned int nelements) {

--- a/src/hasher/expression_hasher.cc
+++ b/src/hasher/expression_hasher.cc
@@ -6,11 +6,10 @@
 
 #include "mbedtls/md5.h"
 
-static unsigned char MD5_BUFFER[16];
-static char HASH[HANDLE_HASH_SIZE];
-static char HASHABLE_STRING[MAX_HASHABLE_STRING_SIZE];
-
 char* compute_hash(char* input) {
+    unsigned char MD5_BUFFER[16];
+    char HASH[HANDLE_HASH_SIZE];
+
     mbedtls_md5_context context;
     mbedtls_md5_init(&context);
     mbedtls_md5_starts(&context);
@@ -27,6 +26,8 @@ char* compute_hash(char* input) {
 char* named_type_hash(char* name) { return compute_hash(name); }
 
 char* terminal_hash(char* type, char* name) {
+    char HASHABLE_STRING[MAX_HASHABLE_STRING_SIZE];
+
     if (strlen(type) + strlen(name) >= MAX_HASHABLE_STRING_SIZE) {
         fprintf(stderr, "Invalid (too large) terminal name");
         exit(1);
@@ -36,6 +37,7 @@ char* terminal_hash(char* type, char* name) {
 }
 
 char* composite_hash(char** elements, unsigned int nelements) {
+    char HASHABLE_STRING[MAX_HASHABLE_STRING_SIZE];
     unsigned int total_size = 0;
     unsigned int element_size[nelements];
 


### PR DESCRIPTION
This PR adds `ConcurrentAddNodesAndLinks` test for `RedisMongoDB`.

In order to make it work I had to fix `RedisMongoDB::get_atom_documents` and change `expression_hasher.cc`. 