### PR TITLE
[#612] Use `LinkSchema` that matches all when there is no `pattern_index_schema`

### DIFF
--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -353,10 +353,8 @@ void RedisMongoDB::set_next_score(const string& key, uint score) {
 }
 
 void RedisMongoDB::reset_scores() {
-    this->patterns_next_score.store(0);
-    this->incoming_set_next_score.store(0);
-    this->set_next_score(REDIS_PATTERNS_PREFIX + ":next_score", this->patterns_next_score.load());
-    this->set_next_score(REDIS_INCOMING_PREFIX + ":next_score", this->incoming_set_next_score.load());
+    this->patterns_next_score.store(get_next_score(REDIS_PATTERNS_PREFIX + ":next_score"));
+    this->incoming_set_next_score.store(get_next_score(REDIS_INCOMING_PREFIX + ":next_score"));
 }
 
 void RedisMongoDB::add_outgoing_set(const string& handle, const vector<string>& outgoing_handles) {
@@ -1014,9 +1012,12 @@ void RedisMongoDB::drop_all() {
         flush_redis_by_prefix(key);
     }
 
-    // We need to reset next scores to 0 to avoid remainings from previous runs
-    // as they were initialized on RedisMongoDB construction
-    this->reset_scores();
+    // Flushing next_scores from Redis and reseting them
+    keys = {REDIS_PATTERNS_PREFIX, REDIS_INCOMING_PREFIX};
+    for (const auto& key : keys) {
+        flush_redis_by_prefix(key + ":next_score");
+    }
+    reset_scores();
 
     // We need to clear the pattern index schema map and reload it
     this->pattern_index_schema_map.clear();

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -926,7 +926,7 @@ vector<string> RedisMongoDB::match_pattern_index_schema(const Link* link) {
     return pattern_handles;
 }
 
-// Combination of "_" and "*" for a given arity
+// Combination of "vX" and "*" for a given arity
 vector<vector<string>> RedisMongoDB::index_entries_combinations(unsigned int arity) {
     vector<vector<string>> index_entries;
     unsigned int total = 1 << arity;  // 2^arity
@@ -937,7 +937,7 @@ vector<vector<string>> RedisMongoDB::index_entries_combinations(unsigned int ari
             if (mask & (1 << i))
                 index_entry.push_back("*");
             else
-                index_entry.push_back("_");
+                index_entry.push_back("v" + to_string(i + 1));
         }
         index_entries.push_back(index_entry);
     }

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -154,6 +154,7 @@ class RedisMongoDB : public AtomDB {
 
     void load_pattern_index_schema();
     vector<string> match_pattern_index_schema(const Link* link);
+    vector<vector<string>> index_entries_combinations(unsigned int arity);
 
     void redis_setup();
     void mongodb_setup();

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -601,6 +601,34 @@ cc_test(
 )
 
 cc_test(
+    name = "redis_mongodb_test_2",
+    size = "small",
+    srcs = [
+        "redis_mongodb_test_2.cc",
+        "test_utils.cc",
+        "test_utils.h",
+    ],
+    copts = [
+        "-Iexternal/gtest/googletest/include",
+        "-Iexternal/gtest/googletest",
+    ],
+    linkopts = [
+        "-L/usr/local/lib",
+        "-lhiredis_cluster",
+        "-lhiredis",
+        "-lmongocxx",
+        "-lbsoncxx",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//atomdb:atomdb_singleton",
+        "//tests/cpp/test_commons",
+        "@com_github_google_googletest//:gtest_main",
+        "@mbedtls",
+    ],
+)
+
+cc_test(
     name = "morkdb_test",
     size = "small",
     srcs = ["morkdb_test.cc"],

--- a/src/tests/cpp/redis_mongodb_test_2.cc
+++ b/src/tests/cpp/redis_mongodb_test_2.cc
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "AtomDBSingleton.h"
+#include "Hasher.h"
+#include "Link.h"
+#include "MettaMapping.h"
+#include "MockAnimalsData.h"
+#include "Node.h"
+#include "RedisMongoDB.h"
+#include "TestConfig.h"
+
+using namespace atomdb;
+using namespace atoms;
+using namespace std;
+
+class RedisMongoDBTestEnvironment : public ::testing::Environment {
+   public:
+    void SetUp() override {
+        TestConfig::load_environment();
+        TestConfig::disable_atomdb_cache();
+        auto atomdb = new RedisMongoDB("test2_");
+        atomdb->drop_all();
+        AtomDBSingleton::provide(shared_ptr<AtomDB>(atomdb));
+    }
+
+    void TearDown() override {
+        auto atomdb = AtomDBSingleton::get_instance();
+        auto db = dynamic_pointer_cast<RedisMongoDB>(atomdb);
+        db->drop_all();
+    }
+};
+
+class RedisMongoDBTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        auto atomdb = AtomDBSingleton::get_instance();
+        db2 = dynamic_pointer_cast<RedisMongoDB>(atomdb);
+        ASSERT_NE(db2, nullptr) << "Failed to cast AtomDB to RedisMongoDB (db2)";
+    }
+
+    void TearDown() override {}
+
+    shared_ptr<RedisMongoDB> db2;
+};
+
+class LinkSchemaHandle : public LinkSchema {
+   public:
+    LinkSchemaHandle(const char* handle) : LinkSchema("blah", 2), fixed_handle(handle) {}
+
+    string handle() const override { return this->fixed_handle; }
+
+   private:
+    string fixed_handle;
+};
+
+TEST_F(RedisMongoDBTest, AddLinksWithNoPatternIndexSchema) {
+    // (TestLink (TestNestedLink1 (TestNestedLink2 N1 N2) N2) N2)
+    vector<string> handles;
+
+    auto link_node = new Node("Symbol", "TestLink");
+    handles.push_back(db2->add_node(link_node));
+
+    auto nested_link_node_1 = new Node("Symbol", "TestNestedLink1");
+    handles.push_back(db2->add_node(nested_link_node_1));
+    auto nested_link_node_2 = new Node("Symbol", "TestNestedLink2");
+    handles.push_back(db2->add_node(nested_link_node_2));
+
+    auto n1_node = new Node("Symbol", "N1");
+    handles.push_back(db2->add_node(n1_node));
+    auto n2_node = new Node("Symbol", "N2");
+    handles.push_back(db2->add_node(n2_node));
+
+    auto nested_link_2 =
+        new Link("Expression", {nested_link_node_2->handle(), n1_node->handle(), n2_node->handle()});
+    handles.push_back(db2->add_link(nested_link_2));
+
+    auto nested_link_1 = new Link(
+        "Expression", {nested_link_node_1->handle(), nested_link_2->handle(), n2_node->handle()});
+    handles.push_back(db2->add_link(nested_link_1));
+
+    auto link =
+        new Link("Expression", {link_node->handle(), nested_link_1->handle(), n2_node->handle()});
+    handles.push_back(db2->add_link(link));
+
+    // (TestNestedLink2 * *)
+    string hash = Hasher::link_handle(
+        "Expression", {nested_link_node_2->handle(), Atom::WILDCARD_STRING, Atom::WILDCARD_STRING});
+    auto link_schema = new LinkSchemaHandle(hash.c_str());
+    auto handle_set = db2->query_for_pattern(*link_schema);
+    EXPECT_EQ(handle_set->size(), 1);
+
+    // (TestNestedLink1 * *)
+    hash = Hasher::link_handle(
+        "Expression", {nested_link_node_1->handle(), Atom::WILDCARD_STRING, Atom::WILDCARD_STRING});
+    link_schema = new LinkSchemaHandle(hash.c_str());
+    handle_set = db2->query_for_pattern(*link_schema);
+    EXPECT_EQ(handle_set->size(), 1);
+
+    // (TestLinkName * *)
+    hash = Hasher::link_handle("Expression",
+                               {link_node->handle(), Atom::WILDCARD_STRING, Atom::WILDCARD_STRING});
+    link_schema = new LinkSchemaHandle(hash.c_str());
+    handle_set = db2->query_for_pattern(*link_schema);
+    EXPECT_EQ(handle_set->size(), 1);
+
+    // (* * *)
+    hash = Hasher::link_handle("Expression",
+                               {Atom::WILDCARD_STRING, Atom::WILDCARD_STRING, Atom::WILDCARD_STRING});
+    link_schema = new LinkSchemaHandle(hash.c_str());
+    handle_set = db2->query_for_pattern(*link_schema);
+    EXPECT_EQ(handle_set->size(), 3);
+
+    // (* N1 *)
+    hash = Hasher::link_handle("Expression",
+                               {Atom::WILDCARD_STRING, n1_node->handle(), Atom::WILDCARD_STRING});
+    link_schema = new LinkSchemaHandle(hash.c_str());
+    handle_set = db2->query_for_pattern(*link_schema);
+    EXPECT_EQ(handle_set->size(), 1);
+
+    // (* * N2)
+    hash = Hasher::link_handle("Expression",
+                               {Atom::WILDCARD_STRING, Atom::WILDCARD_STRING, n2_node->handle()});
+    link_schema = new LinkSchemaHandle(hash.c_str());
+    handle_set = db2->query_for_pattern(*link_schema);
+    EXPECT_EQ(handle_set->size(), 3);
+
+    // Delete nested_link_1 means deleting link but not nested_link_2.
+    EXPECT_TRUE(db2->delete_link(nested_link_1->handle()));
+    EXPECT_FALSE(db2->link_exists(link->handle()));
+    EXPECT_FALSE(db2->link_exists(nested_link_1->handle()));
+    EXPECT_TRUE(db2->link_exists(nested_link_2->handle()));
+
+    // Before delete: 5 nodes + 3 links
+    // After delete: 5 nodes + 1 link (nested_link_2)
+    EXPECT_EQ(db2->atoms_exist(handles).size(), 6);
+
+    db2->delete_atoms(handles);
+    EXPECT_EQ(db2->atoms_exist(handles).size(), 0);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new RedisMongoDBTestEnvironment());
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
If there is no `pattern_index_schema` (eg non existing or empty collection) we fallback to create a `LinkSchema` that matches the given `Link` when adding it.

We also create all possible combination of "vX" and "*" by the `Link::arity` so we can cover ALL possible `patterns:HASH`.

A `WARNING` log message is printed when we initiate the `RedisMongoDB` (while calling `load_pattern_index_schema()`) with no `pattern_index_schema` stored.

This solve #612

UPDATE: Had to create a different test file due to the annoying way `mongocxx` lib deals with its `instance`. Adding test to the current test file (but different DB/context) is breaking due threading issues.