### PR TITLE
[#632] Parameter to repeat Evolution Agent iterations (Toy problem tunning 2/?) 

### DIFF
--- a/3rd_party_slots/python_inference_poc/README.md
+++ b/3rd_party_slots/python_inference_poc/README.md
@@ -14,7 +14,10 @@ To run the setup and agents, `cd` to das root folder and run:
 ``` 
 make run-inference-toy-problem 3rd_party_slots/python_inference_poc/config/scenario_1.json
 ```
-
+To use other MeTTa files (already generated), add the path of the base and bias after the scenario, the script will skip the generation process and load the given files:
+```
+make run-inference-toy-problem 3rd_party_slots/python_inference_poc/config/scenario_1.json /tmp/mybase.metta /tmp/mybias.metta
+```
 To run the problem `feature_a -> feature_d`, `cd` to das root folder and run:
 
 ```

--- a/src/agents/inference_agent/InferenceAgent.cc
+++ b/src/agents/inference_agent/InferenceAgent.cc
@@ -76,7 +76,7 @@ void InferenceAgent::run() {
             if (it->second->finished() || inference_proxy_map[it->first]->is_aborting() ||
                 Utils::get_current_time_millis() / 1000 > inference_timeout_map[it->first]) {
                 LOG_DEBUG("Processing inference abort request for request ID: " << it->first);
-                
+
                 auto inference_request = get_inference_request(it->first);
                 if (inference_request != nullptr) {
                     if (inference_request->get_repeat() > 0) {

--- a/src/agents/inference_agent/InferenceAgent.cc
+++ b/src/agents/inference_agent/InferenceAgent.cc
@@ -75,23 +75,26 @@ void InferenceAgent::run() {
         for (auto it = evolution_proxy_map.begin(); it != evolution_proxy_map.end();) {
             if (it->second->finished() || inference_proxy_map[it->first]->is_aborting() ||
                 Utils::get_current_time_millis() / 1000 > inference_timeout_map[it->first]) {
-                process_inference_abort_request(it->first);
-
+                LOG_DEBUG("Processing inference abort request for request ID: " << it->first);
+                
                 auto inference_request = get_inference_request(it->first);
-                // // Repeat evolution process (not tested)
-                // if(inference_request != nullptr && inference_request->get_repeat() > 0) {
-                //     send_link_creation_request(inference_request);
-                //     inference_request->set_sent_evolution_request(false);
-                // }else{
                 if (inference_request != nullptr) {
-                    this->inference_requests.erase(remove(this->inference_requests.begin(),
-                                                          this->inference_requests.end(),
-                                                          inference_request),
-                                                   this->inference_requests.end());
-                    LOG_DEBUG("Inference request removed for request ID: " << it->first);
+                    if (inference_request->get_repeat() > 0) {
+                        LOG_DEBUG("Sending link creation request for request ID: "
+                                  << inference_request->get_id());
+                        LOG_DEBUG("Request repeat count: " << inference_request->get_repeat());
+                        send_link_creation_request(inference_request);
+                        inference_request->set_sent_evolution_request(false);
+                    } else {
+                        this->inference_requests.erase(remove(this->inference_requests.begin(),
+                                                              this->inference_requests.end(),
+                                                              inference_request),
+                                                       this->inference_requests.end());
+                        LOG_DEBUG("Inference request removed for request ID: " << it->first);
+                        process_inference_abort_request(it->first);
+                    }
                 }
 
-                // }
                 it = evolution_proxy_map.erase(it);
 
             } else {

--- a/src/scripts/setup_inference_toy_problem.sh
+++ b/src/scripts/setup_inference_toy_problem.sh
@@ -2,6 +2,8 @@
 # set -eoux pipefail
 PWD=$(dirname "$0")
 JSON_FILE=$1
+METTA_FILE=$2
+METTA_BIAS_FILE=$3
 echo "Using JSON file: $JSON_FILE"
 # extract the scenario from json file name
 SCENARIO=$(basename "$JSON_FILE" .json)
@@ -12,15 +14,26 @@ ALPHABET=$(jq -r '."alphabet-range"' "$JSON_FILE")
 das-cli db stop
 ITPPATH="3rd_party_slots/python_inference_poc"
 ITPPATHD="/opt/das/3rd_party_slots/python_inference_poc"
-set -eoux pipefail
 rm -f /tmp/output.metta
 rm -f /tmp/biased_predicates.metta
-rm -f 3rd_party_slots/python_inference_poc/output.metta
-rm -f 3rd_party_slots/python_inference_poc/biased_predicates.metta
-$PWD/run_script.sh python3 $ITPPATH/metta_file_generator.py --sentence-node-count $SENTENCE_NODE_COUNT --word-count $WORD_COUNT --word-length $WORD_LENGTH --alphabet-range $ALPHABET
-$PWD/run_script.sh python3 $ITPPATH/predicate_generator.py  $ITPPATHD/output.metta --config-file $ITPPATHD/config/$SCENARIO.json
-cp -f $ITPPATH/output.metta $ITPPATH/biased_predicates.metta /tmp/
+if [ -z "$METTA_FILE" ]; then
+  rm -f 3rd_party_slots/python_inference_poc/output.metta
+  $PWD/run_script.sh python3 $ITPPATH/metta_file_generator.py --sentence-node-count $SENTENCE_NODE_COUNT --word-count $WORD_COUNT --word-length $WORD_LENGTH --alphabet-range $ALPHABET
+  cp -f $ITPPATH/output.metta /tmp/
+else
+  cp -f "$METTA_FILE" /tmp/output.metta
+fi
+
+if [ -z "$METTA_BIAS_FILE" ]; then
+  rm -f 3rd_party_slots/python_inference_poc/biased_predicates.metta
+  $PWD/run_script.sh python3 $ITPPATH/predicate_generator.py  $ITPPATHD/biased_predicates.metta --config-file $ITPPATHD/config/$SCENARIO.json
+  cp -f $ITPPATH/biased_predicates.metta /tmp/
+else
+  cp -f "$METTA_BIAS_FILE" /tmp/biased_predicates.metta
+fi
 das-cli db start
+$PWD/run_agents.sh start no-wait
+$PWD/run_agents.sh stop
 das-cli metta load /tmp/output.metta
 das-cli metta load /tmp/biased_predicates.metta
 export LINK_CREATION_REQUESTS_INTERVAL_SECONDS=5


### PR DESCRIPTION
links to #632 

- Added parameter to repeat evolution iterations
- Toy Script now accepts the MeTTa files as args instead of generate the files every time
- Running Agents before das-cli metta-loader to load DB indexes