### PR TITLE
[MORK][HOTFIX] Use new commit hash.

### DIFF
--- a/src/docker/mork/Dockerfile.server
+++ b/src/docker/mork/Dockerfile.server
@@ -5,7 +5,7 @@ RUN yes | apt update -y \
     && yes | apt clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-ENV COMMIT_ID="de01a1f88a7fd6f2c93829da80fa012697f2b97f"
+ENV COMMIT_ID="578a759d2c4962de7b4a2cd17f695c89f5e53bb4"
 
 WORKDIR /opt
 


### PR DESCRIPTION
This PR uses the latest commit hash from MORK repo.
https://github.com/trueagi-io/MORK/commit/578a759d2c4962de7b4a2cd17f695c89f5e53bb4