### PR TITLE
[#649] Implements a MeTTa parser on top of a lexer previously implemented in #652 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,3 +13,4 @@
 [#544] Add benchmark tests for AtomDB
 [#581] Implementation of remote fitness evaluation in Query Evolution
 [#589] Added optional parameter in PM queries to adda a mapping handle-->metta in QAs delivered to caller
+[#649] Implemented a lexer and a parser for metta input

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -24,9 +24,11 @@ using namespace std;
 // --------------------------------------------------------------------------------
 // Public methods
 
-void Utils::error(string msg) {
+void Utils::error(string msg, bool throw_flag) {
     LOG_ERROR(msg);
-    throw runtime_error(msg);
+    if (throw_flag) {
+        throw runtime_error(msg);
+    }
 }
 
 bool Utils::flip_coin(double true_probability) {

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -49,7 +49,7 @@ class Utils {
     Utils() {}
     ~Utils() {}
 
-    static void error(string msg);
+    static void error(string msg, bool throw_flag = true);
     static bool flip_coin(double true_probability = 0.5);
     static void sleep(unsigned int milliseconds = 100);
     static string get_environment(string const& key);

--- a/src/metta/BUILD
+++ b/src/metta/BUILD
@@ -9,6 +9,8 @@ cc_library(
     includes = ["."],
     deps = [
         ":metta_lexer",
+        ":metta_parser",
+        ":parser_actions",
     ],
 )
 
@@ -23,6 +25,34 @@ cc_library(
         "MettaLexer.h",
         "MettaTokens.h",
         "Token.h",
+    ],
+    includes = ["."],
+    deps = [
+        "//commons:commons_lib",
+    ],
+)
+
+cc_library(
+    name = "metta_parser",
+    srcs = [
+        "MettaParser.cc",
+    ],
+    hdrs = [
+        "MettaParser.h",
+    ],
+    includes = ["."],
+    deps = [
+        "//commons:commons_lib",
+    ],
+)
+
+cc_library(
+    name = "parser_actions",
+    srcs = [
+        "ParserActions.cc",
+    ],
+    hdrs = [
+        "ParserActions.h",
     ],
     includes = ["."],
     deps = [

--- a/src/metta/MettaLexer.h
+++ b/src/metta/MettaLexer.h
@@ -69,6 +69,8 @@ class MettaLexer {
      */
     unique_ptr<Token> next();
 
+    unsigned int line_number;
+
    private:
     void _init(unsigned int input_buffer_size);
     void _attach_string(const string& metta_string);
@@ -86,7 +88,6 @@ class MettaLexer {
     bool file_input_flag;
     unsigned int reading_cursor;
     unsigned int writing_cursor;
-    unsigned int line_number;
     queue<string> attached_strings;
     queue<string> attached_file_names;
     map<string, long> current_offset;

--- a/src/metta/MettaParser.cc
+++ b/src/metta/MettaParser.cc
@@ -1,0 +1,97 @@
+#include <stack>
+
+#include "MettaParser.h"
+#include "MettaTokens.h"
+#include "Utils.h"
+
+using namespace metta;
+using namespace commons;
+
+// -------------------------------------------------------------------------------------------------
+// Constructors, destructors and initializers
+
+MettaParser::MettaParser(shared_ptr<MettaLexer> lexer, shared_ptr<ParserActions> parser_actions) {
+    this->lexer = lexer;
+    _init(parser_actions);
+}
+
+MettaParser::MettaParser(const string& metta_string, shared_ptr<ParserActions> parser_actions) {
+    this->lexer = make_shared<MettaLexer>(metta_string);
+    _init(parser_actions);
+}
+
+void MettaParser::_init(shared_ptr<ParserActions> parser_actions) {
+    this->actions = parser_actions;
+}
+
+MettaParser::~MettaParser() {
+}
+
+// -------------------------------------------------------------------------------------------------
+// Public methods
+
+bool MettaParser::parse(bool throw_on_parse_error) {
+    stack<unique_ptr<Token>> token_stack;
+    unique_ptr<Token> token;
+    while ((token = this->lexer->next()) != nullptr) {
+        if (token->type == MettaTokens::OPEN_PARENTHESIS) {
+            token_stack.push(move(token));
+        } else if (token->type == MettaTokens::CLOSE_PARENTHESIS) {
+            while ((token_stack.size() > 0) && (token_stack.top()->type != MettaTokens::OPEN_PARENTHESIS)) {
+                token_stack.pop();
+            }
+            if (token_stack.size() == 0) {
+                _error(throw_on_parse_error, "Unmached ')'", token->text, token->type);
+                return true;
+            }
+            token_stack.pop();
+            this->actions->expression(token_stack.size() == 0);
+        } else if (token->type == MettaTokens::SYMBOL) {
+            this->actions->symbol(token->text);
+            token_stack.push(move(token));
+        } else if (token->type == MettaTokens::VARIABLE) {
+            this->actions->variable(token->text);
+            token_stack.push(move(token));
+        } else if (token->type == MettaTokens::STRING_LITERAL) {
+            this->actions->literal(token->text);
+            token_stack.push(move(token));
+        } else if (token->type == MettaTokens::INTEGER_LITERAL) {
+            this->actions->literal(Utils::string_to_int(token->text));
+            token_stack.push(move(token));
+        } else if (token->type == MettaTokens::FLOAT_LITERAL) {
+            this->actions->literal(Utils::string_to_float(token->text));
+            token_stack.push(move(token));
+        } else {
+            _error(throw_on_parse_error, "Unexpected token", token->text, token->type);
+        }
+    }
+    while (token_stack.size() > 0) {
+        token = move(token_stack.top());
+        token_stack.pop();
+        if ((token->type == MettaTokens::OPEN_PARENTHESIS) || (token->type == MettaTokens::CLOSE_PARENTHESIS)) {
+            _error(throw_on_parse_error, "Invalid remaining '(' or ')' tokens after matching ()'s", token->text, token->type);
+            return true;
+        }
+    }
+    return false;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Private methods
+
+void MettaParser::_error(bool throw_flag, const string& error_message, const string& token_text, unsigned char token_type) {
+
+    static map<unsigned char, string> token_name;
+    token_name[1] = "OPEN_PARENTHESIS";
+    token_name[2] = "CLOSE_PARENTHESIS";
+    token_name[64] = "SYMBOL";
+    token_name[129] = "STRING_LITERAL";
+    token_name[130] = "INTEGER_LITERAL";
+    token_name[131] = "FLOAT_LITERAL";
+    token_name[192] = "VARIABLE";
+
+    string prefix = "MettaParser error in line " + std::to_string(this->lexer->line_number) +
+                    " near <" + token_text + "> (" + token_name[token_type] + ")";
+    Utils::error(prefix + " - " + error_message, throw_flag);
+}
+

--- a/src/metta/MettaParser.cc
+++ b/src/metta/MettaParser.cc
@@ -1,6 +1,7 @@
+#include "MettaParser.h"
+
 #include <stack>
 
-#include "MettaParser.h"
 #include "MettaTokens.h"
 #include "Utils.h"
 
@@ -20,12 +21,9 @@ MettaParser::MettaParser(const string& metta_string, shared_ptr<ParserActions> p
     _init(parser_actions);
 }
 
-void MettaParser::_init(shared_ptr<ParserActions> parser_actions) {
-    this->actions = parser_actions;
-}
+void MettaParser::_init(shared_ptr<ParserActions> parser_actions) { this->actions = parser_actions; }
 
-MettaParser::~MettaParser() {
-}
+MettaParser::~MettaParser() {}
 
 // -------------------------------------------------------------------------------------------------
 // Public methods
@@ -37,7 +35,8 @@ bool MettaParser::parse(bool throw_on_parse_error) {
         if (token->type == MettaTokens::OPEN_PARENTHESIS) {
             token_stack.push(move(token));
         } else if (token->type == MettaTokens::CLOSE_PARENTHESIS) {
-            while ((token_stack.size() > 0) && (token_stack.top()->type != MettaTokens::OPEN_PARENTHESIS)) {
+            while ((token_stack.size() > 0) &&
+                   (token_stack.top()->type != MettaTokens::OPEN_PARENTHESIS)) {
                 token_stack.pop();
             }
             if (token_stack.size() == 0) {
@@ -68,8 +67,12 @@ bool MettaParser::parse(bool throw_on_parse_error) {
     while (token_stack.size() > 0) {
         token = move(token_stack.top());
         token_stack.pop();
-        if ((token->type == MettaTokens::OPEN_PARENTHESIS) || (token->type == MettaTokens::CLOSE_PARENTHESIS)) {
-            _error(throw_on_parse_error, "Invalid remaining '(' or ')' tokens after matching ()'s", token->text, token->type);
+        if ((token->type == MettaTokens::OPEN_PARENTHESIS) ||
+            (token->type == MettaTokens::CLOSE_PARENTHESIS)) {
+            _error(throw_on_parse_error,
+                   "Invalid remaining '(' or ')' tokens after matching ()'s",
+                   token->text,
+                   token->type);
             return true;
         }
     }
@@ -79,8 +82,10 @@ bool MettaParser::parse(bool throw_on_parse_error) {
 // -------------------------------------------------------------------------------------------------
 // Private methods
 
-void MettaParser::_error(bool throw_flag, const string& error_message, const string& token_text, unsigned char token_type) {
-
+void MettaParser::_error(bool throw_flag,
+                         const string& error_message,
+                         const string& token_text,
+                         unsigned char token_type) {
     static map<unsigned char, string> token_name;
     token_name[1] = "OPEN_PARENTHESIS";
     token_name[2] = "CLOSE_PARENTHESIS";
@@ -90,8 +95,7 @@ void MettaParser::_error(bool throw_flag, const string& error_message, const str
     token_name[131] = "FLOAT_LITERAL";
     token_name[192] = "VARIABLE";
 
-    string prefix = "MettaParser error in line " + std::to_string(this->lexer->line_number) +
-                    " near <" + token_text + "> (" + token_name[token_type] + ")";
+    string prefix = "MettaParser error in line " + std::to_string(this->lexer->line_number) + " near <" +
+                    token_text + "> (" + token_name[token_type] + ")";
     Utils::error(prefix + " - " + error_message, throw_flag);
 }
-

--- a/src/metta/MettaParser.h
+++ b/src/metta/MettaParser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+
 #include "MettaLexer.h"
 #include "ParserActions.h"
 
@@ -19,9 +20,7 @@ namespace metta {
  * use the constructor that expects a MettaLexer instead.
  */
 class MettaParser {
-
-public:
-
+   public:
     /**
      * Basic constructor which expects a single MeTTa string to be parsed.
      *
@@ -55,13 +54,15 @@ public:
      */
     bool parse(bool throw_on_parse_error = true);
 
-private:
-
+   private:
     void _init(shared_ptr<ParserActions> parser_actions);
-    void _error(bool throw_flag, const string& error_message, const string& token_text, unsigned char token_type);
+    void _error(bool throw_flag,
+                const string& error_message,
+                const string& token_text,
+                unsigned char token_type);
 
     shared_ptr<MettaLexer> lexer;
     shared_ptr<ParserActions> actions;
 };
 
-} // namespace metta
+}  // namespace metta

--- a/src/metta/MettaParser.h
+++ b/src/metta/MettaParser.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <memory>
+#include "MettaLexer.h"
+#include "ParserActions.h"
+
+using namespace std;
+
+namespace metta {
+
+/**
+ * A configurable parser of MeTTa input. It's configurable in the sense that the actual
+ * parser actions (i.e. the methods called as the elements of the MeTTa syntax are scanned
+ * and parsed) can be extended and changed to fit different needs.
+ *
+ * The parser can work on a plain string or on some more complex inputs (e.g. a file,
+ * a list of strings or a list of files). The simpler way to use it is just to use the constructor
+ * whi9ch expects a MeTTa string. To parse file(s) or more than one string at once, one should
+ * use the constructor that expects a MettaLexer instead.
+ */
+class MettaParser {
+
+public:
+
+    /**
+     * Basic constructor which expects a single MeTTa string to be parsed.
+     *
+     * @param metta_string Parser input.
+     * @param parser_actions Object that is called back as elements are parsed from the input.
+     */
+    MettaParser(const string& metta_string, shared_ptr<ParserActions> parser_actions = nullptr);
+
+    /**
+     * Constructor which can be used to parse more complex entries such as files, list of strings
+     * or list of files.
+     *
+     * @param lexer MettaLexer object initialized according to the input to be used.
+     * @param parser_actions Object that is called back as elements are parsed from the input.
+     */
+    MettaParser(shared_ptr<MettaLexer> lexer, shared_ptr<ParserActions> parser_actions = nullptr);
+
+    /**
+     * Destructor.
+     */
+    ~MettaParser();
+
+    /**
+     * Method used to actually parse the input. A successful parse will return 'false'. If any
+     * syntax or lexer error occur, the method returns 'true'.
+     *
+     * @param throw_on_parse_error When true, syntax or lexer errors will throw an exception. If
+     * this flag is false, errors will still be logged using LOG_ERROR but no exceptions will be thrown.
+     * The success of the parse can only be determined by the method's return value.
+     * @return False if parsing completed whitout any errors. True otherwise.
+     */
+    bool parse(bool throw_on_parse_error = true);
+
+private:
+
+    void _init(shared_ptr<ParserActions> parser_actions);
+    void _error(bool throw_flag, const string& error_message, const string& token_text, unsigned char token_type);
+
+    shared_ptr<MettaLexer> lexer;
+    shared_ptr<ParserActions> actions;
+};
+
+} // namespace metta

--- a/src/metta/ParserActions.cc
+++ b/src/metta/ParserActions.cc
@@ -1,0 +1,39 @@
+#include "ParserActions.h"
+
+#define LOG_LEVEL NORMAL_LEVEL
+#include "Logger.h"
+
+using namespace metta;
+
+// -------------------------------------------------------------------------------------------------
+// Public methods
+
+ParserActions::ParserActions() {
+}
+
+ParserActions::~ParserActions() {
+}
+
+void ParserActions::symbol(const string& name) {
+    LOG_DEBUG("SYMBOL: <" + name + ">");
+}
+
+void ParserActions::variable(const string& value) {
+    LOG_DEBUG("VARIABLE: <" + value + ">");
+}
+
+void ParserActions::literal(const string& value) {
+    LOG_DEBUG("STRING_LITERAL: <" + value + ">");
+}
+
+void ParserActions::literal(int value) {
+    LOG_DEBUG("INTEGER_LITERAL: <" + std::to_string(value) + ">");
+}
+
+void ParserActions::literal(float value) {
+    LOG_DEBUG("FLOAT_LITERAL: <" + std::to_string(value) + ">");
+}
+
+void ParserActions::expression(bool toplevel) {
+    LOG_DEBUG(((toplevel ? "TOPLEVEL " : "") + string("EXPRESSION")));
+}

--- a/src/metta/ParserActions.cc
+++ b/src/metta/ParserActions.cc
@@ -8,31 +8,19 @@ using namespace metta;
 // -------------------------------------------------------------------------------------------------
 // Public methods
 
-ParserActions::ParserActions() {
-}
+ParserActions::ParserActions() {}
 
-ParserActions::~ParserActions() {
-}
+ParserActions::~ParserActions() {}
 
-void ParserActions::symbol(const string& name) {
-    LOG_DEBUG("SYMBOL: <" + name + ">");
-}
+void ParserActions::symbol(const string& name) { LOG_DEBUG("SYMBOL: <" + name + ">"); }
 
-void ParserActions::variable(const string& value) {
-    LOG_DEBUG("VARIABLE: <" + value + ">");
-}
+void ParserActions::variable(const string& value) { LOG_DEBUG("VARIABLE: <" + value + ">"); }
 
-void ParserActions::literal(const string& value) {
-    LOG_DEBUG("STRING_LITERAL: <" + value + ">");
-}
+void ParserActions::literal(const string& value) { LOG_DEBUG("STRING_LITERAL: <" + value + ">"); }
 
-void ParserActions::literal(int value) {
-    LOG_DEBUG("INTEGER_LITERAL: <" + std::to_string(value) + ">");
-}
+void ParserActions::literal(int value) { LOG_DEBUG("INTEGER_LITERAL: <" + std::to_string(value) + ">"); }
 
-void ParserActions::literal(float value) {
-    LOG_DEBUG("FLOAT_LITERAL: <" + std::to_string(value) + ">");
-}
+void ParserActions::literal(float value) { LOG_DEBUG("FLOAT_LITERAL: <" + std::to_string(value) + ">"); }
 
 void ParserActions::expression(bool toplevel) {
     LOG_DEBUG(((toplevel ? "TOPLEVEL " : "") + string("EXPRESSION")));

--- a/src/metta/ParserActions.h
+++ b/src/metta/ParserActions.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <memory>
+#include <stack>
+
+#include "Token.h"
+
+using namespace std;
+
+namespace metta {
+
+/**
+ * This class holds the actions which are supposed to be taken during the parsing
+ * os a MeTTa input. Default behavior is just to log which methods are being called.
+ *
+ * This class is supposed to be extended in order to provide real actions for the parser
+ * but these concrete implementations depends on the way the parser is being used
+ * (e.g. building LinkSchema or reading a file to populate AtomDB). Such concrete
+ * subclasses are supposed to be provided in the package using the parser.
+ */
+class ParserActions {
+   public:
+    ParserActions();
+    virtual ~ParserActions();
+
+    /**
+     * Action called when a symbol is parsed.
+     */
+    virtual void symbol(const string& name);
+
+    /**
+     * Action called when a variable is parsed.
+     */
+    virtual void variable(const string& value);
+
+    /**
+     * Action called when a string literal is parsed.
+     */
+    virtual void literal(const string& value);
+
+    /**
+     * Action called when a integer literal is parsed.
+     */
+    virtual void literal(int value);
+
+    /**
+     * Action called when a float literal is parsed.
+     */
+    virtual void literal(float value);
+
+    /**
+     * Action called when an expression is fully parsed (i.e. after the corresponding ')' token).
+     *
+     * @param toplevel A flag to indicate whether the expression is a toplevel onr or not.
+     */
+    virtual void expression(bool toplevel);
+};
+
+}  // namespace metta

--- a/src/metta/Token.cc
+++ b/src/metta/Token.cc
@@ -6,35 +6,35 @@ using namespace metta;
 // Public methods
 
 Token::Token() {
-    this->value = 0;
+    this->type = 0;
     this->text = "";
 }
 
-Token::Token(unsigned char value) {
-    this->value = value;
+Token::Token(unsigned char type) {
+    this->type = type;
     this->text = "";
 }
 
 Token::Token(const Token& other) {
-    this->value = other.value;
+    this->type = other.type;
     this->text = other.text;
 }
 
-Token::Token(unsigned char value, const string& text) {
-    this->value = value;
+Token::Token(unsigned char type, const string& text) {
+    this->type = type;
     this->text = text;
 }
 
 Token::~Token() {}
 
 Token& Token::operator=(const Token& other) {
-    this->value = other.value;
+    this->type = other.type;
     this->text = other.text;
     return *this;
 }
 
 bool Token::operator==(const Token& other) {
-    return (this->value == other.value) && (this->text == other.text);
+    return (this->type == other.type) && (this->text == other.text);
 }
 
 bool Token::operator!=(const Token& other) { return !(*this == other); }

--- a/src/metta/Token.h
+++ b/src/metta/Token.h
@@ -21,7 +21,7 @@ class Token {
     bool operator==(const Token& other);
     bool operator!=(const Token& other);
 
-    unsigned char value;
+    unsigned char type;
     string text;
 
    private:

--- a/src/tests/cpp/metta_parser_test.cc
+++ b/src/tests/cpp/metta_parser_test.cc
@@ -28,8 +28,8 @@ static void check_tokens(const string& tag,
     if (expected_tokens.size() == tokens->size()) {
         for (unsigned int i = 0; i < tokens->size(); i++) {
             LOG_INFO(token_name[expected_tokens[i].first] + "<" + expected_tokens[i].second + "> " +
-                     token_name[(*tokens)[i]->value] + " <" + (*tokens)[i]->text + ">");
-            EXPECT_EQ(expected_tokens[i].first, (*tokens)[i]->value);
+                     token_name[(*tokens)[i]->type] + " <" + (*tokens)[i]->text + ">");
+            EXPECT_EQ(expected_tokens[i].first, (*tokens)[i]->type);
             EXPECT_EQ(expected_tokens[i].second, (*tokens)[i]->text);
         }
     }

--- a/src/tests/cpp/metta_parser_test.cc
+++ b/src/tests/cpp/metta_parser_test.cc
@@ -11,7 +11,7 @@
 using namespace metta;
 
 class TestActions : public ParserActions {
-    public:
+   public:
     vector<string> actions;
     TestActions() {}
     ~TestActions() {}
@@ -80,11 +80,15 @@ static void check_string(const string& tag,
     check_tokens(tag, &tokens, expected_tokens);
 }
 
-static void check_parse(const string& tag, const string& metta_str, bool syntax_ok, const vector<string>& expected) {
+static void check_parse(const string& tag,
+                        const string& metta_str,
+                        bool syntax_ok,
+                        const vector<string>& expected) {
     LOG_INFO("--------------------------------------------------------------------------------");
     LOG_INFO("Test case " + tag);
 
-    shared_ptr<TestActions> broker = make_shared<TestActions>();;
+    shared_ptr<TestActions> broker = make_shared<TestActions>();
+    ;
     MettaParser parser(metta_str, broker);
     if (syntax_ok) {
         EXPECT_FALSE(parser.parse(false));
@@ -94,7 +98,7 @@ static void check_parse(const string& tag, const string& metta_str, bool syntax_
     if (expected.size() > 0) {
         EXPECT_EQ(expected.size(), broker->actions.size());
         for (unsigned int i = 0; i < expected.size(); i++) {
-            LOG_INFO(expected[i] + " - " +  broker->actions[i]);
+            LOG_INFO(expected[i] + " - " + broker->actions[i]);
             EXPECT_EQ(expected[i], broker->actions[i]);
         }
     }
@@ -283,59 +287,41 @@ TEST(MettaParser, basics) {
     check_parse("06", "-1.0", true, {"FLOAT_LITERAL " + std::to_string(-1.0)});
     check_parse("07", "$a", true, {"VARIABLE a"});
     check_parse("08",
-                 "($a 1)",
-                 true,
-                 {
-                     "VARIABLE a",
-                     "INTEGER_LITERAL 1",
-                     "TOPLEVEL_EXPRESSION",
-                 });
+                "($a 1)",
+                true,
+                {
+                    "VARIABLE a",
+                    "INTEGER_LITERAL 1",
+                    "TOPLEVEL_EXPRESSION",
+                });
     check_parse("09",
-                 "(($v1 n1) $v2 n2)",
-                 true,
-                 {
-                     "VARIABLE v1",
-                     "SYMBOL n1",
-                     "EXPRESSION",
-                     "VARIABLE v2",
-                     "SYMBOL n2",
-                     "TOPLEVEL_EXPRESSION",
-                 });
+                "(($v1 n1) $v2 n2)",
+                true,
+                {
+                    "VARIABLE v1",
+                    "SYMBOL n1",
+                    "EXPRESSION",
+                    "VARIABLE v2",
+                    "SYMBOL n2",
+                    "TOPLEVEL_EXPRESSION",
+                });
     check_parse("10",
-                 "($a \"blah\\\"bleh\\\"blih\\\"\")",
-                 true,
-                 {
-                     "VARIABLE a",
-                     "STRING_LITERAL \"blah\\\"bleh\\\"blih\\\"\"",
-                     "TOPLEVEL_EXPRESSION",
-                 });
-    check_parse("11",
-                 "(($v1 n1) (2) $v2 (n8) ($v4) 1 n2 (n4 n5 (n6 (n7 $v3)))) (n10 n11)",
-                 true,
-                 {
-                     "VARIABLE v1",
-                     "SYMBOL n1",
-                     "EXPRESSION",
-                     "INTEGER_LITERAL 2",
-                     "EXPRESSION",
-                     "VARIABLE v2",
-                     "SYMBOL n8",
-                     "EXPRESSION",
-                     "VARIABLE v4",
-                     "EXPRESSION",
-                     "INTEGER_LITERAL 1",
-                     "SYMBOL n2",
-                     "SYMBOL n4",
-                     "SYMBOL n5",
-                     "SYMBOL n6",
-                     "SYMBOL n7",
-                     "VARIABLE v3",
-                     "EXPRESSION",
-                     "EXPRESSION",
-                     "EXPRESSION",
-                     "TOPLEVEL_EXPRESSION",
-                     "SYMBOL n10",
-                     "SYMBOL n11",
-                     "TOPLEVEL_EXPRESSION",
-                 });
+                "($a \"blah\\\"bleh\\\"blih\\\"\")",
+                true,
+                {
+                    "VARIABLE a",
+                    "STRING_LITERAL \"blah\\\"bleh\\\"blih\\\"\"",
+                    "TOPLEVEL_EXPRESSION",
+                });
+    check_parse(
+        "11",
+        "(($v1 n1) (2) $v2 (n8) ($v4) 1 n2 (n4 n5 (n6 (n7 $v3)))) (n10 n11)",
+        true,
+        {
+            "VARIABLE v1",         "SYMBOL n1",   "EXPRESSION", "INTEGER_LITERAL 2",   "EXPRESSION",
+            "VARIABLE v2",         "SYMBOL n8",   "EXPRESSION", "VARIABLE v4",         "EXPRESSION",
+            "INTEGER_LITERAL 1",   "SYMBOL n2",   "SYMBOL n4",  "SYMBOL n5",           "SYMBOL n6",
+            "SYMBOL n7",           "VARIABLE v3", "EXPRESSION", "EXPRESSION",          "EXPRESSION",
+            "TOPLEVEL_EXPRESSION", "SYMBOL n10",  "SYMBOL n11", "TOPLEVEL_EXPRESSION",
+        });
 }

--- a/src/tests/cpp/metta_parser_test.cc
+++ b/src/tests/cpp/metta_parser_test.cc
@@ -1,4 +1,5 @@
 #include "MettaLexer.h"
+#include "MettaParser.h"
 #include "MettaTokens.h"
 #include "Utils.h"
 #include "gtest/gtest.h"
@@ -8,6 +9,37 @@
 #include "Logger.h"
 
 using namespace metta;
+
+class TestActions : public ParserActions {
+    public:
+    vector<string> actions;
+    TestActions() {}
+    ~TestActions() {}
+    void symbol(const string& name) override {
+        ParserActions::symbol(name);
+        actions.push_back("SYMBOL " + name);
+    }
+    void variable(const string& value) override {
+        ParserActions::variable(value);
+        actions.push_back("VARIABLE " + value);
+    }
+    void literal(const string& value) override {
+        ParserActions::literal(value);
+        actions.push_back("STRING_LITERAL " + value);
+    }
+    void literal(int value) override {
+        ParserActions::literal(value);
+        actions.push_back("INTEGER_LITERAL " + std::to_string(value));
+    }
+    void literal(float value) override {
+        ParserActions::literal(value);
+        actions.push_back("FLOAT_LITERAL " + std::to_string(value));
+    }
+    void expression(bool toplevel) override {
+        ParserActions::expression(toplevel);
+        actions.push_back((toplevel ? "TOPLEVEL_" : "") + string("EXPRESSION"));
+    }
+};
 
 static void check_tokens(const string& tag,
                          vector<unique_ptr<Token>>* tokens,
@@ -46,6 +78,26 @@ static void check_string(const string& tag,
     }
 
     check_tokens(tag, &tokens, expected_tokens);
+}
+
+static void check_parse(const string& tag, const string& metta_str, bool syntax_ok, const vector<string>& expected) {
+    LOG_INFO("--------------------------------------------------------------------------------");
+    LOG_INFO("Test case " + tag);
+
+    shared_ptr<TestActions> broker = make_shared<TestActions>();;
+    MettaParser parser(metta_str, broker);
+    if (syntax_ok) {
+        EXPECT_FALSE(parser.parse(false));
+    } else {
+        EXPECT_TRUE(parser.parse(false));
+    }
+    if (expected.size() > 0) {
+        EXPECT_EQ(expected.size(), broker->actions.size());
+        for (unsigned int i = 0; i < expected.size(); i++) {
+            LOG_INFO(expected[i] + " - " +  broker->actions[i]);
+            EXPECT_EQ(expected[i], broker->actions[i]);
+        }
+    }
 }
 
 TEST(MettaTokens, basics) {
@@ -99,10 +151,10 @@ TEST(MettaLexer, string_input) {
     check_string("02", "a", {make_pair(MettaTokens::SYMBOL, "a")});
     check_string("03", "\"a\"", {make_pair(MettaTokens::STRING_LITERAL, "\"a\"")});
     check_string("04", "1", {make_pair(MettaTokens::INTEGER_LITERAL, "1")});
-    check_string("04", "1.0", {make_pair(MettaTokens::FLOAT_LITERAL, "1.0")});
-    check_string("05", "-1.0", {make_pair(MettaTokens::FLOAT_LITERAL, "-1.0")});
-    check_string("06", "$a", {make_pair(MettaTokens::VARIABLE, "a")});
-    check_string("07",
+    check_string("05", "1.0", {make_pair(MettaTokens::FLOAT_LITERAL, "1.0")});
+    check_string("06", "-1.0", {make_pair(MettaTokens::FLOAT_LITERAL, "-1.0")});
+    check_string("07", "$a", {make_pair(MettaTokens::VARIABLE, "a")});
+    check_string("08",
                  "($a 1)",
                  {
                      make_pair(MettaTokens::OPEN_PARENTHESIS, "("),
@@ -110,7 +162,7 @@ TEST(MettaLexer, string_input) {
                      make_pair(MettaTokens::INTEGER_LITERAL, "1"),
                      make_pair(MettaTokens::CLOSE_PARENTHESIS, ")"),
                  });
-    check_string("08",
+    check_string("09",
                  "(($v1 n1) $v2 n2)",
                  {
                      make_pair(MettaTokens::OPEN_PARENTHESIS, "("),
@@ -122,7 +174,7 @@ TEST(MettaLexer, string_input) {
                      make_pair(MettaTokens::SYMBOL, "n2"),
                      make_pair(MettaTokens::CLOSE_PARENTHESIS, ")"),
                  });
-    check_string("09",
+    check_string("10",
                  "($a \"blah\\\"bleh\\\"blih\\\"\")",
                  {
                      make_pair(MettaTokens::OPEN_PARENTHESIS, "("),
@@ -219,5 +271,71 @@ TEST(MettaLexer, file_large) {
                      make_pair(MettaTokens::VARIABLE, "v2"),
                      make_pair(MettaTokens::CLOSE_PARENTHESIS, ")"),
                      make_pair(MettaTokens::CLOSE_PARENTHESIS, ")"),
+                 });
+}
+
+TEST(MettaParser, basics) {
+    check_parse("01", "", true, {});
+    check_parse("02", "a", true, {"SYMBOL a"});
+    check_parse("03", "\"a\"", true, {"STRING_LITERAL \"a\""});
+    check_parse("04", "1", true, {"INTEGER_LITERAL 1"});
+    check_parse("05", "1.0", true, {"FLOAT_LITERAL " + std::to_string(1.0)});
+    check_parse("06", "-1.0", true, {"FLOAT_LITERAL " + std::to_string(-1.0)});
+    check_parse("07", "$a", true, {"VARIABLE a"});
+    check_parse("08",
+                 "($a 1)",
+                 true,
+                 {
+                     "VARIABLE a",
+                     "INTEGER_LITERAL 1",
+                     "TOPLEVEL_EXPRESSION",
+                 });
+    check_parse("09",
+                 "(($v1 n1) $v2 n2)",
+                 true,
+                 {
+                     "VARIABLE v1",
+                     "SYMBOL n1",
+                     "EXPRESSION",
+                     "VARIABLE v2",
+                     "SYMBOL n2",
+                     "TOPLEVEL_EXPRESSION",
+                 });
+    check_parse("10",
+                 "($a \"blah\\\"bleh\\\"blih\\\"\")",
+                 true,
+                 {
+                     "VARIABLE a",
+                     "STRING_LITERAL \"blah\\\"bleh\\\"blih\\\"\"",
+                     "TOPLEVEL_EXPRESSION",
+                 });
+    check_parse("11",
+                 "(($v1 n1) (2) $v2 (n8) ($v4) 1 n2 (n4 n5 (n6 (n7 $v3)))) (n10 n11)",
+                 true,
+                 {
+                     "VARIABLE v1",
+                     "SYMBOL n1",
+                     "EXPRESSION",
+                     "INTEGER_LITERAL 2",
+                     "EXPRESSION",
+                     "VARIABLE v2",
+                     "SYMBOL n8",
+                     "EXPRESSION",
+                     "VARIABLE v4",
+                     "EXPRESSION",
+                     "INTEGER_LITERAL 1",
+                     "SYMBOL n2",
+                     "SYMBOL n4",
+                     "SYMBOL n5",
+                     "SYMBOL n6",
+                     "SYMBOL n7",
+                     "VARIABLE v3",
+                     "EXPRESSION",
+                     "EXPRESSION",
+                     "EXPRESSION",
+                     "TOPLEVEL_EXPRESSION",
+                     "SYMBOL n10",
+                     "SYMBOL n11",
+                     "TOPLEVEL_EXPRESSION",
                  });
 }


### PR DESCRIPTION
This is WIP towards #649

We are still missing a concrete class for ParserActions and its actual integration to build LinkSchema when a LinkTemplate is built. This will be implemented in a forthcomming PR.