### PR TITLE
[#695] Creates a class AttentionBrokerClient which shaw be used as a hub to all AB requests

### DIFF
--- a/src/agents/evolution/BUILD
+++ b/src/agents/evolution/BUILD
@@ -37,6 +37,7 @@ cc_library(
         ":query_evolution_proxy",
         "//agents/query_engine:query_answer",
         "//atom_space:atom_space_lib",
+        "//attention_broker:attention_broker_client",
         "//commons:commons_lib",
         "//service_bus:service_bus_lib",
     ],

--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -1,5 +1,6 @@
-#include "AttentionBrokerClient.h"
 #include "QueryEvolutionProcessor.h"
+
+#include "AttentionBrokerClient.h"
 #include "LinkSchema.h"
 #include "QueryEvolutionProxy.h"
 #include "ServiceBus.h"

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -4,9 +4,10 @@
 #define LOG_LEVEL INFO_LEVEL
 #include "Logger.h"
 
-#include <grpcpp/grpcpp.h>
+#include <map>
 
 #include "And.h"
+#include "AttentionBrokerClient.h"
 #include "Link.h"
 #include "LinkSchema.h"
 #include "LinkTemplate.h"
@@ -21,13 +22,12 @@
 #include "Terminal.h"
 #include "UniqueAssignmentFilter.h"
 #include "UntypedVariable.h"
-#include "attention_broker.grpc.pb.h"
-#include "attention_broker.pb.h"
 
 // clang-format on
 
 using namespace atomdb;
 using namespace metta;
+using namespace attention_broker;
 
 string PatternMatchingQueryProcessor::AND = "AND";
 string PatternMatchingQueryProcessor::OR = "OR";
@@ -99,20 +99,7 @@ void PatternMatchingQueryProcessor::update_attention_broker_single_answer(
         // -------------
     }
     if (single_answer.size() > 1) {
-        auto stub = dasproto::AttentionBroker::NewStub(
-            grpc::CreateChannel(ATTENTION_BROKER_ADDRESS, grpc::InsecureChannelCredentials()));
-
-        dasproto::HandleList handle_list;  // GRPC command parameter
-        dasproto::Ack ack;                 // GRPC command return
-        handle_list.set_context(proxy->get_context());
-        for (auto handle : single_answer) {
-            handle_list.add_list(handle);
-        }
-        LOG_DEBUG("Calling AttentionBroker GRPC. Correlating " << single_answer.size() << " handles");
-        stub->correlate(new grpc::ClientContext(), handle_list, &ack);
-        if (ack.msg() != "CORRELATE") {
-            Utils::error("Failed GRPC command: AttentionBroker::correlate()");
-        }
+        AttentionBrokerClient::correlate(single_answer, proxy->get_context());
     } else {
         LOG_DEBUG("Too few handles (" + std::to_string(single_answer.size()) + ") to stimulate");
     }
@@ -121,21 +108,11 @@ void PatternMatchingQueryProcessor::update_attention_broker_single_answer(
 void PatternMatchingQueryProcessor::update_attention_broker_joint_answer(
     shared_ptr<PatternMatchingQueryProxy> proxy, set<string>& joint_answer) {
     if (joint_answer.size() > 0) {
-        auto stub = dasproto::AttentionBroker::NewStub(
-            grpc::CreateChannel(ATTENTION_BROKER_ADDRESS, grpc::InsecureChannelCredentials()));
-
-        dasproto::HandleCount handle_count;  // GRPC command parameter
-        dasproto::Ack ack;                   // GRPC command return
-        handle_count.set_context(proxy->get_context());
+        map<string, unsigned int> handle_count;
         for (auto handle : joint_answer) {
-            (*handle_count.mutable_map())[handle] = 1;
+            handle_count[handle] = 1;
         }
-        (*handle_count.mutable_map())["SUM"] = joint_answer.size();
-        LOG_DEBUG("Calling AttentionBroker GRPC. Stimulating " << joint_answer.size() << " handles");
-        stub->stimulate(new grpc::ClientContext(), handle_count, &ack);
-        if (ack.msg() != "STIMULATE") {
-            Utils::error("Failed GRPC command: AttentionBroker::stimulate()");
-        }
+        AttentionBrokerClient::stimulate(handle_count, proxy->get_context());
     } else {
         LOG_DEBUG("No handles to stimulate");
     }

--- a/src/agents/query_engine/query_element/LinkTemplate.cc
+++ b/src/agents/query_engine/query_element/LinkTemplate.cc
@@ -1,4 +1,5 @@
 #include "LinkTemplate.h"
+
 #include "AtomDBSingleton.h"
 #include "AttentionBrokerClient.h"
 #include "Terminal.h"
@@ -90,7 +91,7 @@ void LinkTemplate::compute_importance(vector<pair<char*, float>>& handles) {
     vector<float> importance_list;
     handle_list.reserve(handles.size());
     importance_list.reserve(handles.size());
-    for (auto pair: handles) {
+    for (auto pair : handles) {
         handle_list.push_back(string(pair.first));
     }
     AttentionBrokerClient::get_importance(handle_list, this->context, importance_list);

--- a/src/agents/query_engine/query_element/LinkTemplate.h
+++ b/src/agents/query_engine/query_element/LinkTemplate.h
@@ -18,8 +18,6 @@ using namespace query_element;
 using namespace atoms;
 using namespace atomdb;
 
-#define MAX_GET_IMPORTANCE_BUNDLE_SIZE ((unsigned int) 100000)
-
 namespace query_element {
 
 /**
@@ -32,7 +30,6 @@ class LinkTemplate : public QueryElement {
         bool buffers_set_up_flag;
         mutex api_mutex;
         SourceElement() { buffers_set_up_flag = false; }
-        string get_attention_broker_address() { return this->attention_broker_address; }
         void add_handle(char* handle, float importance, Assignment& assignment) {
             QueryAnswer* answer = new QueryAnswer(string(handle), importance);
             answer->assignment = assignment;

--- a/src/agents/query_engine/query_element/Source.cc
+++ b/src/agents/query_engine/query_element/Source.cc
@@ -4,18 +4,13 @@
 
 using namespace query_element;
 
-string Source::DEFAULT_ATTENTION_BROKER_PORT = "37007";
-
 // ------------------------------------------------------------------------------------------------
 // Constructors and destructors
 
-Source::Source(const string& attention_broker_address) {
+Source::Source() {
     LOG_LOCAL_DEBUG("Creating Source: " + std::to_string((unsigned long) this));
-    this->attention_broker_address = attention_broker_address;
     this->output_buffer = nullptr;
 }
-
-Source::Source() : Source(Source::get_attention_broker_address()) {}
 
 Source::~Source() {
     LOG_LOCAL_DEBUG("Deleting Source: " + std::to_string((unsigned long) this) + "...");
@@ -25,20 +20,6 @@ Source::~Source() {
 
 // ------------------------------------------------------------------------------------------------
 // Public methods
-
-string Source::get_attention_broker_address() {
-    string attention_broker_address = Utils::get_environment("DAS_ATTENTION_BROKER_ADDRESS");
-    string attention_broker_port = Utils::get_environment("DAS_ATTENTION_BROKER_PORT");
-    if (attention_broker_address.empty()) {
-        attention_broker_address = "localhost";
-    }
-    if (attention_broker_port.empty()) {
-        attention_broker_address += ":" + DEFAULT_ATTENTION_BROKER_PORT;
-    } else {
-        attention_broker_address += ":" + attention_broker_port;
-    }
-    return attention_broker_address;
-}
 
 void Source::setup_buffers() {
     LOG_LOCAL_DEBUG("Setting up buffers for Source: " + std::to_string((unsigned long) this) + "...");

--- a/src/agents/query_engine/query_element/Source.h
+++ b/src/agents/query_engine/query_element/Source.h
@@ -18,19 +18,6 @@ namespace query_element {
 class Source : public QueryElement {
    public:
     /**
-     * Sources tipically need to communicate with the AttentionBroker in order to sort links
-     * by importance. AttentionBroker is supposed to be running in the same machine as all
-     * Source elements so only a port number is required. Here we provide a default value
-     * in the case none is passed in constructor.
-     */
-    static string DEFAULT_ATTENTION_BROKER_PORT;
-
-    /**
-     * Constructor which also sets a value for AttentionBroker address
-     */
-    Source(const string& attention_broker_address);
-
-    /**
      * Basic empty constructor.
      */
     Source();
@@ -39,11 +26,6 @@ class Source : public QueryElement {
      * Destructor.
      */
     virtual ~Source();
-
-    /**
-     * Helper to get AttentionBroker address from env vars or default values.
-     */
-    static string get_attention_broker_address();
 
     // --------------------------------------------------------------------------------------------
     // QueryElement API
@@ -59,7 +41,6 @@ class Source : public QueryElement {
     virtual void setup_buffers();
 
    protected:
-    string attention_broker_address;
     shared_ptr<QueryNode> output_buffer;
     shared_ptr<QueryElement> subsequent;
 };

--- a/src/attention_broker/AttentionBrokerClient.cc
+++ b/src/attention_broker/AttentionBrokerClient.cc
@@ -1,0 +1,90 @@
+#include <grpcpp/grpcpp.h>
+
+#include "AttentionBrokerClient.h"
+#include "Utils.h"
+
+#define LOG_LEVEL INFO_LEVEL
+#include "Logger.h"
+
+#include "attention_broker.grpc.pb.h"
+#include "attention_broker.pb.h"
+
+using namespace attention_broker;
+using namespace commons;
+
+mutex AttentionBrokerClient::api_mutex;
+string AttentionBrokerClient::SERVER_ADDRESS = DEFAULT_ATTENTION_BROKER_ADDRESS;
+unsigned int AttentionBrokerClient::MAX_GET_IMPORTANCE_BUNDLE_SIZE = 100000;
+
+// -------------------------------------------------------------------------------------------------
+// Public methods
+
+void AttentionBrokerClient::set_server_address(const string& ip_port) {
+    SERVER_ADDRESS = ip_port;
+}
+
+void AttentionBrokerClient::correlate(const set<string>& handles, const string& context) {
+
+    dasproto::HandleList handle_list;  // GRPC command parameter
+    dasproto::Ack ack;                 // GRPC command return
+    auto stub = dasproto::AttentionBroker::NewStub(grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
+
+    handle_list.set_context(context);
+    for (string handle : handles) {
+        handle_list.add_list(handle);
+    }
+    if (handle_list.list_size() > 0) {
+        LOG_INFO("Calling AttentionBroker GRPC. Correlating " << handle_list.list_size() << " handles");
+        stub->correlate(new grpc::ClientContext(), handle_list, &ack);
+        if (ack.msg() != "CORRELATE") {
+            Utils::error("Failed GRPC command: AttentionBroker::correlate()");
+        }
+    } else {
+        LOG_INFO("No handles to correlate");
+    }
+}
+
+void AttentionBrokerClient::stimulate(const map<string, unsigned int>& handle_map, const string& context) {
+
+    dasproto::HandleCount handle_count;  // GRPC command parameter
+    dasproto::Ack ack;                   // GRPC command return
+    auto stub = dasproto::AttentionBroker::NewStub(grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
+
+    handle_count.set_context(context);
+    unsigned int sum;
+    for (auto pair : handle_map) {
+        (*handle_count.mutable_map())[pair.first] = pair.second;
+        sum += pair.second;
+    }
+    (*handle_count.mutable_map())["SUM"] = sum;
+    LOG_INFO("Calling AttentionBroker GRPC. Stimulating " << handle_count.mutable_map()->size() << " handles");
+    stub->stimulate(new grpc::ClientContext(), handle_count, &ack);
+    if (ack.msg() != "STIMULATE") {
+        Utils::error("Failed GRPC command: AttentionBroker::stimulate()");
+    }
+}
+
+void AttentionBrokerClient::get_importance(const vector<string>& handles, const string& context, vector<float>& importances) {
+    unsigned int pending_count = handles.size();
+    unsigned int cursor = 0;
+    unsigned int bundle_count = 0;
+    dasproto::HandleList handle_list;
+    dasproto::ImportanceList importance_list;
+    while (pending_count > 0) {
+        handle_list.set_context(context);
+        while ((pending_count > 0) && (bundle_count < MAX_GET_IMPORTANCE_BUNDLE_SIZE)) {
+            handle_list.add_list(handles[cursor++]);
+            pending_count--;
+            bundle_count++;
+        }
+        auto stub = dasproto::AttentionBroker::NewStub(grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
+        LOG_INFO("Querying AttentionBroker for importance of " << handle_list.list_size() << " atoms.");
+        stub->get_importance(new grpc::ClientContext(), handle_list, &importance_list);
+        for (unsigned int i = 0; i < bundle_count; i++) {
+            importances.push_back(importance_list.list(i));
+        }
+        bundle_count = 0;
+        handle_list.clear_list();
+        importance_list.clear_list();
+    }
+}

--- a/src/attention_broker/AttentionBrokerClient.h
+++ b/src/attention_broker/AttentionBrokerClient.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <mutex>
-#include <string>
-#include <set>
 #include <map>
+#include <mutex>
+#include <set>
+#include <string>
 #include <vector>
 
 using namespace std;
@@ -16,22 +16,21 @@ namespace attention_broker {
  *
  */
 class AttentionBrokerClient {
-
-public:
-
+   public:
     ~AttentionBrokerClient() {}
 
     static void set_server_address(const string& ip_port);
     static void correlate(const set<string>& handles, const string& context);
     static void stimulate(const map<string, unsigned int>& handle_count, const string& context);
-    static void get_importance(const vector<string>& handles, const string& context, vector<float>& importances);
+    static void get_importance(const vector<string>& handles,
+                               const string& context,
+                               vector<float>& importances);
 
-private:
-
+   private:
     static mutex api_mutex;
     static string SERVER_ADDRESS;
     static unsigned int MAX_GET_IMPORTANCE_BUNDLE_SIZE;
     AttentionBrokerClient() {}
 };
 
-} // namespace attention_broker
+}  // namespace attention_broker

--- a/src/attention_broker/AttentionBrokerClient.h
+++ b/src/attention_broker/AttentionBrokerClient.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <set>
+#include <map>
+#include <vector>
+
+using namespace std;
+
+#define DEFAULT_ATTENTION_BROKER_ADDRESS "localhost:37007"
+
+namespace attention_broker {
+
+/**
+ *
+ */
+class AttentionBrokerClient {
+
+public:
+
+    ~AttentionBrokerClient() {}
+
+    static void set_server_address(const string& ip_port);
+    static void correlate(const set<string>& handles, const string& context);
+    static void stimulate(const map<string, unsigned int>& handle_count, const string& context);
+    static void get_importance(const vector<string>& handles, const string& context, vector<float>& importances);
+
+private:
+
+    static mutex api_mutex;
+    static string SERVER_ADDRESS;
+    static unsigned int MAX_GET_IMPORTANCE_BUNDLE_SIZE;
+    AttentionBrokerClient() {}
+};
+
+} // namespace attention_broker

--- a/src/attention_broker/AttentionBrokerServer.cc
+++ b/src/attention_broker/AttentionBrokerServer.cc
@@ -1,5 +1,4 @@
 #include "AttentionBrokerServer.h"
-
 #include "RequestSelector.h"
 
 #define LOG_LEVEL INFO_LEVEL

--- a/src/attention_broker/AttentionBrokerServer.cc
+++ b/src/attention_broker/AttentionBrokerServer.cc
@@ -1,4 +1,5 @@
 #include "AttentionBrokerServer.h"
+
 #include "RequestSelector.h"
 
 #define LOG_LEVEL INFO_LEVEL

--- a/src/attention_broker/BUILD
+++ b/src/attention_broker/BUILD
@@ -17,10 +17,10 @@ cc_library(
     ],
     includes = ["."],
     deps = [
+        ":attention_broker_client",
         ":hebbian_network",
         ":hebbian_network_updater",
         ":request_selector",
-        ":attention_broker_client",
         "//commons:commons_lib",
         "//commons:handle_trie",
         "//hasher:hasher_lib",

--- a/src/attention_broker/BUILD
+++ b/src/attention_broker/BUILD
@@ -20,9 +20,22 @@ cc_library(
         ":hebbian_network",
         ":hebbian_network_updater",
         ":request_selector",
+        ":attention_broker_client",
         "//commons:commons_lib",
         "//commons:handle_trie",
         "//hasher:hasher_lib",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_grpc_grpc//:grpc++_reflection",
+        "@com_github_singnet_das_proto//:attention_broker_cc_grpc",
+    ],
+)
+
+cc_library(
+    name = "attention_broker_client",
+    srcs = ["AttentionBrokerClient.cc"],
+    hdrs = ["AttentionBrokerClient.h"],
+    deps = [
+        "//commons:commons_lib",
         "@com_github_grpc_grpc//:grpc++",
         "@com_github_grpc_grpc//:grpc++_reflection",
         "@com_github_singnet_das_proto//:attention_broker_cc_grpc",

--- a/src/main/evolution_engine_main.cc
+++ b/src/main/evolution_engine_main.cc
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "AtomDBSingleton.h"
+#include "AttentionBrokerClient.h"
 #include "FitnessFunctionRegistry.h"
 #include "QueryEvolutionProcessor.h"
 #include "ServiceBusSingleton.h"
@@ -16,6 +17,7 @@ using namespace std;
 using namespace atomdb;
 using namespace evolution;
 using namespace service_bus;
+using namespace attention_broker;
 
 void ctrl_c_handler(int) {
     LOG_INFO("Stopping evolution engine server...");
@@ -24,9 +26,12 @@ void ctrl_c_handler(int) {
 }
 
 int main(int argc, char* argv[]) {
-    if (argc != 4) {
-        cerr << "Usage: " << argv[0] << " <port> <start_port:end_port> BUS_IP:PORT" << endl;
+    if (argc < 4) {
+        cerr << "Usage: " << argv[0] << " <port> <start_port:end_port> BUS_IP:PORT [AB_ip:AB_port]" << endl;
         exit(1);
+    }
+    if (argc == 5) {
+        AttentionBrokerClient::set_server_address(string(argv[4]));
     }
 
     string server_id = "0.0.0.0:" + string(argv[1]);

--- a/src/main/evolution_engine_main.cc
+++ b/src/main/evolution_engine_main.cc
@@ -27,7 +27,8 @@ void ctrl_c_handler(int) {
 
 int main(int argc, char* argv[]) {
     if (argc < 4) {
-        cerr << "Usage: " << argv[0] << " <port> <start_port:end_port> BUS_IP:PORT [AB_ip:AB_port]" << endl;
+        cerr << "Usage: " << argv[0] << " <port> <start_port:end_port> BUS_IP:PORT [AB_ip:AB_port]"
+             << endl;
         exit(1);
     }
     if (argc == 5) {

--- a/src/main/query_engine_main.cc
+++ b/src/main/query_engine_main.cc
@@ -4,9 +4,9 @@
 #include <string>
 
 #include "AtomDBSingleton.h"
+#include "AttentionBrokerClient.h"
 #include "PatternMatchingQueryProcessor.h"
 #include "ServiceBusSingleton.h"
-#include "AttentionBrokerClient.h"
 #include "Utils.h"
 
 #define LOG_LEVEL INFO_LEVEL

--- a/src/main/query_engine_main.cc
+++ b/src/main/query_engine_main.cc
@@ -6,6 +6,7 @@
 #include "AtomDBSingleton.h"
 #include "PatternMatchingQueryProcessor.h"
 #include "ServiceBusSingleton.h"
+#include "AttentionBrokerClient.h"
 #include "Utils.h"
 
 #define LOG_LEVEL INFO_LEVEL
@@ -13,6 +14,7 @@
 
 using namespace std;
 using namespace atomdb;
+using namespace attention_broker;
 using namespace query_engine;
 using namespace service_bus;
 
@@ -23,10 +25,14 @@ void ctrl_c_handler(int) {
 }
 
 int main(int argc, char* argv[]) {
-    if (argc != 3) {
-        cerr << "Usage: " << argv[0] << " <port> <start_port:end_port>" << endl;
+    if (argc < 3) {
+        cerr << "Usage: " << argv[0] << " <port> <start_port:end_port> [AB_ip:AB_port]" << endl;
         exit(1);
     }
+    if (argc == 4) {
+        AttentionBrokerClient::set_server_address(string(argv[3]));
+    }
+
     string server_id = "0.0.0.0:" + string(argv[1]);
     auto ports_range = Utils::parse_ports_range(argv[2]);
     LOG_INFO("Starting query engine server with id: " + server_id);


### PR DESCRIPTION
WIP towards #695
The new class makes all AttentionBroker commands available through static method calls passing regular std containers. All GRPC-related stuff is now inside this class. So agents which makes requesta to AttentionBroker no longer need to deal with GRPC stuff.

As a side effect, we removed the hardwired ATTENTION_BROKER_ADDRESS definitions. Now both query agent and evolution agent (the agents that makes AB requests) accept an optional parameter with the actual Attention Broker address (ip:port). We kept a default to 0.0.0.0:37007 so everything which is relying on this is still working, this new parameter is optional.