### PR TITLE
[#499] Allow ATOM elements in query tokens allowing the use of handles as LINK targets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,3 +6,4 @@
 [#511] Create a Properties class in commons by moving and renaming CustomAttributesMap from AtomDB package
 [#499] Refactor proxy classes to use commons:Properties
 [#521] Creates atom classes in common and refactors query elements to use them
+[#499] Allow ATOM elements in query tokens allowing the use of handles as LINK targets

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -27,7 +27,6 @@ using namespace atomdb;
 string PatternMatchingQueryProcessor::AND = "AND";
 string PatternMatchingQueryProcessor::OR = "OR";
 
-
 // -------------------------------------------------------------------------------------------------
 // Constructors and destructors
 
@@ -231,8 +230,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
             (query_tokens[cursor] == LinkSchema::NODE)) {
             cursor += 3;
         } else if ((query_tokens[cursor] == LinkSchema::UNTYPED_VARIABLE) ||
-                   (query_tokens[cursor] == LinkSchema::ATOM) ||
-                   (query_tokens[cursor] == AND) ||
+                   (query_tokens[cursor] == LinkSchema::ATOM) || (query_tokens[cursor] == AND) ||
                    (query_tokens[cursor] == OR)) {
             cursor += 2;
         } else {

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -24,6 +24,10 @@
 
 using namespace atomdb;
 
+string PatternMatchingQueryProcessor::AND = "AND";
+string PatternMatchingQueryProcessor::OR = "OR";
+
+
 // -------------------------------------------------------------------------------------------------
 // Constructors and destructors
 
@@ -222,11 +226,17 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
 
     while (cursor < tokens_count) {
         execution_stack.push(cursor);
-        if ((query_tokens[cursor] == "VARIABLE") || (query_tokens[cursor] == "AND") ||
-            ((query_tokens[cursor] == "OR"))) {
+        if ((query_tokens[cursor] == LinkSchema::LINK) ||
+            (query_tokens[cursor] == LinkSchema::LINK_TEMPLATE) ||
+            (query_tokens[cursor] == LinkSchema::NODE)) {
+            cursor += 3;
+        } else if ((query_tokens[cursor] == LinkSchema::UNTYPED_VARIABLE) ||
+                   (query_tokens[cursor] == LinkSchema::ATOM) ||
+                   (query_tokens[cursor] == AND) ||
+                   (query_tokens[cursor] == OR)) {
             cursor += 2;
         } else {
-            cursor += 3;
+            Utils::error("Invalid token in query: " + query_tokens[cursor]);
         }
     }
 
@@ -237,21 +247,25 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
 
     while (!execution_stack.empty()) {
         cursor = execution_stack.top();
-        if (query_tokens[cursor] == "NODE") {
+        if (query_tokens[cursor] == LinkSchema::ATOM) {
+            shared_ptr<Terminal> atom = make_shared<Terminal>();
+            atom->handle = query_tokens[cursor + 1];
+            element_stack.push(atom);
+        } else if (query_tokens[cursor] == LinkSchema::NODE) {
             element_stack.push(
                 make_shared<Terminal>(query_tokens[cursor + 1], query_tokens[cursor + 2]));
-        } else if (query_tokens[cursor] == "VARIABLE") {
+        } else if (query_tokens[cursor] == LinkSchema::UNTYPED_VARIABLE) {
             element_stack.push(make_shared<Terminal>(query_tokens[cursor + 1]));
-        } else if (query_tokens[cursor] == "LINK") {
+        } else if (query_tokens[cursor] == LinkSchema::LINK) {
             element_stack.push(build_link(proxy, cursor, element_stack));
-        } else if (query_tokens[cursor] == "LINK_TEMPLATE") {
+        } else if (query_tokens[cursor] == LinkSchema::LINK_TEMPLATE) {
             element_stack.push(build_link_template(proxy, cursor, element_stack));
-        } else if (query_tokens[cursor] == "AND") {
+        } else if (query_tokens[cursor] == AND) {
             element_stack.push(build_and(proxy, cursor, element_stack));
             if (proxy->parameters.get<bool>(BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG)) {
                 element_stack.push(build_unique_assignment_filter(proxy, cursor, element_stack));
             }
-        } else if (query_tokens[cursor] == "OR") {
+        } else if (query_tokens[cursor] == OR) {
             element_stack.push(build_or(proxy, cursor, element_stack));
             if (proxy->parameters.get<bool>(BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG)) {
                 element_stack.push(build_unique_assignment_filter(proxy, cursor, element_stack));

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.h
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.h
@@ -86,6 +86,8 @@ class PatternMatchingQueryProcessor : public BusCommandProcessor {
     map<string, shared_ptr<StoppableThread>> query_threads;
     mutex query_threads_mutex;
     shared_ptr<PatternMatchingQueryProxy> proxy;
+    static string AND;
+    static string OR;
 };
 
 }  // namespace atomdb

--- a/src/agents/query_engine/query_element/LinkTemplate.cc
+++ b/src/agents/query_engine/query_element/LinkTemplate.cc
@@ -37,11 +37,15 @@ void LinkTemplate::recursive_build(shared_ptr<QueryElement> element, LinkSchema&
             link_schema.stack_untyped_variable(terminal->name);
         } else if (terminal->is_node) {
             link_schema.stack_node(terminal->type, terminal->name);
+        } else if (terminal->is_atom) {
+            link_schema.stack_atom(terminal->handle);
         } else if (terminal->is_link) {
             for (auto target : terminal->targets) {
                 recursive_build(target, link_schema);
             }
             link_schema.stack_link(terminal->type, terminal->targets.size());
+        } else {
+            Utils::error("Invalid terminal");
         }
     } else {
         // is an inner LinkTemplate

--- a/src/agents/query_engine/query_element/Terminal.cc
+++ b/src/agents/query_engine/query_element/Terminal.cc
@@ -8,6 +8,13 @@
 
 using namespace query_element;
 
+Terminal::Terminal() : QueryElement() {
+    // Atom
+    init();
+    this->is_atom = true;
+    this->handle = "UNINITIALIZED";
+}
+
 Terminal::Terminal(const string& type, const string& name) : QueryElement() {
     // Node
     init();
@@ -36,11 +43,14 @@ void Terminal::init() {
     this->is_variable = false;
     this->is_node = false;
     this->is_link = false;
+    this->is_atom = false;
     this->is_terminal = true;
 }
 
 string Terminal::to_string() {
-    if (this->is_node) {
+    if (this->is_atom) {
+        return this->handle;
+    } else if (this->is_node) {
         return "<" + this->type + ", " + this->name + ">";
     } else if (this->is_variable) {
         return this->name;

--- a/src/agents/query_engine/query_element/Terminal.h
+++ b/src/agents/query_engine/query_element/Terminal.h
@@ -20,11 +20,14 @@ class Terminal : public QueryElement {
     bool is_variable;
     bool is_link;
     bool is_node;
+    bool is_atom;
     string type;
     string name;
+    string handle;
     vector<shared_ptr<QueryElement>> targets;
 
     ~Terminal(){};
+    Terminal();                                                                     // Atom
     Terminal(const string& type, const string& name);                               // Node
     Terminal(const string& type, const vector<shared_ptr<QueryElement>>& targets);  // Link
     Terminal(const string& name);                                                   // Variable

--- a/src/commons/atoms/LinkSchema.cc
+++ b/src/commons/atoms/LinkSchema.cc
@@ -11,6 +11,12 @@
 
 using namespace atoms;
 
+string LinkSchema::ATOM = "ATOM";
+string LinkSchema::NODE = "NODE";
+string LinkSchema::LINK = "LINK";
+string LinkSchema::UNTYPED_VARIABLE = "VARIABLE";
+string LinkSchema::LINK_TEMPLATE = "LINK_TEMPLATE";
+
 // -------------------------------------------------------------------------------------------------
 // Constructors, destructors , basic operators and initializers
 
@@ -35,10 +41,6 @@ void LinkSchema::_init(unsigned int arity) {
     this->_metta_representation = "(";
     this->_schema_element.is_link = true;
 
-    this->LINK_TEMPLATE = "LINK_TEMPLATE";
-    this->NODE = "NODE";
-    this->LINK = "LINK";
-    this->UNTYPED_VARIABLE = "VARIABLE";
     this->_build_tokens.push_back({LINK_TEMPLATE, this->type, std::to_string(arity)});
 }
 
@@ -193,6 +195,18 @@ void LinkSchema::add_target(const string& schema_handle,
     } else {
         Utils::error("Attempt to add a new target beyond LinkSchema's arity. LinkSchema: " +
                      this->to_string());
+    }
+}
+
+void LinkSchema::stack_atom(const string& handle) {
+    LOG_DEBUG("            STACK ATOM: " + handle);
+    if (!_check_not_frozen()) {
+        tuple<string, string, string> triplet(handle, handle, handle);
+        this->_atom_stack.push_back(triplet);
+        this->_build_tokens.push_back({ATOM, handle});
+        SchemaElement atom_element;
+        atom_element.handle = handle;
+        this->_schema_element_stack.push(atom_element);
     }
 }
 
@@ -381,7 +395,7 @@ void LinkSchema::untokenize(const vector<string>& tokens) {
     }
 
     stack<tuple<string, string, unsigned int, unsigned int>> link_schema_stack;
-    string token, type, name;
+    string token, type, name, handle;
     unsigned int arity, current_pending_elements;
     unsigned int cursor = 0;
     token = tokens[cursor++];
@@ -396,7 +410,16 @@ void LinkSchema::untokenize(const vector<string>& tokens) {
     while (current_pending_elements > 0) {
         _syntax_assert((cursor + current_pending_elements) <= tokens.size(), token, cursor);
         token = tokens[cursor++];
-        if (token == NODE) {
+        if (token == ATOM) {
+            _syntax_assert((cursor + 1) <= tokens.size(), token, cursor);
+            handle = tokens[cursor++];
+            LOG_DEBUG("STACK ATOM: " << handle);
+            stack_atom(handle);
+            current_pending_elements--;
+            if (current_pending_elements == 0) {
+                current_pending_elements = _push_stack_top(link_schema_stack, token, cursor);
+            }
+        } else if (token == NODE) {
             _syntax_assert((cursor + 2) <= tokens.size(), token, cursor);
             type = tokens[cursor++];
             name = tokens[cursor++];

--- a/src/commons/atoms/LinkSchema.h
+++ b/src/commons/atoms/LinkSchema.h
@@ -46,7 +46,6 @@ class LinkSchema : public Wildcard {
         unsigned int cursor);
 
    public:
-
     static string LINK_TEMPLATE;
     static string ATOM;
     static string NODE;

--- a/src/commons/atoms/LinkSchema.h
+++ b/src/commons/atoms/LinkSchema.h
@@ -45,12 +45,14 @@ class LinkSchema : public Wildcard {
         string cursor_token,
         unsigned int cursor);
 
-    string LINK_TEMPLATE;
-    string NODE;
-    string LINK;
-    string UNTYPED_VARIABLE;
-
    public:
+
+    static string LINK_TEMPLATE;
+    static string ATOM;
+    static string NODE;
+    static string LINK;
+    static string UNTYPED_VARIABLE;
+
     // ---------------------------------------------------------------------------------------------
     // Constructors, destructors , basic operators and initializers
 
@@ -153,6 +155,8 @@ class LinkSchema : public Wildcard {
     void add_target(const string& schema_handle,
                     const string& composite_type_hash,
                     const string& metta_representation);
+
+    void stack_atom(const string& handle);
 
     void stack_node(const string& type, const string& name);
 

--- a/src/tests/cpp/atom_space_types_test.cc
+++ b/src/tests/cpp/atom_space_types_test.cc
@@ -266,6 +266,16 @@ TEST(WildcardTest, LinkSchema) {
     schema7.stack_node(symbol, "n1");
     schema7.stack_untyped_variable("v1");
     EXPECT_THROW(schema7.stack_link(expression, 2), runtime_error);
+
+    cout << "8 ---------------------------------------------------------" << endl;
+    LinkSchema schema8(expression, 2);
+    schema8.stack_atom("h1");
+    schema8.stack_untyped_variable("v1");
+    schema8.build();
+    EXPECT_EQ(schema8.metta_representation(db), "(h1 $v1)");
+    LinkSchema schema8_1(schema8.tokenize());
+    EXPECT_EQ(schema8.to_string(), schema8_1.to_string());
+    EXPECT_TRUE(schema8 == schema8_1);
 }
 
 void check_match(const string& test_tag,
@@ -354,6 +364,21 @@ TEST(LinkTest, Match) {
             "VARIABLE", "v2",
             });
     check_match("test case 4.1", schema4, {link4, node2, link2}, db, true);
+
+    LinkSchema schema5({
+    "LINK_TEMPLATE", "Expression", "3",
+        "LINK_TEMPLATE", "Expression", "2",
+            "NODE", "Symbol", "n1",
+            "LINK_TEMPLATE", "Expression", "3",
+                "ATOM", Hasher::node_handle("Symbol", "n2"),
+                "ATOM", Hasher::node_handle("Symbol", "n3"),
+                "VARIABLE", "v1",
+        "ATOM", Hasher::node_handle("Symbol", "n2"),
+        "LINK_TEMPLATE", "Expression", "2",
+            "NODE", "Symbol", "n1",
+            "VARIABLE", "v2",
+            });
+    check_match("test case 5.1", schema5, {link4, node2, link2}, db, true);
 
     // clang-format on
 }

--- a/src/tests/cpp/link_template_test.cc
+++ b/src/tests/cpp/link_template_test.cc
@@ -1,10 +1,10 @@
 #include <cstdlib>
 
 #include "AtomDBSingleton.h"
+#include "Hasher.h"
 #include "LinkTemplate.h"
 #include "QueryAnswer.h"
 #include "QueryNode.h"
-#include "Hasher.h"
 #include "Terminal.h"
 #include "gtest/gtest.h"
 #include "test_utils.h"

--- a/src/tests/cpp/link_template_test.cc
+++ b/src/tests/cpp/link_template_test.cc
@@ -4,6 +4,7 @@
 #include "LinkTemplate.h"
 #include "QueryAnswer.h"
 #include "QueryNode.h"
+#include "Hasher.h"
 #include "Terminal.h"
 #include "gtest/gtest.h"
 #include "test_utils.h"
@@ -30,7 +31,8 @@ TEST(LinkTemplate, basics) {
     auto v1 = make_shared<Terminal>("v1");
     auto v2 = make_shared<Terminal>("v2");
     auto v3 = make_shared<Terminal>("v3");
-    auto similarity = make_shared<Terminal>(symbol, "Similarity");
+    auto similarity = make_shared<Terminal>();
+    similarity->handle = Hasher::node_handle(symbol, "Similarity");
     auto human = make_shared<Terminal>(symbol, "\"human\"");
 
     LinkTemplate link_template1("Expression", {similarity, human, v1}, "", false);

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -1,9 +1,9 @@
 #include "AtomDBSingleton.h"
+#include "Hasher.h"
 #include "PatternMatchingQueryProcessor.h"
 #include "PatternMatchingQueryProxy.h"
 #include "ServiceBus.h"
 #include "Utils.h"
-#include "Hasher.h"
 #include "gtest/gtest.h"
 
 #define LOG_LEVEL INFO_LEVEL

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -3,6 +3,7 @@
 #include "PatternMatchingQueryProxy.h"
 #include "ServiceBus.h"
 #include "Utils.h"
+#include "Hasher.h"
 #include "gtest/gtest.h"
 
 #define LOG_LEVEL INFO_LEVEL
@@ -186,6 +187,19 @@ TEST(PatternMatchingQuery, queries) {
                 "NODE", "Symbol", "\"chimp\""
     };
     int q6_expected_count = 4;
+    
+    vector<string> q7 = {
+        "OR", "2",
+            "LINK_TEMPLATE", "Expression", "3",
+                "NODE", "Symbol", "Similarity",
+                "VARIABLE", "v1",
+                "NODE", "Symbol", "\"human\"",
+            "LINK_TEMPLATE", "Expression", "3",
+                "NODE", "Symbol", "Similarity",
+                "VARIABLE", "v1",
+                "ATOM", Hasher::node_handle("Symbol", "\"chimp\"")
+    };
+    int q7_expected_count = 4;
 
     // Regular queries
     check_query("q1", q1, q1_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
@@ -194,6 +208,7 @@ TEST(PatternMatchingQuery, queries) {
     check_query("q4", q4, q4_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
     check_query("q5", q5, q5_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false);
     check_query("q6", q6, q6_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false);
+    check_query("q7", q7, q7_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false);
 
     // Importance filtering
     check_query("filtered q2", q2, q2_expected_count, client_bus, "PatternMatchingQuery.queries", true, false, false, false);


### PR DESCRIPTION
WIP towards #499 
In this PR we implement a new type of token in queries: ATOM
It can be used to define LINK elements using handles rather than NODEs or LINKs. Like this:

```
    vector<string> query_tokens = {
        "OR", "2",
            "LINK_TEMPLATE", "Expression", "3",
                "NODE", "Symbol", "Similarity",
                "VARIABLE", "v1",
                "NODE", "Symbol", "\"human\"",
            "LINK_TEMPLATE", "Expression", "3",
                "NODE", "Symbol", "Similarity",
                "VARIABLE", "v1",
                "ATOM", Hasher::node_handle("Symbol", "\"chimp\"")
    };          
```