### PR TITLE
[#637][HE Client] Add `InferenceProxy`

### DIFF
--- a/3rd_party_slots/rust_metta_bus_client/Cargo.lock
+++ b/3rd_party_slots/rust_metta_bus_client/Cargo.lock
@@ -578,7 +578,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metta-bus-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "env_logger",
  "hyperon-atom",

--- a/3rd_party_slots/rust_metta_bus_client/Cargo.lock
+++ b/3rd_party_slots/rust_metta_bus_client/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "hyperon-atom"
 version = "0.2.6"
-source = "git+https://github.com/trueagi-io/hyperon-experimental.git#ec8b7c65d6edad28058f90c6be71708f5e910148"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#bd27e25a08447085a15e3ef7448693da11e0e1eb"
 dependencies = [
  "bitset",
  "hyperon-common",
@@ -474,7 +474,7 @@ dependencies = [
 [[package]]
 name = "hyperon-common"
 version = "0.2.6"
-source = "git+https://github.com/trueagi-io/hyperon-experimental.git#ec8b7c65d6edad28058f90c6be71708f5e910148"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#bd27e25a08447085a15e3ef7448693da11e0e1eb"
 dependencies = [
  "itertools 0.13.0",
  "log",
@@ -483,7 +483,7 @@ dependencies = [
 [[package]]
 name = "hyperon-space"
 version = "0.2.6"
-source = "git+https://github.com/trueagi-io/hyperon-experimental.git#ec8b7c65d6edad28058f90c6be71708f5e910148"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#bd27e25a08447085a15e3ef7448693da11e0e1eb"
 dependencies = [
  "bimap",
  "hyperon-atom",

--- a/3rd_party_slots/rust_metta_bus_client/Cargo.toml
+++ b/3rd_party_slots/rust_metta_bus_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metta-bus-client"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/3rd_party_slots/rust_metta_bus_client/src/bus.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/bus.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
-pub static PATTERN_MATCHING_QUERY: &str = "pattern_matching_query";
-pub static QUERY_EVOLUTION: &str = "query_evolution";
+pub static PATTERN_MATCHING_QUERY_CMD: &str = "pattern_matching_query";
+pub static QUERY_EVOLUTION_CMD: &str = "query_evolution";
+pub static LINK_CREATION_CMD: &str = "link_creation";
+pub static INFERENCE_CMD: &str = "inference";
 
 #[derive(Debug, Default, Clone)]
 pub struct Bus {

--- a/3rd_party_slots/rust_metta_bus_client/src/bus.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/bus.rs
@@ -29,6 +29,7 @@ impl Bus {
 		if !self.command_owner.contains_key(&command) {
 			panic!("Bus: command <{command}> is not defined");
 		} else if self.command_owner[&command].is_empty() {
+			log::trace!(target: "das", "Bus::set_ownership(): Adding {command} to bus, owner: {node_id}");
 			self.command_owner.insert(command.to_string(), node_id.to_string());
 		} else if self.command_owner[&command] != node_id {
 			panic!(

--- a/3rd_party_slots/rust_metta_bus_client/src/bus_node.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/bus_node.rs
@@ -61,15 +61,21 @@ impl BusNode {
 
 		let mut count = 0;
 		loop {
+			let proxy = proxy_arc.lock().unwrap();
 			sleep(Duration::from_millis(100));
 
 			count += 1;
 			if count > 200 {
-				log::error!(target: "das", "BusNode::join_network(): Unable to get service list from peer {}", self.peer_id);
+				log::warn!(
+					target: "das",
+					"BusNode::join_network(): Unable to get all services ({}/{}) from peer {}",
+					self.peer_id,
+					self.bus.command_owner.len(),
+					proxy.service_list.len(),
+				);
 				break;
 			}
 
-			let proxy = proxy_arc.lock().unwrap();
 			for (command, owner) in proxy.service_list.iter() {
 				log::trace!(target: "das", "BusNode::join_network(): Adding {command} to bus, owner: {owner}");
 				self.bus.set_ownership(command.clone(), owner);

--- a/3rd_party_slots/rust_metta_bus_client/src/bus_node.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/bus_node.rs
@@ -79,7 +79,6 @@ impl BusNode {
 			}
 
 			for (command, owner) in proxy.service_list.iter() {
-				log::trace!(target: "das", "BusNode::join_network(): Adding {command} to bus, owner: {owner}");
 				self.bus.set_ownership(command.clone(), owner);
 			}
 

--- a/3rd_party_slots/rust_metta_bus_client/src/bus_node.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/bus_node.rs
@@ -61,8 +61,9 @@ impl BusNode {
 
 		let mut count = 0;
 		loop {
-			let proxy = proxy_arc.lock().unwrap();
 			sleep(Duration::from_millis(100));
+
+			let proxy = proxy_arc.lock().unwrap();
 
 			count += 1;
 			if count > 200 {
@@ -73,6 +74,7 @@ impl BusNode {
 					self.bus.command_owner.len(),
 					self.peer_id,
 				);
+				drop(proxy);
 				break;
 			}
 
@@ -82,6 +84,7 @@ impl BusNode {
 			}
 
 			if proxy.service_list.len() == self.bus.command_owner.len() {
+				drop(proxy);
 				break;
 			}
 			drop(proxy);

--- a/3rd_party_slots/rust_metta_bus_client/src/bus_node.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/bus_node.rs
@@ -69,9 +69,9 @@ impl BusNode {
 				log::warn!(
 					target: "das",
 					"BusNode::join_network(): Unable to get all services ({}/{}) from peer {}",
-					self.peer_id,
-					self.bus.command_owner.len(),
 					proxy.service_list.len(),
+					self.bus.command_owner.len(),
+					self.peer_id,
 				);
 				break;
 			}

--- a/3rd_party_slots/rust_metta_bus_client/src/helpers/mod.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/helpers/mod.rs
@@ -118,7 +118,8 @@ pub fn map_variables(atom_str: &str) -> HashSet<VariableAtom> {
 	let tokens = split_ignore_quoted(atom_str);
 	for (idx, token) in tokens.iter().enumerate() {
 		if token.starts_with("$") {
-			variables.insert(VariableAtom::parse_name(token).unwrap());
+			let var_name = token.replace("$", "").replace(")", "");
+			variables.insert(VariableAtom::parse_name(&var_name).unwrap());
 		} else if token == "VARIABLE" && idx + 1 < tokens.len() {
 			variables.insert(VariableAtom::new(&tokens[idx + 1]));
 		}

--- a/3rd_party_slots/rust_metta_bus_client/src/helpers/mod.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/helpers/mod.rs
@@ -1,8 +1,8 @@
 pub mod query_answer;
 
-use std::collections::HashMap;
+use std::collections::HashSet;
 
-use hyperon_atom::Atom;
+use hyperon_atom::{Atom, VariableAtom};
 
 use crate::types::{BoxError, MeTTaRunner};
 
@@ -112,15 +112,15 @@ pub fn run_metta_runner(atom: &Atom, metta_runner: &MeTTaRunner) -> Result<Atom,
 	}
 }
 
-pub fn map_variables(atom_str: &str) -> HashMap<String, String> {
-	let mut variables = HashMap::new();
+pub fn map_variables(atom_str: &str) -> HashSet<VariableAtom> {
+	let mut variables = HashSet::new();
 
 	let tokens = split_ignore_quoted(atom_str);
 	for (idx, token) in tokens.iter().enumerate() {
 		if token.starts_with("$") {
-			variables.insert(token.replace("$", ""), "".to_string());
+			variables.insert(VariableAtom::parse_name(token).unwrap());
 		} else if token == "VARIABLE" && idx + 1 < tokens.len() {
-			variables.insert(tokens[idx + 1].clone(), "".to_string());
+			variables.insert(VariableAtom::new(&tokens[idx + 1]));
 		}
 	}
 

--- a/3rd_party_slots/rust_metta_bus_client/src/helpers/query_answer.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/helpers/query_answer.rs
@@ -111,7 +111,7 @@ fn read_metta_expression(token_string: &str, cursor: &mut usize) -> String {
 	if close_char != b' ' && *cursor < bytes.len() {
 		*cursor += 1;
 	}
-	String::from_utf8(bytes[start..end].to_vec()).unwrap_or_default()
+	String::from_utf8(bytes[start..end].to_vec()).unwrap_or_default().trim().to_string()
 }
 
 pub fn parse_query_answer(query_answer_str: &str, populate_metta_mapping: bool) -> Bindings {
@@ -126,8 +126,8 @@ pub fn parse_query_answer(query_answer_str: &str, populate_metta_mapping: bool) 
 	for (key, value) in query_answer.assignment.iter() {
 		if populate_metta_mapping {
 			if let Some(metta_expression) = query_answer.metta_expression.get(value) {
-				let atom_value = Atom::sym(metta_expression.trim().to_string());
-				bindings = bindings.add_var_binding(VariableAtom::new(key), atom_value).unwrap();
+				let atom = Atom::sym(metta_expression.clone());
+				bindings = bindings.add_var_binding(VariableAtom::new(key), atom).unwrap();
 			}
 		} else {
 			bindings =

--- a/3rd_party_slots/rust_metta_bus_client/src/helpers/query_answer.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/helpers/query_answer.rs
@@ -126,9 +126,8 @@ pub fn parse_query_answer(query_answer_str: &str, populate_metta_mapping: bool) 
 	for (key, value) in query_answer.assignment.iter() {
 		if populate_metta_mapping {
 			if let Some(metta_expression) = query_answer.metta_expression.get(value) {
-				bindings = bindings
-					.add_var_binding(VariableAtom::new(key), Atom::sym(metta_expression.clone()))
-					.unwrap();
+				let atom_value = Atom::sym(metta_expression.trim().to_string());
+				bindings = bindings.add_var_binding(VariableAtom::new(key), atom_value).unwrap();
 			}
 		} else {
 			bindings =

--- a/3rd_party_slots/rust_metta_bus_client/src/inference_proxy.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/inference_proxy.rs
@@ -1,0 +1,122 @@
+use std::sync::{Arc, Mutex};
+
+use hyperon_atom::Atom;
+
+use crate::{
+	base_proxy_query::{BaseQueryProxy, BaseQueryProxyT},
+	bus::INFERENCE_CMD,
+	helpers::split_ignore_quoted,
+	types::BoxError,
+	QueryParams,
+};
+
+pub const PROOF_OF_IMPLICATION_OR_EQUIVALENCE: &str = "PROOF_OF_IMPLICATION_OR_EQUIVALENCE";
+pub const PROOF_OF_IMPLICATION: &str = "PROOF_OF_IMPLICATION";
+pub const PROOF_OF_EQUIVALENCE: &str = "PROOF_OF_EQUIVALENCE";
+
+pub static INFERENCE_PARSER_ERROR_MESSAGE: &str = "INFERENCE query must have (request_type handle1 handle2 max_proof_length) eg:
+(
+	INFERENCE
+	(PROOF_OF_IMPLICATION_OR_EQUIVALENCE cf07db895a5656bfd3652ba565727554 c4d0ef92e7265f9298f8dd6d3ae1e014 1)
+)";
+
+#[derive(Clone)]
+pub struct InferenceParams {
+	pub request_type: String,
+	pub handle1: String,
+	pub handle2: String,
+	pub max_proof_length: u64,
+}
+
+#[derive(Clone)]
+pub struct InferenceProxy {
+	pub base: Arc<Mutex<BaseQueryProxy>>,
+}
+
+impl InferenceProxy {
+	pub fn new(params: &QueryParams, inference_params: &InferenceParams) -> Result<Self, BoxError> {
+		let mut base = BaseQueryProxy::new(INFERENCE_CMD.to_string(), params.clone())?;
+
+		let mut args = vec![];
+		args.extend(base.properties.to_vec());
+		args.push(base.context.clone());
+		// TODO(arturgontijo): Shouldn't be the query length ?!
+		args.push("0".to_string());
+		args.push(inference_params.request_type.clone());
+		args.push(inference_params.handle1.clone());
+		args.push(inference_params.handle2.clone());
+		args.push(inference_params.max_proof_length.to_string());
+		// TODO(arturgontijo): Context (bug) ?!
+		args.push(base.context.clone());
+		base.args = args;
+
+		Ok(InferenceProxy { base: Arc::new(Mutex::new(base)) })
+	}
+
+	pub fn request_types() -> Vec<String> {
+		vec![
+			PROOF_OF_IMPLICATION_OR_EQUIVALENCE.to_string(),
+			PROOF_OF_IMPLICATION.to_string(),
+			PROOF_OF_EQUIVALENCE.to_string(),
+		]
+	}
+}
+
+impl BaseQueryProxyT for InferenceProxy {
+	fn finished(&self) -> bool {
+		self.base.lock().unwrap().finished()
+	}
+
+	fn pop(&mut self) -> Option<String> {
+		self.base.lock().unwrap().pop()
+	}
+
+	fn push(&mut self, query_answer: String) -> Result<(), BoxError> {
+		self.base.lock().unwrap().push(query_answer)
+	}
+
+	fn get_count(&self) -> u64 {
+		self.base.lock().unwrap().get_count()
+	}
+
+	fn abort(&mut self) {
+		self.base.lock().unwrap().abort()
+	}
+
+	fn to_remote_peer(&self, command: String, args: Vec<String>) -> Result<(), BoxError> {
+		self.base.lock().unwrap().to_remote_peer(command, args)
+	}
+
+	fn setup_proxy_node(
+		&mut self, proxy_arc: Arc<Mutex<BaseQueryProxy>>, client_id: Option<String>,
+		server_id: Option<String>,
+	) {
+		self.base.lock().unwrap().setup_proxy_node(proxy_arc, client_id, server_id)
+	}
+
+	fn drop_runtime(&mut self) {
+		self.base.lock().unwrap().drop_runtime()
+	}
+}
+
+pub fn parse_inference_parameters(atom: &Atom) -> Result<Option<InferenceParams>, BoxError> {
+	if let Atom::Expression(exp_atom) = &atom {
+		let children = exp_atom.children();
+		if let Some(Atom::Symbol(s)) = children.first() {
+			if s.name() == "INFERENCE" {
+				if children.len() < 2 {
+					return Err(INFERENCE_PARSER_ERROR_MESSAGE.to_string().into());
+				}
+				let tokens = children[1].to_string().replace("(", "").replace(")", "");
+				let tokens = split_ignore_quoted(&tokens);
+				return Ok(Some(InferenceParams {
+					request_type: tokens[0].clone(),
+					handle1: tokens[1].clone(),
+					handle2: tokens[2].clone(),
+					max_proof_length: tokens[3].parse().unwrap(),
+				}));
+			}
+		}
+	}
+	Ok(None)
+}

--- a/3rd_party_slots/rust_metta_bus_client/src/main.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use hyperon_atom::Atom;
 use metta_bus_client::{
 	extract_query_params, host_id_from_atom, pattern_matching_query,
-	service_bus_singleton::ServiceBusSingleton, types::BoxError,
+	service_bus_singleton::ServiceBusSingleton, types::BoxError, QueryType,
 };
 
 const MAX_QUERY_ANSWERS: u32 = 100;
@@ -72,7 +72,7 @@ fn main() -> Result<(), BoxError> {
 
 	let params = match extract_query_params(
 		Some(context.to_string()),
-		tokens,
+		&QueryType::String(tokens),
 		max_query_answers,
 		unique_assignment,
 		positive_importance,

--- a/3rd_party_slots/rust_metta_bus_client/src/pattern_matching_proxy.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/pattern_matching_proxy.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::{
 	base_proxy_query::{BaseQueryProxy, BaseQueryProxyT},
-	bus::PATTERN_MATCHING_QUERY,
+	bus::PATTERN_MATCHING_QUERY_CMD,
 	types::BoxError,
 	QueryParams,
 };
@@ -14,7 +14,7 @@ pub struct PatternMatchingQueryProxy {
 
 impl PatternMatchingQueryProxy {
 	pub fn new(params: &QueryParams) -> Result<Self, BoxError> {
-		let mut base = BaseQueryProxy::new(PATTERN_MATCHING_QUERY.to_string(), params.clone())?;
+		let mut base = BaseQueryProxy::new(PATTERN_MATCHING_QUERY_CMD.to_string(), params.clone())?;
 
 		let mut args = vec![];
 		args.extend(base.properties.to_vec());

--- a/3rd_party_slots/rust_metta_bus_client/src/query_evolution_proxy.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/query_evolution_proxy.rs
@@ -4,7 +4,7 @@ use hyperon_atom::{matcher::Bindings, Atom};
 
 use crate::{
 	base_proxy_query::{BaseQueryProxy, BaseQueryProxyT},
-	bus::QUERY_EVOLUTION,
+	bus::QUERY_EVOLUTION_CMD,
 	helpers::query_answer::parse_query_answer,
 	properties::{
 		PropertyValue, ELITISM_RATE, MAX_GENERATIONS, POPULATION_SIZE, SELECTION_RATE,
@@ -58,7 +58,7 @@ impl QueryEvolutionProxy {
 	pub fn new(
 		params: &QueryParams, evolution_params: &QueryEvolutionParams,
 	) -> Result<Self, BoxError> {
-		let mut base = BaseQueryProxy::new(QUERY_EVOLUTION.to_string(), params.clone())?;
+		let mut base = BaseQueryProxy::new(QUERY_EVOLUTION_CMD.to_string(), params.clone())?;
 
 		base.properties.insert(
 			POPULATION_SIZE.to_string(),

--- a/3rd_party_slots/rust_metta_bus_client/src/service_bus_singleton.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/service_bus_singleton.rs
@@ -1,7 +1,7 @@
 use std::sync::OnceLock;
 
 use crate::{
-	bus::{PATTERN_MATCHING_QUERY, QUERY_EVOLUTION},
+	bus::{INFERENCE_CMD, LINK_CREATION_CMD, PATTERN_MATCHING_QUERY_CMD, QUERY_EVOLUTION_CMD},
 	service_bus::ServiceBus,
 	types::BoxError,
 };
@@ -20,7 +20,12 @@ impl ServiceBusSingleton {
 		let service_bus = ServiceBus::new(
 			host_id,
 			known_peer,
-			vec![PATTERN_MATCHING_QUERY.to_string(), QUERY_EVOLUTION.to_string()],
+			vec![
+				PATTERN_MATCHING_QUERY_CMD.to_string(),
+				QUERY_EVOLUTION_CMD.to_string(),
+				LINK_CREATION_CMD.to_string(),
+				INFERENCE_CMD.to_string(),
+			],
 			port_lower,
 			port_upper,
 		)?;

--- a/3rd_party_slots/rust_metta_bus_client/src/space/mod.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/space/mod.rs
@@ -8,7 +8,9 @@ use hyperon_common::FlexRef;
 use hyperon_space::{Space, SpaceCommon, SpaceMut, SpaceVisitor};
 use log;
 
-use crate::{init_service_bus, query_with_das, service_bus::ServiceBus, types::MeTTaRunner};
+use crate::{
+	init_service_bus, query_with_das, service_bus::ServiceBus, types::MeTTaRunner, QueryType,
+};
 
 #[derive(Clone)]
 pub struct DistributedAtomSpace {
@@ -36,13 +38,18 @@ impl DistributedAtomSpace {
 	}
 
 	pub fn query(&self, query: &Atom) -> BindingsSet {
-		query_with_das(
+		match query_with_das(
 			self.name.clone(),
 			self.service_bus.clone(),
-			query,
+			&QueryType::Atom(query.clone()),
 			Some(self.metta_runner.clone()),
-		)
-		.unwrap()
+		) {
+			Ok(bindings) => bindings,
+			Err(e) => {
+				log::error!(target: "das", "Error querying with DAS: {e}");
+				BindingsSet::empty()
+			},
+		}
 	}
 
 	pub fn add(&mut self, _atom: Atom) {

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,1 @@
-
+[#637][HE Client] Add InferenceProxy


### PR DESCRIPTION
This PR adds `InferenceProxy` to `rust_metta_bus_client` it also improves its `main.rs` so it can be executed as an independent (from HE) program to call `pattern_matching_query()`.