### PR TITLE
Expose base class implementation of query_for_pattern in MorkDB

### DIFF
--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -200,4 +200,9 @@ const atoms::Atom* MorkDB::parse_tokens_to_atom(const vector<string>& tokens, si
         return new atoms::Node(symbol, tokens[pos++]);
     }
 }
+
+shared_ptr<atomdb_api_types::HandleSet> MorkDB::query_for_pattern_base(const LinkSchema& link_schema) {
+    return RedisMongoDB::query_for_pattern(link_schema);
+}
+
 // <--

--- a/src/atomdb/morkdb/MorkDB.h
+++ b/src/atomdb/morkdb/MorkDB.h
@@ -41,6 +41,9 @@ class MorkDB : public RedisMongoDB {
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const LinkSchema& link_schema) override;
 
+    // Used for testing purposes
+    shared_ptr<atomdb_api_types::HandleSet> query_for_pattern_base(const LinkSchema& link_schema);
+
    private:
     shared_ptr<AtomDBCache> atomdb_cache;
     shared_ptr<MorkClient> mork_client;

--- a/src/tests/benchmark/atomdb/atomdb_main.cc
+++ b/src/tests/benchmark/atomdb/atomdb_main.cc
@@ -131,19 +131,19 @@ int main(int argc, char** argv) {
         } else if (action == "DeleteAtom") {
             DeleteAtom benchmark(tid, atomdb, iterations);
             map<string, function<void()>> benchmark_handlers{
-                {"delete_node", [&]() { benchmark.delete_node(); }},
-                {"delete_link", [&]() { benchmark.delete_link(); }},
-                {"delete_atom_node", [&]() { benchmark.delete_atom_node(); }},
-                {"delete_atom_link", [&]() { benchmark.delete_atom_link(); }},
+                {"delete_node", [&]() { benchmark.delete_node(atomdb_type); }},
+                {"delete_link", [&]() { benchmark.delete_link(atomdb_type); }},
+                {"delete_atom_node", [&]() { benchmark.delete_atom_node(atomdb_type); }},
+                {"delete_atom_link", [&]() { benchmark.delete_atom_link(atomdb_type); }},
             };
             dispatch_handler(benchmark, benchmark_handlers, method);
         } else if (action == "DeleteAtoms") {
             DeleteAtoms benchmark(tid, atomdb, iterations);
             map<string, function<void()>> benchmark_handlers{
-                {"delete_nodes", [&]() { benchmark.delete_nodes(); }},
-                {"delete_links", [&]() { benchmark.delete_links(); }},
-                {"delete_atoms_node", [&]() { benchmark.delete_atoms_node(); }},
-                {"delete_atoms_link", [&]() { benchmark.delete_atoms_link(); }},
+                {"delete_nodes", [&]() { benchmark.delete_nodes(atomdb_type); }},
+                {"delete_links", [&]() { benchmark.delete_links(atomdb_type); }},
+                {"delete_atoms_node", [&]() { benchmark.delete_atoms_node(atomdb_type); }},
+                {"delete_atoms_link", [&]() { benchmark.delete_atoms_link(atomdb_type); }},
             };
             dispatch_handler(benchmark, benchmark_handlers, method);
         } else {

--- a/src/tests/benchmark/atomdb/atomdb_operations.cc
+++ b/src/tests/benchmark/atomdb/atomdb_operations.cc
@@ -143,7 +143,7 @@ void GetAtom::get_node_document() {
             auto handle_set = db_->query_for_pattern(link_schema);
             vector<string> random_link_handles = get_random_link_handle(handle_set);
             auto link_document = db_->get_link_document(random_link_handles[0]);
-            auto contains_node_handle = link_document->get("targets", 0);
+            auto contains_node_handle = string(link_document->get("targets", 0));
             return contains_node_handle;
         },
         [&](string handle) { db_->get_node_document(handle); });
@@ -167,7 +167,7 @@ void GetAtom::get_atom_document_node() {
             auto handle_set = db_->query_for_pattern(link_schema);
             vector<string> random_link_handles = get_random_link_handle(handle_set);
             auto link_document = db_->get_link_document(random_link_handles[0]);
-            auto contains_node_handle = link_document->get("targets", 0);
+            auto contains_node_handle = string(link_document->get("targets", 0));
             return contains_node_handle;
         },
         [&](string handle) { db_->get_atom_document(handle); });
@@ -191,7 +191,7 @@ void GetAtom::get_atom_node() {
             auto handle_set = db_->query_for_pattern(link_schema);
             vector<string> random_link_handles = get_random_link_handle(handle_set);
             auto link_document = db_->get_link_document(random_link_handles[0]);
-            auto contains_node_handle = link_document->get("targets", 0);
+            auto contains_node_handle = string(link_document->get("targets", 0));
             return contains_node_handle;
         },
         [&](string handle) { db_->get_atom(handle); });
@@ -221,7 +221,7 @@ void GetAtoms::get_node_documents() {
             vector<string> handles;
             for (const auto& link_handle : random_link_handles) {
                 auto link_document = db_->get_link_document(link_handle);
-                auto node_handle = link_document->get("targets", 1);
+                auto node_handle = string(link_document->get("targets", 1));
                 handles.push_back(node_handle);
             }
             return handles;
@@ -252,7 +252,7 @@ void GetAtoms::get_atom_documents_node() {
             vector<string> handles;
             for (const auto& link_handle : random_link_handles) {
                 auto link_document = db_->get_link_document(link_handle);
-                auto node_handle = link_document->get("targets", 1);
+                auto node_handle = string(link_document->get("targets", 1));
                 handles.push_back(node_handle);
             }
             return handles;
@@ -292,61 +292,86 @@ void GetAtoms::query_for_targets() {
         [&](string handle) { db_->query_for_targets(handle); });
 }
 
-void DeleteAtom::delete_node() {
+void DeleteAtom::delete_node(string type) {
     run_benchmark(
         "delete_node",
         [&](int i) -> string {
             auto link_schema = LinkSchema(sentence_links_query);
-            auto handle_set = db_->query_for_pattern(link_schema);
+            shared_ptr<atomdb_api_types::HandleSet> handle_set;
+            if (type == "mork") {
+                handle_set = dynamic_pointer_cast<MorkDB>(db_)->query_for_pattern_base(link_schema);
+            } else {
+                handle_set = db_->query_for_pattern(link_schema);
+            }
             vector<string> random_link_handles = get_random_link_handle(handle_set);
             auto link_document = db_->get_link_document(random_link_handles[0]);
-            auto node_handle = link_document->get("targets", 1);
+            auto node_handle = string(link_document->get("targets", 1));
             return node_handle;
         },
         [&](string handle) { db_->delete_node(handle); });
 }
-void DeleteAtom::delete_link() {
+void DeleteAtom::delete_link(string type) {
     run_benchmark(
         "delete_link",
         [&](int i) -> string {
             auto link_schema = LinkSchema(contains_links_query);
-            auto handle_set = db_->query_for_pattern(link_schema);
+            shared_ptr<atomdb_api_types::HandleSet> handle_set;
+            if (type == "mork") {
+                handle_set = dynamic_pointer_cast<MorkDB>(db_)->query_for_pattern_base(link_schema);
+            } else {
+                handle_set = db_->query_for_pattern(link_schema);
+            }
             vector<string> random_link_handles = get_random_link_handle(handle_set);
             return random_link_handles[0];
         },
         [&](string handle) { db_->delete_link(handle); });
 }
-void DeleteAtom::delete_atom_node() {
+void DeleteAtom::delete_atom_node(string type) {
     run_benchmark(
         "delete_atom[node]",
         [&](int i) -> string {
             auto link_schema = LinkSchema(sentence_links_query);
-            auto handle_set = db_->query_for_pattern(link_schema);
+            shared_ptr<atomdb_api_types::HandleSet> handle_set;
+            if (type == "mork") {
+                handle_set = dynamic_pointer_cast<MorkDB>(db_)->query_for_pattern_base(link_schema);
+            } else {
+                handle_set = db_->query_for_pattern(link_schema);
+            }
             vector<string> random_link_handles = get_random_link_handle(handle_set);
             auto link_document = db_->get_link_document(random_link_handles[0]);
-            auto node_handle = link_document->get("targets", 1);
+            auto node_handle = string(link_document->get("targets", 1));
             return node_handle;
         },
         [&](string handle) { db_->delete_atom(handle); });
 }
-void DeleteAtom::delete_atom_link() {
+void DeleteAtom::delete_atom_link(string type) {
     run_benchmark(
         "delete_atom[link]",
         [&](int i) -> string {
             auto link_schema = LinkSchema(contains_links_query);
-            auto handle_set = db_->query_for_pattern(link_schema);
+            shared_ptr<atomdb_api_types::HandleSet> handle_set;
+            if (type == "mork") {
+                handle_set = dynamic_pointer_cast<MorkDB>(db_)->query_for_pattern_base(link_schema);
+            } else {
+                handle_set = db_->query_for_pattern(link_schema);
+            }
             vector<string> random_link_handles = get_random_link_handle(handle_set);
             return random_link_handles[0];
         },
         [&](string handle) { db_->delete_atom(handle); });
 }
 
-void DeleteAtoms::delete_nodes() {
+void DeleteAtoms::delete_nodes(string type) {
     run_benchmark(
         "delete_nodes",
         [&](int i) -> vector<string> {
             auto link_schema = LinkSchema(sentence_links_query);
-            auto handle_set = db_->query_for_pattern(link_schema);
+            shared_ptr<atomdb_api_types::HandleSet> handle_set;
+            if (type == "mork") {
+                handle_set = dynamic_pointer_cast<MorkDB>(db_)->query_for_pattern_base(link_schema);
+            } else {
+                handle_set = db_->query_for_pattern(link_schema);
+            }
             size_t max_count = max<size_t>(BATCH_SIZE, MAX_COUNT);
             vector<string> random_link_handles =
                 get_random_link_handle(handle_set, max_count, BATCH_SIZE);
@@ -354,7 +379,7 @@ void DeleteAtoms::delete_nodes() {
             vector<string> handles;
             for (const auto& link_handle : random_link_handles) {
                 auto link_document = db_->get_link_document(link_handle);
-                auto node_handle = link_document->get("targets", 1);
+                auto node_handle = string(link_document->get("targets", 1));
                 handles.push_back(node_handle);
             }
             return handles;
@@ -362,24 +387,34 @@ void DeleteAtoms::delete_nodes() {
         [&](vector<string> handles) { db_->delete_nodes(handles); },
         BATCH_SIZE);
 }
-void DeleteAtoms::delete_links() {
+void DeleteAtoms::delete_links(string type) {
     run_benchmark(
         "delete_links",
         [&](int i) -> vector<string> {
             auto link_schema = LinkSchema(contains_links_query);
-            auto handle_set = db_->query_for_pattern(link_schema);
+            shared_ptr<atomdb_api_types::HandleSet> handle_set;
+            if (type == "mork") {
+                handle_set = dynamic_pointer_cast<MorkDB>(db_)->query_for_pattern_base(link_schema);
+            } else {
+                handle_set = db_->query_for_pattern(link_schema);
+            }
             size_t max_count = max<size_t>(BATCH_SIZE, MAX_COUNT);
             return get_random_link_handle(handle_set, max_count, BATCH_SIZE);
         },
         [&](vector<string> handles) { db_->delete_links(handles); },
         BATCH_SIZE);
 }
-void DeleteAtoms::delete_atoms_node() {
+void DeleteAtoms::delete_atoms_node(string type) {
     run_benchmark(
         "delete_atoms[node]",
         [&](int i) -> vector<string> {
             auto link_schema = LinkSchema(sentence_links_query);
-            auto handle_set = db_->query_for_pattern(link_schema);
+            shared_ptr<atomdb_api_types::HandleSet> handle_set;
+            if (type == "mork") {
+                handle_set = dynamic_pointer_cast<MorkDB>(db_)->query_for_pattern_base(link_schema);
+            } else {
+                handle_set = db_->query_for_pattern(link_schema);
+            }
             size_t max_count = max<size_t>(BATCH_SIZE, MAX_COUNT);
             vector<string> random_link_handles =
                 get_random_link_handle(handle_set, max_count, BATCH_SIZE);
@@ -387,7 +422,7 @@ void DeleteAtoms::delete_atoms_node() {
             vector<string> handles;
             for (const auto& link_handle : random_link_handles) {
                 auto link_document = db_->get_link_document(link_handle);
-                auto node_handle = link_document->get("targets", 1);
+                auto node_handle = string(link_document->get("targets", 1));
                 handles.push_back(node_handle);
             }
             return handles;
@@ -395,12 +430,17 @@ void DeleteAtoms::delete_atoms_node() {
         [&](vector<string> handles) { db_->delete_atoms(handles); },
         BATCH_SIZE);
 }
-void DeleteAtoms::delete_atoms_link() {
+void DeleteAtoms::delete_atoms_link(string type) {
     run_benchmark(
         "delete_atoms[link]",
         [&](int i) -> vector<string> {
             auto link_schema = LinkSchema(contains_links_query);
-            auto handle_set = db_->query_for_pattern(link_schema);
+            shared_ptr<atomdb_api_types::HandleSet> handle_set;
+            if (type == "mork") {
+                handle_set = dynamic_pointer_cast<MorkDB>(db_)->query_for_pattern_base(link_schema);
+            } else {
+                handle_set = db_->query_for_pattern(link_schema);
+            }
             size_t max_count = max<size_t>(BATCH_SIZE, MAX_COUNT);
             return get_random_link_handle(handle_set, max_count, BATCH_SIZE);
         },

--- a/src/tests/benchmark/atomdb/atomdb_operations.h
+++ b/src/tests/benchmark/atomdb/atomdb_operations.h
@@ -65,18 +65,18 @@ class DeleteAtom : public AtomDBRunner<DeleteAtom> {
    public:
     using AtomDBRunner::AtomDBRunner;
 
-    void delete_node();
-    void delete_link();
-    void delete_atom_node();
-    void delete_atom_link();
+    void delete_node(string type);
+    void delete_link(string type);
+    void delete_atom_node(string type);
+    void delete_atom_link(string type);
 };
 
 class DeleteAtoms : public AtomDBRunner<DeleteAtoms> {
    public:
     using AtomDBRunner::AtomDBRunner;
 
-    void delete_nodes();
-    void delete_links();
-    void delete_atoms_node();
-    void delete_atoms_link();
+    void delete_nodes(string type);
+    void delete_links(string type);
+    void delete_atoms_node(string type);
+    void delete_atoms_link(string type);
 };

--- a/src/tests/benchmark/atomdb/atomdb_runner.h
+++ b/src/tests/benchmark/atomdb/atomdb_runner.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "AtomDB.h"
+#include "MorkDB.h"
 #include "atomdb_utils.h"
 
 using namespace std;


### PR DESCRIPTION
Adds a new public method, `query_for_pattern_base`, to the `MorkDB` class.

This method allows callers to explicitly invoke the original `RedisMongoDB::query_for_pattern` implementation, bypassing the overridden version in `MorkDB`.