### PR TITLE
[#620] Miscellaneous changes in order to diminish probability of PORT conflict error

### DIFF
--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -111,9 +111,7 @@ void QueryEvolutionProcessor::sample_population(
         }
     }
     if (!pm->finished()) {
-        // TODO Uncomment this when abort() is implemented
-        // pm->abort();
-        LOG_ERROR("Couldn't abort pattern matching query because abort() is not implemented");
+        pm->abort();
         unsigned int count = 0;
         while (!pm->finished()) {
             shared_ptr<QueryAnswer> query_answer;
@@ -123,7 +121,9 @@ void QueryEvolutionProcessor::sample_population(
                 count++;
             }
         }
-        LOG_ERROR("Discarding " << count << " answers");
+        if (count > 0) {
+            LOG_DEBUG("Discarding " << count << " answers");
+        }
     }
     if (remote_fitness && (answer_bundle_vector.size() > 0)) {
         LOG_INFO("Evaluating fitness remotelly");

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -165,12 +165,10 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
         shared_ptr<QueryElement> root_query_element = setup_query_tree(proxy);
         set<string> joint_answer;  // used to stimulate attention broker
         string command = proxy->get_command();
-        unsigned int sink_port_number;
         if (root_query_element == NULL) {
             Utils::error("Invalid empty query tree.");
         } else {
             if (command == ServiceBus::PATTERN_MATCHING_QUERY) {
-                sink_port_number = PortPool::get_port();
                 LinkTemplate* root_link_template = dynamic_cast<LinkTemplate*>(root_query_element.get());
                 shared_ptr<Sink> query_sink;
                 if (root_link_template != NULL) {
@@ -206,7 +204,6 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
                 Utils::sleep(500);
                 LOG_INFO("Total processed answers: " << answer_count);
                 query_sink->graceful_shutdown();
-                PortPool::return_port(sink_port_number);
             } else {
                 Utils::error("Invalid command " + command + " in PatternMatchingQueryProcessor");
             }

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -1,5 +1,7 @@
 #include "Utils.h"
 
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -13,8 +15,6 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
-#include <sys/socket.h>
-#include <netinet/in.h>
 
 #include "Logger.h"
 
@@ -209,7 +209,6 @@ unsigned long Utils::get_current_ram_usage() {
 }
 
 bool Utils::is_port_available(unsigned int port) {
-
     int socket_descriptor;
     struct sockaddr_in my_addr;
 
@@ -223,7 +222,7 @@ bool Utils::is_port_available(unsigned int port) {
     my_addr.sin_addr.s_addr = INADDR_ANY;
     bzero(&(my_addr.sin_zero), 8);
 
-    if (bind(socket_descriptor, (struct sockaddr *)&my_addr, sizeof(struct sockaddr)) == -1) {
+    if (bind(socket_descriptor, (struct sockaddr*) &my_addr, sizeof(struct sockaddr)) == -1) {
         return false;
     }
 
@@ -371,4 +370,3 @@ string MemoryFootprint::to_string() {
 }
 
 // --------------------------------------------------------------------------------
-

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -13,6 +13,8 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 #include "Logger.h"
 
@@ -22,16 +24,10 @@ using namespace std;
 // --------------------------------------------------------------------------------
 // Public methods
 
-Utils::Utils() {}
-
-Utils::~Utils() {}
-
 void Utils::error(string msg) {
     LOG_ERROR(msg);
     throw runtime_error(msg);
 }
-
-void Utils::warning(string msg) { cerr << msg << endl; }
 
 bool Utils::flip_coin(double true_probability) {
     long f = 1000;
@@ -47,147 +43,6 @@ string Utils::get_environment(string const& key) {
     string answer = (value == NULL ? "" : value);
     return answer;
 }
-
-// --------------------------------------------------------------------------------
-// StopWatch
-
-StopWatch::StopWatch() { reset(); }
-
-StopWatch::~StopWatch() {}
-
-void StopWatch::start() {
-    if (running) {
-        stop();
-    }
-    start_time = chrono::steady_clock::now();
-    running = true;
-}
-
-void StopWatch::stop() {
-    if (running) {
-        chrono::steady_clock::time_point check = chrono::steady_clock::now();
-        accumulator = accumulator + (check - start_time);
-        start_time = check;
-        running = false;
-    }
-}
-
-void StopWatch::reset() {
-    running = false;
-    accumulator = chrono::steady_clock::duration::zero();
-}
-
-unsigned long StopWatch::milliseconds() {
-    return chrono::duration_cast<chrono::milliseconds>(accumulator).count();
-}
-
-string StopWatch::str_time() {
-    unsigned long millis = milliseconds();
-
-    unsigned long seconds = millis / 1000;
-    if (seconds > 0) {
-        millis = millis % 1000;
-    }
-
-    unsigned long minutes = seconds / 60;
-    if (minutes > 0) {
-        seconds = seconds % 60;
-    }
-
-    unsigned long hours = minutes / 60;
-    if (hours > 0) {
-        minutes = minutes % 60;
-    }
-
-    if (hours > 0) {
-        return to_string(hours) + " hours " + to_string(minutes) + " mins";
-    } else if (minutes > 0) {
-        return to_string(minutes) + " mins " + to_string(seconds) + " secs";
-    } else {
-        return to_string(seconds) + " secs " + to_string(millis) + " millis";
-    }
-}
-
-// --------------------------------------------------------------------------------
-// MemoryFootprint
-
-MemoryFootprint::MemoryFootprint() {
-    this->running = false;
-    this->start_snapshot = 0L;
-    this->last_snapshot = 0L;
-    this->final_snapshot = 0L;
-}
-
-MemoryFootprint::~MemoryFootprint() {}
-
-void MemoryFootprint::start() {
-    this->running = true;
-    this->delta_ram.clear();
-    this->start_snapshot = Utils::get_current_ram_usage();
-    this->last_snapshot = this->start_snapshot;
-}
-
-void MemoryFootprint::check(const string& tag) {
-    if (this->running) {
-        unsigned long snapshot = Utils::get_current_ram_usage();
-        delta_ram.push_back(make_pair(snapshot - this->last_snapshot, tag));
-        this->last_snapshot = snapshot;
-    } else {
-        Utils::error("MemoryFootprint is not running");
-    }
-}
-
-void MemoryFootprint::stop(const string& tag) {
-    if (this->running) {
-        if (tag != "") {
-            check(tag);
-        }
-        this->final_snapshot = Utils::get_current_ram_usage();
-        this->running = false;
-    } else {
-        Utils::error("MemoryFootprint is not running");
-    }
-}
-
-long MemoryFootprint::delta_usage(bool since_last_check) {
-    unsigned long baseline;
-    unsigned long reference;
-    if (since_last_check) {
-        baseline = this->last_snapshot;
-    } else {
-        baseline = this->start_snapshot;
-    }
-    if (this->running) {
-        reference = Utils::get_current_ram_usage();
-    } else {
-        reference = this->final_snapshot;
-    }
-    return reference - baseline;
-}
-
-string MemoryFootprint::to_string() {
-    string answer = "{Begin: " + std::to_string(this->start_snapshot) + ", End: ";
-    if (this->running) {
-        answer += std::to_string(this->final_snapshot);
-    } else {
-        answer += std::to_string(this->last_snapshot);
-    }
-    answer += ", Delta: " + std::to_string(delta_usage()) + ", Checkpoints: [";
-    bool empty_flag = true;
-    for (auto pair : this->delta_ram) {
-        answer += "(\"" + pair.second + "\", " + std::to_string(pair.first) + ")";
-        answer += ", ";
-        empty_flag = false;
-    }
-    if (!empty_flag) {
-        answer.pop_back();
-        answer.pop_back();
-    }
-    answer += "]}";
-    return answer;
-}
-
-// --------------------------------------------------------------------------------
 
 map<string, string> Utils::parse_config(string const& config_path) {
     map<string, string> config;
@@ -352,3 +207,168 @@ unsigned long Utils::get_current_ram_usage() {
 
     return (unsigned long) resident_set;
 }
+
+bool Utils::is_port_available(unsigned int port) {
+
+    int socket_descriptor;
+    struct sockaddr_in my_addr;
+
+    socket_descriptor = socket(AF_INET, SOCK_STREAM, 0);
+    if (socket_descriptor == -1) {
+        return false;
+    }
+
+    my_addr.sin_family = AF_INET;
+    my_addr.sin_port = htons(port);
+    my_addr.sin_addr.s_addr = INADDR_ANY;
+    bzero(&(my_addr.sin_zero), 8);
+
+    if (bind(socket_descriptor, (struct sockaddr *)&my_addr, sizeof(struct sockaddr)) == -1) {
+        return false;
+    }
+
+    close(socket_descriptor);
+    return true;
+}
+
+// --------------------------------------------------------------------------------
+// StopWatch
+
+StopWatch::StopWatch() { reset(); }
+
+StopWatch::~StopWatch() {}
+
+void StopWatch::start() {
+    if (running) {
+        stop();
+    }
+    start_time = chrono::steady_clock::now();
+    running = true;
+}
+
+void StopWatch::stop() {
+    if (running) {
+        chrono::steady_clock::time_point check = chrono::steady_clock::now();
+        accumulator = accumulator + (check - start_time);
+        start_time = check;
+        running = false;
+    }
+}
+
+void StopWatch::reset() {
+    running = false;
+    accumulator = chrono::steady_clock::duration::zero();
+}
+
+unsigned long StopWatch::milliseconds() {
+    return chrono::duration_cast<chrono::milliseconds>(accumulator).count();
+}
+
+string StopWatch::str_time() {
+    unsigned long millis = milliseconds();
+
+    unsigned long seconds = millis / 1000;
+    if (seconds > 0) {
+        millis = millis % 1000;
+    }
+
+    unsigned long minutes = seconds / 60;
+    if (minutes > 0) {
+        seconds = seconds % 60;
+    }
+
+    unsigned long hours = minutes / 60;
+    if (hours > 0) {
+        minutes = minutes % 60;
+    }
+
+    if (hours > 0) {
+        return to_string(hours) + " hours " + to_string(minutes) + " mins";
+    } else if (minutes > 0) {
+        return to_string(minutes) + " mins " + to_string(seconds) + " secs";
+    } else {
+        return to_string(seconds) + " secs " + to_string(millis) + " millis";
+    }
+}
+
+// --------------------------------------------------------------------------------
+// MemoryFootprint
+
+MemoryFootprint::MemoryFootprint() {
+    this->running = false;
+    this->start_snapshot = 0L;
+    this->last_snapshot = 0L;
+    this->final_snapshot = 0L;
+}
+
+MemoryFootprint::~MemoryFootprint() {}
+
+void MemoryFootprint::start() {
+    this->running = true;
+    this->delta_ram.clear();
+    this->start_snapshot = Utils::get_current_ram_usage();
+    this->last_snapshot = this->start_snapshot;
+}
+
+void MemoryFootprint::check(const string& tag) {
+    if (this->running) {
+        unsigned long snapshot = Utils::get_current_ram_usage();
+        delta_ram.push_back(make_pair(snapshot - this->last_snapshot, tag));
+        this->last_snapshot = snapshot;
+    } else {
+        Utils::error("MemoryFootprint is not running");
+    }
+}
+
+void MemoryFootprint::stop(const string& tag) {
+    if (this->running) {
+        if (tag != "") {
+            check(tag);
+        }
+        this->final_snapshot = Utils::get_current_ram_usage();
+        this->running = false;
+    } else {
+        Utils::error("MemoryFootprint is not running");
+    }
+}
+
+long MemoryFootprint::delta_usage(bool since_last_check) {
+    unsigned long baseline;
+    unsigned long reference;
+    if (since_last_check) {
+        baseline = this->last_snapshot;
+    } else {
+        baseline = this->start_snapshot;
+    }
+    if (this->running) {
+        reference = Utils::get_current_ram_usage();
+    } else {
+        reference = this->final_snapshot;
+    }
+    return reference - baseline;
+}
+
+string MemoryFootprint::to_string() {
+    string answer = "{Begin: " + std::to_string(this->start_snapshot) + ", End: ";
+    if (this->running) {
+        answer += std::to_string(this->final_snapshot);
+    } else {
+        answer += std::to_string(this->last_snapshot);
+    }
+    answer += ", Delta: " + std::to_string(delta_usage()) + ", Checkpoints: [";
+    bool empty_flag = true;
+    for (auto pair : this->delta_ram) {
+        answer += "(\"" + pair.second + "\", " + std::to_string(pair.first) + ")";
+        answer += ", ";
+        empty_flag = false;
+    }
+    if (!empty_flag) {
+        answer.pop_back();
+        answer.pop_back();
+    }
+    answer += "]}";
+    return answer;
+}
+
+// --------------------------------------------------------------------------------
+

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -46,11 +46,10 @@ class MemoryFootprint {
 
 class Utils {
    public:
-    Utils();
-    ~Utils();
+    Utils() {}
+    ~Utils() {}
 
     static void error(string msg);
-    static void warning(string msg);
     static bool flip_coin(double true_probability = 0.5);
     static void sleep(unsigned int milliseconds = 100);
     static string get_environment(string const& key);
@@ -67,6 +66,7 @@ class Utils {
     static string linux_command_line(const char* cmd);
     static unsigned long get_current_free_ram();   // Kbytes
     static unsigned long get_current_ram_usage();  // Kbytes
+    static bool is_port_available(unsigned int port);
 };
 
 }  // namespace commons

--- a/src/distributed_algorithm_node/MessageBroker.cc
+++ b/src/distributed_algorithm_node/MessageBroker.cc
@@ -17,12 +17,13 @@
 #include "atom_space_node.grpc.pb.h"
 #include "atom_space_node.pb.h"
 
-#define LOG_LEVEL INFO_LEVEL
+#define LOG_LEVEL DEBUG_LEVEL
 #include "Logger.h"
 
 using namespace distributed_algorithm_node;
 
 unsigned int SynchronousGRPC::MESSAGE_THREAD_COUNT = 10;
+mutex SynchronousGRPC::GRPC_BUILDER_MUTEX;
 unsigned int SynchronousSharedRAM::MESSAGE_THREAD_COUNT = 1;
 unordered_map<string, SharedQueue*> SynchronousSharedRAM::NODE_QUEUE;
 mutex SynchronousSharedRAM::NODE_QUEUE_MUTEX;
@@ -93,27 +94,44 @@ SynchronousGRPC::~SynchronousGRPC() {
     if (this->joined_network) {
         this->stop();
         this->inbox_threads.clear();
-
-        this->grpc_server->Shutdown();
-        this->grpc_server.reset();
-
-        this->grpc_thread->stop();
+        this->grpc_thread->stop(true);
     }
 }
 
 // -------------------------------------------------------------------------------------------------
 // Methods used to start threads
 
+void SynchronousGRPC::grpc_thread_teardown(shared_ptr<StoppableThread> monitor) {
+    while (! monitor->stopped()) {
+        Utils::sleep();
+    }
+    this->grpc_server->Shutdown();
+    this->grpc_server->Wait();
+    Utils::sleep();
+}
+
 void SynchronousGRPC::grpc_thread_method(shared_ptr<StoppableThread> monitor) {
-    grpc::EnableDefaultHealthCheckService(false);
-    grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+    thread* grpc_teardown = new thread(&SynchronousGRPC::grpc_thread_teardown, this, monitor);
+    GRPC_BUILDER_MUTEX.lock();
     grpc::ServerBuilder builder;
     builder.AddListeningPort(this->node_id, grpc::InsecureServerCredentials());
+    builder.AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 1);
     builder.RegisterService(this);
-    LOG_INFO("SynchronousGRPC listening on " + this->node_id);
+    LOG_DEBUG("Building GRPC server on " + this->node_id);
     this->grpc_server = builder.BuildAndStart();
+    if (this->grpc_server == nullptr) {
+        GRPC_BUILDER_MUTEX.unlock();
+        Utils::error("Couldn't start GRPC server on " + this->node_id);
+        return;
+    }
+    LOG_INFO("SynchronousGRPC listening on " + this->node_id);
     set_grpc_server_started();
+    GRPC_BUILDER_MUTEX.unlock();
     this->grpc_server->Wait();
+    grpc_teardown->join();
+    this->grpc_server.reset();
+    delete grpc_teardown;
+    LOG_DEBUG("GRPC thread finished " + this->node_id);
 }
 
 void SynchronousSharedRAM::inbox_thread_method(shared_ptr<StoppableThread> monitor) {
@@ -425,7 +443,7 @@ void SynchronousGRPC::stop() {
     for (auto thread : this->inbox_threads) {
         thread->stop();
     }
-    grpc_thread->stop(false);
+    grpc_thread->stop(true);
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/src/distributed_algorithm_node/MessageBroker.cc
+++ b/src/distributed_algorithm_node/MessageBroker.cc
@@ -102,7 +102,7 @@ SynchronousGRPC::~SynchronousGRPC() {
 // Methods used to start threads
 
 void SynchronousGRPC::grpc_thread_teardown(shared_ptr<StoppableThread> monitor) {
-    while (! monitor->stopped()) {
+    while (!monitor->stopped()) {
         Utils::sleep();
     }
     this->grpc_server->Shutdown();

--- a/src/distributed_algorithm_node/MessageBroker.h
+++ b/src/distributed_algorithm_node/MessageBroker.h
@@ -336,6 +336,7 @@ class SynchronousGRPC : public MessageBroker, public dasproto::AtomSpaceNode::Se
 
    private:
     static unsigned int MESSAGE_THREAD_COUNT;
+    static mutex GRPC_BUILDER_MUTEX;
     unique_ptr<grpc::Server> grpc_server;
     shared_ptr<StoppableThread> grpc_thread;
     vector<shared_ptr<StoppableThread>> inbox_threads;
@@ -352,6 +353,7 @@ class SynchronousGRPC : public MessageBroker, public dasproto::AtomSpaceNode::Se
     bool inbox_setup_finished();
 
     // Methods used to start threads
+    void grpc_thread_teardown(shared_ptr<StoppableThread> monitor);
     void grpc_thread_method(shared_ptr<StoppableThread> monitor);
     void inbox_thread_method(shared_ptr<StoppableThread> monitor);
 };

--- a/src/service_bus/BusCommandProxy.cc
+++ b/src/service_bus/BusCommandProxy.cc
@@ -126,9 +126,7 @@ void ProxyNode::node_joined_network(const string& node_id) {
     this->peer_id = node_id;
 }
 
-bool ProxyNode::is_server() {
-    return StarNode::is_server;
-}
+bool ProxyNode::is_server() { return StarNode::is_server; }
 
 // -------------------------------------------------------------------------------------------------
 // Messages

--- a/src/service_bus/BusCommandProxy.cc
+++ b/src/service_bus/BusCommandProxy.cc
@@ -24,6 +24,12 @@ BusCommandProxy::~BusCommandProxy() {
         // Return the port to the pool of available ports
         PortPool::return_port(this->proxy_port);
         this->proxy_node->graceful_shutdown();
+        if (this->proxy_node->is_server()) {
+            // Force BUS command caller to wait for the client while it shuts down.  This
+            // reduces the probability of having PORTs in TIME_WAIT mode which would make
+            // them unusable for a period of time.
+            Utils::sleep(500);
+        }
         delete this->proxy_node;
     }
 }
@@ -118,6 +124,10 @@ void ProxyNode::to_remote_peer(const string& command, const vector<string>& args
 void ProxyNode::node_joined_network(const string& node_id) {
     StarNode::node_joined_network(node_id);
     this->peer_id = node_id;
+}
+
+bool ProxyNode::is_server() {
+    return StarNode::is_server;
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/src/service_bus/BusCommandProxy.h
+++ b/src/service_bus/BusCommandProxy.h
@@ -48,6 +48,7 @@ class ProxyNode : public StarNode {
     void node_joined_network(const string& node_id);
 
     void remote_call(const string& command, const vector<string>& args);
+    bool is_server();
 
    private:
     BusCommandProxy* proxy;

--- a/src/service_bus/PortPool.cc
+++ b/src/service_bus/PortPool.cc
@@ -6,26 +6,29 @@
 using namespace service_bus;
 
 SharedQueue* PortPool::POOL = NULL;
-unsigned long PortPool::PORT_LOWER = 0;
-unsigned long PortPool::PORT_UPPER = 0;
+unsigned int PortPool::PORT_LOWER = 0;
+unsigned int PortPool::PORT_UPPER = 0;
 
-void PortPool::initialize_statics(unsigned long port_lower, unsigned long port_upper) {
+void PortPool::initialize_statics(unsigned int port_lower, unsigned int port_upper) {
     if (port_lower > port_upper) {
         Utils::error("Invalid port limits [" + to_string(port_lower) + ".." + to_string(port_upper) +
                      "]");
     }
-
     LOG_INFO("Port range: [" << port_lower << " : " << port_upper << "]");
     PORT_LOWER = port_lower;
     PORT_UPPER = port_upper;
     POOL = new SharedQueue(port_upper - port_lower + 1);
-    for (unsigned long port = port_lower; port <= port_upper; port++) {
-        POOL->enqueue((void*) port);
+    for (unsigned int port = port_lower; port <= port_upper; port++) {
+        if (Utils::is_port_available(port)) {
+            POOL->enqueue((void*) ((unsigned long) port));
+        } else {
+            LOG_ERROR("Discarding unavailable PORT " + std::to_string(port));
+        }
     }
 }
 
-unsigned long PortPool::get_port() {
-    unsigned long port = (unsigned long) POOL->dequeue();
+unsigned int PortPool::get_port() {
+    unsigned int port = (unsigned int) ((unsigned long) POOL->dequeue());
     if (!port) {
         Utils::error("Unable to get available PORT number in [" + to_string(PORT_LOWER) + ".." +
                      to_string(PORT_UPPER) + "]");
@@ -33,4 +36,4 @@ unsigned long PortPool::get_port() {
     return port;
 }
 
-void PortPool::return_port(unsigned long port) { POOL->enqueue((void*) port); }
+void PortPool::return_port(unsigned int port) { POOL->enqueue((void*) ((unsigned long) port)); }

--- a/src/service_bus/PortPool.h
+++ b/src/service_bus/PortPool.h
@@ -13,15 +13,15 @@ namespace service_bus {
  */
 class PortPool {
    public:
-    static void initialize_statics(unsigned long port_lower, unsigned long port_upper);
-    static unsigned long get_port();
-    static void return_port(unsigned long port);
+    static void initialize_statics(unsigned int port_lower, unsigned int port_upper);
+    static unsigned int get_port();
+    static void return_port(unsigned int port);
 
    private:
     PortPool();
     static SharedQueue* POOL;
-    static unsigned long PORT_LOWER;
-    static unsigned long PORT_UPPER;
+    static unsigned int PORT_LOWER;
+    static unsigned int PORT_UPPER;
 };
 
 }  // namespace service_bus

--- a/src/tests/cpp/atom_space_test.cc
+++ b/src/tests/cpp/atom_space_test.cc
@@ -390,7 +390,7 @@ class AtomDBEnvironment : public ::testing::Environment {
         TestConfig::load_environment();
         // Initialize the singleton once
         AtomDBSingleton::init();
-        ServiceBusSingleton::init("localhost:31701", "localhost:31702", 31700, 31799);
+        ServiceBusSingleton::init("localhost:40030", "localhost:40031", 40100, 40199);
     }
 
     void TearDown() override {

--- a/src/tests/cpp/distributed_algorithm_node_test.cc
+++ b/src/tests/cpp/distributed_algorithm_node_test.cc
@@ -82,9 +82,9 @@ void TestMessage::act(shared_ptr<MessageFactory> node) {
 // Test cases
 
 TEST(DistributedAlgorithmNode, basics) {
-    string server_id = "localhost:30700";
-    string client1_id = "localhost:30701";
-    string client2_id = "localhost:30702";
+    string server_id = "localhost:40032";
+    string client1_id = "localhost:40033";
+    string client2_id = "localhost:40034";
     TestNode* server;
     TestNode* client1;
     TestNode* client2;
@@ -135,9 +135,9 @@ TEST(DistributedAlgorithmNode, basics) {
 }
 
 TEST(DistributedAlgorithmNode, communication) {
-    string server_id = "localhost:30700";
-    string client1_id = "localhost:30701";
-    string client2_id = "localhost:30702";
+    string server_id = "localhost:40035";
+    string client1_id = "localhost:40036";
+    string client2_id = "localhost:40037";
     TestNode* server;
     TestNode* client1;
     TestNode* client2;

--- a/src/tests/cpp/inference_agent_test.cc
+++ b/src/tests/cpp/inference_agent_test.cc
@@ -41,7 +41,7 @@ class InferenceAgentTest : public ::testing::Test {
 
     void SetUp() override {
         ServiceBusSingleton::provide(
-            move(make_shared<MockServiceBus>("localhost:1111", "localhost:1121")));
+            move(make_shared<MockServiceBus>("localhost:40038", "localhost:40039")));
         AtomDBSingleton::provide(move(make_shared<AtomDBMock>()));
     }
 

--- a/src/tests/cpp/link_creation_agent_test.cc
+++ b/src/tests/cpp/link_creation_agent_test.cc
@@ -38,7 +38,7 @@ class LinkCreationAgentTest : public ::testing::Test {
         this->metta_file_path = ".";
         this->save_links_to_metta_file = true;
         this->save_links_to_db = false;
-        this->server_id = "localhost:7003";
+        this->server_id = "localhost:40040";
         AtomDBSingleton::provide(move(make_shared<AtomDBMock>()));
     }
 
@@ -92,7 +92,7 @@ TEST_F(LinkCreationAgentTest, TestRequest) {
 }
 
 TEST_F(LinkCreationAgentTest, TestConfig) {
-    ServiceBusSingleton::init(this->server_id);
+    ServiceBusSingleton::init(this->server_id, "", 40500, 40599);
     shared_ptr<ServiceBus> service_bus = ServiceBusSingleton::get_instance();
     service_bus->register_processor(
         make_shared<LinkCreationRequestProcessor>(this->request_interval,

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -103,10 +103,10 @@ TEST(PatternMatchingQuery, queries) {
     TestConfig::load_environment();
 
     AtomDBSingleton::init();
-    ServiceBus::initialize_statics({}, 57000, 57500);
+    ServiceBus::initialize_statics({}, 40200, 40299);
 
-    string peer1_id = "localhost:33701";
-    string peer2_id = "localhost:33702";
+    string peer1_id = "localhost:40041";
+    string peer2_id = "localhost:40042";
 
     ServiceBus* server_bus = new ServiceBus(peer1_id);
     Utils::sleep(500);

--- a/src/tests/cpp/query_evolution_test.cc
+++ b/src/tests/cpp/query_evolution_test.cc
@@ -36,9 +36,9 @@ TEST(QueryEvolution, protected_methods) {
     TestConfig::load_environment();
     AtomDBSingleton::init();
 
-    string peer1_id = "localhost:33801";
-    string peer2_id = "localhost:33802";
-    ServiceBusSingleton::init(peer1_id, "", 64000, 64999);
+    string peer1_id = "localhost:40043";
+    string peer2_id = "localhost:40044";
+    ServiceBusSingleton::init(peer1_id, "", 40300, 40399);
     FitnessFunctionRegistry::initialize_statics();
     shared_ptr<ServiceBus> query_bus = ServiceBusSingleton::get_instance();
     query_bus->register_processor(make_shared<PatternMatchingQueryProcessor>());

--- a/src/tests/cpp/service_bus_test.cc
+++ b/src/tests/cpp/service_bus_test.cc
@@ -60,13 +60,13 @@ void check_command(ServiceBus& source, shared_ptr<TestProcessor> target, const s
 
 TEST(ServiceBus, basics) {
     set<string> commands = {"c1", "c2", "c3", "c4", "c5"};
-    ServiceBus::initialize_statics(commands, 72400, 73400);
+    ServiceBus::initialize_statics(commands, 40400, 40499);
     shared_ptr<TestProcessor> processor1(new TestProcessor({"c1", "c4"}));
     shared_ptr<TestProcessor> processor2(new TestProcessor({"c2"}));
     shared_ptr<TestProcessor> processor3(new TestProcessor({"c3"}));
-    string peer1_id = "localhost:32701";
-    string peer2_id = "localhost:32702";
-    string peer3_id = "localhost:32703";
+    string peer1_id = "localhost:40045";
+    string peer2_id = "localhost:40046";
+    string peer3_id = "localhost:40047";
 
     ServiceBus service_bus1(peer1_id);
     Utils::sleep(1000);


### PR DESCRIPTION
Actually there are a lot of issues which may cause the error mentioned in #620 . This PR addresses some of them in order to diminish its probability but it still happens, specially when we run unit tests in a multiple-core machine (the larger the number of cores, the bigger the probability of error). Further investigation is required.

The root cause of the crash seems to be related to when a program (agent, unit tests, etc) aborts unexpectedly, letting the PORTS used by GRPC in TIME_WAIT mode for some time (which varies from seconds to a couple of minutes). 