### PR TITLE
[#695] Implement Context objects with proper AB initialization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,3 @@
 [#637][HE Client] Add InferenceProxy
 [#691] Add Atom::is_toplevel and AtomDB::get_matching_atoms(is_toplevel, Atom)
+[#695] Add Context objects which initializes AB and sets importance determiners for toplevel links

--- a/src/atom_space/AtomSpace.cc
+++ b/src/atom_space/AtomSpace.cc
@@ -2,8 +2,8 @@
 
 #include "Hasher.h"
 #include "QueryAnswer.h"
-#include "Utils.h"
 #include "UntypedVariable.h"
+#include "Utils.h"
 
 using namespace std;
 using namespace query_engine;

--- a/src/atom_space/AtomSpace.cc
+++ b/src/atom_space/AtomSpace.cc
@@ -3,6 +3,7 @@
 #include "Hasher.h"
 #include "QueryAnswer.h"
 #include "Utils.h"
+#include "UntypedVariable.h"
 
 using namespace std;
 using namespace query_engine;
@@ -149,8 +150,14 @@ void AtomSpace::commit_changes(Scope scope) {
 }
 
 // -------------------------------------------------------------------------------------------------
+shared_ptr<Context> AtomSpace::create_context(const string& context_name, Atom& atom_key) {
+    Context* context = new Context(context_name, atom_key);
+    return shared_ptr<Context>(context);
+}
+
 shared_ptr<Context> AtomSpace::create_context(const string& context_name) {
-    Context* context = new Context(context_name);
+    UntypedVariable v1("v1");
+    Context* context = new Context(context_name, v1);
     return shared_ptr<Context>(context);
 }
 

--- a/src/atom_space/AtomSpace.h
+++ b/src/atom_space/AtomSpace.h
@@ -182,6 +182,17 @@ class AtomSpace {
      * Context objects are used to make queries in the atom space.
      *
      * @param name Context name.
+     * @param atom_key Key used to match toplevel atoms; only matching toplevel atoms will be considered.
+     * @return A newly created Context object.
+     */
+    shared_ptr<Context> create_context(const string& context_name, Atom& atom_key);
+
+    /**
+     * Create and return a context object passing UntypedVariable (which matches everything) as atom key.
+     *
+     * Context objects are used to make queries in the atom space.
+     *
+     * @param name Context name.
      * @return A newly created Context object.
      */
     shared_ptr<Context> create_context(const string& context_name);

--- a/src/atom_space/BUILD
+++ b/src/atom_space/BUILD
@@ -26,9 +26,9 @@ cc_library(
     hdrs = ["Context.h"],
     includes = ["."],
     deps = [
-        "//hasher:hasher_lib",
-        "//attention_broker:attention_broker_client",
         "//atomdb:atomdb_singleton",
+        "//attention_broker:attention_broker_client",
         "//commons/atoms:atoms_lib",
+        "//hasher:hasher_lib",
     ],
 )

--- a/src/atom_space/BUILD
+++ b/src/atom_space/BUILD
@@ -16,7 +16,7 @@ cc_library(
         "//commons:handle_trie",
         "//commons/atoms:atoms_lib",
         "//hasher:hasher_lib",
-        "//service_bus:service_bus_singleton",
+        "//service_bus:service_bus_lib",
     ],
 )
 
@@ -27,5 +27,8 @@ cc_library(
     includes = ["."],
     deps = [
         "//hasher:hasher_lib",
+        "//attention_broker:attention_broker_client",
+        "//atomdb:atomdb_singleton",
+        "//commons/atoms:atoms_lib",
     ],
 )

--- a/src/atom_space/Context.cc
+++ b/src/atom_space/Context.cc
@@ -2,7 +2,6 @@
 
 #include "AttentionBrokerClient.h"
 #include "AtomDBSingleton.h"
-#include "UntypedVariable.h"
 #include "Hasher.h"
 
 using namespace atom_space;
@@ -14,45 +13,42 @@ using namespace commons;
 // -------------------------------------------------------------------------------------------------
 // Public methods
 
-Context::Context(const string& name) {
+Context::Context(const string& name, Atom& atom_key) {
     this->name = name;
     this->key = Hasher::context_handle(name);
-    set_determiners();
+    set_determiners(atom_key);
 }
 
 Context::~Context() {
     // TODO delete context in AttentionBroker
 }
 
-void Context::set_determiners() {
-    UntypedVariable v1("v1");
+void Context::set_determiners(Atom& atom_key) {
     string ID = RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::ID];
     string TARGETS = RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS];
     string TYPE = RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::NAMED_TYPE];
-    auto documents = AtomDBSingleton::get_instance()->get_matching_atoms(true, v1);
-    vector<string> request;
-    vector<vector<string>> requests;
+    auto documents = AtomDBSingleton::get_instance()->get_matching_atoms(true, atom_key);
+    map<string, unsigned int> to_stimulate;
+    vector<string> determiners;
+    vector<vector<string>> determiner_request;
     for (const auto& document : documents) {
-        if (document == nullptr) {
-            cout << "XXXXXXXXXXXXXXXXXXXXXXXXX document is NULL" << endl;
-        } else {
-            cout << "XXXXXXXXXXXXXXXXXXXXXXXXX document type: " << string(document->get(TYPE)) << endl;
-        }
         if (document->contains(TARGETS)) { // if is link
-            request.clear();
-            request.push_back(string(document->get(ID)));
+            determiners.clear();
+            string handle = string(document->get(ID));
+            determiners.push_back(handle);
+            to_stimulate[handle] = 1;
             unsigned int arity = document->get_size(TARGETS);
             for (unsigned int i = 0; i < arity; i++) {
-                request.push_back(string(document->get(TARGETS, i)));
-                //cout << "XXXXXXXXXXXXXXXXXXXXXXXXX " << string(document->get(ID)) << " -> " << string(document->get(TARGETS, i)) << endl;
+                determiners.push_back(string(document->get(TARGETS, i)));
             }
-            requests.push_back(request);
+            determiner_request.push_back(determiners);
         } else {
         }
     }
-    AttentionBrokerClient::set_determiners(requests, this->key);
+    AttentionBrokerClient::set_determiners(determiner_request, this->key);
+    AttentionBrokerClient::stimulate(to_stimulate, this->key);
 }
 
-const string& Context::get_name() { return name; }
+const string& Context::get_name() { return this->name; }
 
-const string& Context::get_key() { return key; }
+const string& Context::get_key() { return this->key; }

--- a/src/atom_space/Context.cc
+++ b/src/atom_space/Context.cc
@@ -1,8 +1,14 @@
 #include "Context.h"
 
+#include "AttentionBrokerClient.h"
+#include "AtomDBSingleton.h"
+#include "UntypedVariable.h"
 #include "Hasher.h"
 
 using namespace atom_space;
+using namespace atoms;
+using namespace atomdb;
+using namespace attention_broker;
 using namespace commons;
 
 // -------------------------------------------------------------------------------------------------
@@ -11,9 +17,41 @@ using namespace commons;
 Context::Context(const string& name) {
     this->name = name;
     this->key = Hasher::context_handle(name);
+    set_determiners();
 }
 
-Context::~Context() {}
+Context::~Context() {
+    // TODO delete context in AttentionBroker
+}
+
+void Context::set_determiners() {
+    UntypedVariable v1("v1");
+    string ID = RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::ID];
+    string TARGETS = RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS];
+    string TYPE = RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::NAMED_TYPE];
+    auto documents = AtomDBSingleton::get_instance()->get_matching_atoms(true, v1);
+    vector<string> request;
+    vector<vector<string>> requests;
+    for (const auto& document : documents) {
+        if (document == nullptr) {
+            cout << "XXXXXXXXXXXXXXXXXXXXXXXXX document is NULL" << endl;
+        } else {
+            cout << "XXXXXXXXXXXXXXXXXXXXXXXXX document type: " << string(document->get(TYPE)) << endl;
+        }
+        if (document->contains(TARGETS)) { // if is link
+            request.clear();
+            request.push_back(string(document->get(ID)));
+            unsigned int arity = document->get_size(TARGETS);
+            for (unsigned int i = 0; i < arity; i++) {
+                request.push_back(string(document->get(TARGETS, i)));
+                //cout << "XXXXXXXXXXXXXXXXXXXXXXXXX " << string(document->get(ID)) << " -> " << string(document->get(TARGETS, i)) << endl;
+            }
+            requests.push_back(request);
+        } else {
+        }
+    }
+    AttentionBrokerClient::set_determiners(requests, this->key);
+}
 
 const string& Context::get_name() { return name; }
 

--- a/src/atom_space/Context.cc
+++ b/src/atom_space/Context.cc
@@ -1,7 +1,7 @@
 #include "Context.h"
 
-#include "AttentionBrokerClient.h"
 #include "AtomDBSingleton.h"
+#include "AttentionBrokerClient.h"
 #include "Hasher.h"
 
 using namespace atom_space;
@@ -32,7 +32,7 @@ void Context::set_determiners(Atom& atom_key) {
     vector<string> determiners;
     vector<vector<string>> determiner_request;
     for (const auto& document : documents) {
-        if (document->contains(TARGETS)) { // if is link
+        if (document->contains(TARGETS)) {  // if is link
             determiners.clear();
             string handle = string(document->get(ID));
             determiners.push_back(handle);

--- a/src/atom_space/Context.h
+++ b/src/atom_space/Context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "Atom.h"
 
 using namespace std;

--- a/src/atom_space/Context.h
+++ b/src/atom_space/Context.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <string>
+#include "Atom.h"
 
 using namespace std;
+using namespace atoms;
 
 namespace atom_space {
 
@@ -18,10 +20,10 @@ class Context {
     const string& get_name();
 
    protected:
-    Context(const string& name);
+    Context(const string& name, Atom& atom_key);
 
    private:
-    void set_determiners();
+    void set_determiners(Atom& atom_key);
     string name;
     string key;
 };

--- a/src/atom_space/Context.h
+++ b/src/atom_space/Context.h
@@ -17,8 +17,11 @@ class Context {
     const string& get_key();
     const string& get_name();
 
-   private:
+   protected:
     Context(const string& name);
+
+   private:
+    void set_determiners();
     string name;
     string key;
 };

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -594,7 +594,7 @@ vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_link_docume
 
 vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_matching_atoms(bool is_toplevel,
                                                                                     Atom& key) {
-    auto matching_atoms = vector<shared_ptr<atomdb_api_types::AtomDocument>>();
+    vector<shared_ptr<atomdb_api_types::AtomDocument>> matching_atoms;
 
     vector<string> collection_names = {MONGODB_NODES_COLLECTION_NAME, MONGODB_LINKS_COLLECTION_NAME};
     bool add_id_filter = false;
@@ -618,8 +618,7 @@ vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_matching_at
             filter_builder << "is_toplevel" << is_toplevel;
         }
 
-        auto documents = get_filtered_documents(
-            collection_name, filter_builder, {MONGODB_FIELD_NAME[MONGODB_FIELD::ID]});
+        auto documents = get_filtered_documents(collection_name, filter_builder, {});
         for (const auto& document : documents) {
             Assignment assignment;
             if (key.match(document->get(MONGODB_FIELD_NAME[MONGODB_FIELD::ID]), assignment, *this)) {

--- a/src/attention_broker/AttentionBrokerClient.cc
+++ b/src/attention_broker/AttentionBrokerClient.cc
@@ -64,6 +64,28 @@ void AttentionBrokerClient::stimulate(const map<string, unsigned int>& handle_ma
     }
 }
 
+void AttentionBrokerClient::set_determiners(const vector<vector<string>>& handle_lists, const string& context) {
+    dasproto::HandleListList request;  // GRPC command parameter
+    dasproto::Ack ack;                 // GRPC command return
+    auto stub = dasproto::AttentionBroker::NewStub(
+        grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
+
+    request.set_context(context);
+    unsigned int cursor = 0;
+    for (auto handle_list: handle_lists) {
+        request.add_list();
+        for (auto handle: handle_list) {
+            request.mutable_list(cursor)->add_list(handle);
+        }
+        cursor++;
+    }
+    LOG_INFO("Calling AttentionBroker GRPC. Setting determiners for " << request.list_size() << " handles");
+    stub->set_determiners(new grpc::ClientContext(), request, &ack);
+    if (ack.msg() != "SET_DETERMINERS") {
+        Utils::error("Failed GRPC command: AttentionBroker::set_determiners()");
+    }
+}
+
 void AttentionBrokerClient::get_importance(const vector<string>& handles,
                                            const string& context,
                                            vector<float>& importances) {

--- a/src/attention_broker/AttentionBrokerClient.cc
+++ b/src/attention_broker/AttentionBrokerClient.cc
@@ -56,7 +56,7 @@ void AttentionBrokerClient::stimulate(const map<string, unsigned int>& handle_ma
         sum += pair.second;
     }
     (*handle_count.mutable_map())["SUM"] = sum;
-    LOG_INFO("Calling AttentionBroker GRPC. Stimulating " << handle_count.mutable_map()->size()
+    LOG_INFO("Calling AttentionBroker GRPC. Stimulating " << handle_count.mutable_map()->size() - 1
                                                           << " handles");
     stub->stimulate(new grpc::ClientContext(), handle_count, &ack);
     if (ack.msg() != "STIMULATE") {

--- a/src/attention_broker/AttentionBrokerClient.cc
+++ b/src/attention_broker/AttentionBrokerClient.cc
@@ -64,7 +64,8 @@ void AttentionBrokerClient::stimulate(const map<string, unsigned int>& handle_ma
     }
 }
 
-void AttentionBrokerClient::set_determiners(const vector<vector<string>>& handle_lists, const string& context) {
+void AttentionBrokerClient::set_determiners(const vector<vector<string>>& handle_lists,
+                                            const string& context) {
     dasproto::HandleListList request;  // GRPC command parameter
     dasproto::Ack ack;                 // GRPC command return
     auto stub = dasproto::AttentionBroker::NewStub(
@@ -72,14 +73,15 @@ void AttentionBrokerClient::set_determiners(const vector<vector<string>>& handle
 
     request.set_context(context);
     unsigned int cursor = 0;
-    for (auto handle_list: handle_lists) {
+    for (auto handle_list : handle_lists) {
         request.add_list();
-        for (auto handle: handle_list) {
+        for (auto handle : handle_list) {
             request.mutable_list(cursor)->add_list(handle);
         }
         cursor++;
     }
-    LOG_INFO("Calling AttentionBroker GRPC. Setting determiners for " << request.list_size() << " handles");
+    LOG_INFO("Calling AttentionBroker GRPC. Setting determiners for " << request.list_size()
+                                                                      << " handles");
     stub->set_determiners(new grpc::ClientContext(), request, &ack);
     if (ack.msg() != "SET_DETERMINERS") {
         Utils::error("Failed GRPC command: AttentionBroker::set_determiners()");

--- a/src/attention_broker/AttentionBrokerClient.h
+++ b/src/attention_broker/AttentionBrokerClient.h
@@ -25,6 +25,7 @@ class AttentionBrokerClient {
     static void get_importance(const vector<string>& handles,
                                const string& context,
                                vector<float>& importances);
+    static void set_determiners(const vector<vector<string>>& handle_lists, const string& context);
 
    private:
     static mutex api_mutex;

--- a/src/attention_broker/BUILD
+++ b/src/attention_broker/BUILD
@@ -34,6 +34,7 @@ cc_library(
     name = "attention_broker_client",
     srcs = ["AttentionBrokerClient.cc"],
     hdrs = ["AttentionBrokerClient.h"],
+    includes = ["."],
     deps = [
         "//commons:commons_lib",
         "@com_github_grpc_grpc//:grpc++",
@@ -46,6 +47,7 @@ cc_library(
     name = "hebbian_network",
     srcs = ["HebbianNetwork.cc"],
     hdrs = ["HebbianNetwork.h"],
+    includes = ["."],
     deps = [
         "//commons:commons_lib",
         "//commons:handle_trie",
@@ -57,6 +59,7 @@ cc_library(
     name = "hebbian_network_updater",
     srcs = ["HebbianNetworkUpdater.cc"],
     hdrs = ["HebbianNetworkUpdater.h"],
+    includes = ["."],
     deps = [
         ":hebbian_network",
         "//commons:commons_lib",
@@ -72,6 +75,7 @@ cc_library(
     name = "request_selector",
     srcs = ["RequestSelector.cc"],
     hdrs = ["RequestSelector.h"],
+    includes = ["."],
     deps = [
         ":hebbian_network",
         "//commons:commons_lib",

--- a/src/attention_broker/HebbianNetworkUpdater.cc
+++ b/src/attention_broker/HebbianNetworkUpdater.cc
@@ -1,7 +1,9 @@
 #include "HebbianNetworkUpdater.h"
 
-#include <string>
+#define LOG_LEVEL DEBUG_LEVEL
+#include "Logger.h"
 
+#include <string>
 #include "Utils.h"
 
 using namespace attention_broker_server;
@@ -42,6 +44,7 @@ void HebbianNetworkUpdater::determiners(const dasproto::HandleList& sub_request,
                 node2->count = 0;
             }
             node1->determiners.insert(node2);
+            LOG_DEBUG("Adding importance determiner: " + sub_request.list(0) + " -> " + sub_request.list(i));
         }
     }
 }

--- a/src/attention_broker/HebbianNetworkUpdater.cc
+++ b/src/attention_broker/HebbianNetworkUpdater.cc
@@ -1,6 +1,6 @@
 #include "HebbianNetworkUpdater.h"
 
-#define LOG_LEVEL DEBUG_LEVEL
+#define LOG_LEVEL INFO_LEVEL
 #include "Logger.h"
 
 #include <string>

--- a/src/attention_broker/HebbianNetworkUpdater.cc
+++ b/src/attention_broker/HebbianNetworkUpdater.cc
@@ -1,9 +1,9 @@
 #include "HebbianNetworkUpdater.h"
 
 #define LOG_LEVEL INFO_LEVEL
-#include "Logger.h"
-
 #include <string>
+
+#include "Logger.h"
 #include "Utils.h"
 
 using namespace attention_broker_server;
@@ -44,7 +44,8 @@ void HebbianNetworkUpdater::determiners(const dasproto::HandleList& sub_request,
                 node2->count = 0;
             }
             node1->determiners.insert(node2);
-            LOG_DEBUG("Adding importance determiner: " + sub_request.list(0) + " -> " + sub_request.list(i));
+            LOG_DEBUG("Adding importance determiner: " + sub_request.list(0) + " -> " +
+                      sub_request.list(i));
         }
     }
 }

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -469,7 +469,11 @@ cc_test(
 cc_test(
     name = "context_test",
     size = "small",
-    srcs = ["context_test.cc"],
+    srcs = [
+        "context_test.cc",
+        "test_utils.cc",
+        "test_utils.h",
+    ],
     copts = [
         "-Iexternal/gtest/googletest/include",
         "-Iexternal/gtest/googletest",

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -467,6 +467,31 @@ cc_test(
 )
 
 cc_test(
+    name = "context_test",
+    size = "small",
+    srcs = ["context_test.cc"],
+    copts = [
+        "-Iexternal/gtest/googletest/include",
+        "-Iexternal/gtest/googletest",
+    ],
+    linkopts = [
+        "-L/usr/local/lib",
+        "-lhiredis_cluster",
+        "-lhiredis",
+        "-lmongocxx",
+        "-lbsoncxx",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//atomdb:atomdb",
+        "//atom_space:context",
+        "//attention_broker:attention_broker_lib",
+        "//tests/cpp/test_commons",
+        "@com_github_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "query_evolution_test",
     size = "small",
     srcs = ["query_evolution_test.cc"],

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -487,8 +487,8 @@ cc_test(
     ],
     linkstatic = 1,
     deps = [
-        "//atomdb:atomdb",
         "//atom_space:context",
+        "//atomdb",
         "//attention_broker:attention_broker_lib",
         "//tests/cpp/test_commons",
         "@com_github_google_googletest//:gtest_main",

--- a/src/tests/cpp/context_test.cc
+++ b/src/tests/cpp/context_test.cc
@@ -16,6 +16,7 @@ using namespace atomdb;
 using namespace atom_space;
 using namespace attention_broker;
 
+/*
 class TestContext : public Context {
    public:
     TestContext(const string& name, Atom& atom_key) : Context(name, atom_key) {}
@@ -83,3 +84,4 @@ TEST(Context, basics) {
     EXPECT_TRUE(importance[5] > importance[6]);
     EXPECT_TRUE(double_equals(importance[6], importance[7]));
 }
+*/

--- a/src/tests/cpp/context_test.cc
+++ b/src/tests/cpp/context_test.cc
@@ -22,7 +22,7 @@ class TestContext : public Context {
 };
 
 /*
-TEST(Context, basics) {
+TEST(Context, link_delete) {
     TestConfig::load_environment();
     AtomDBSingleton::init();
     shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();

--- a/src/tests/cpp/context_test.cc
+++ b/src/tests/cpp/context_test.cc
@@ -21,47 +21,6 @@ class TestContext : public Context {
     TestContext(const string& name, Atom& atom_key) : Context(name, atom_key) {}
 };
 
-/*
-TEST(Context, link_delete) {
-    TestConfig::load_environment();
-    AtomDBSingleton::init();
-    shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
-
-    // (outter (intermediate (inner a) b) c)
-    string node1 = db->add_node(new Node("Symbol", "outter"));
-    string node2 = db->add_node(new Node("Symbol", "intermediate"));
-    string node3 = db->add_node(new Node("Symbol", "inner"));
-    string node4 = db->add_node(new Node("Symbol", "a"));
-    string node5 = db->add_node(new Node("Symbol", "b"));
-    string node6 = db->add_node(new Node("Symbol", "c"));
-    string link1 = db->add_link(new Link("Expression", {node3, node4}));
-    string link2 = db->add_link(new Link("Expression", {node2, link1, node5}));
-    string link3 = db->add_link(new Link("Expression", {node1, link2, node6}, true));
-
-    cout << "XXX node1: " << node1 << endl;
-    cout << "XXX node2: " << node2 << endl;
-    cout << "XXX node3: " << node3 << endl;
-    cout << "XXX node4: " << node4 << endl;
-    cout << "XXX node5: " << node5 << endl;
-    cout << "XXX node6: " << node6 << endl;
-    cout << "XXX link1: " << link1 << endl;
-    cout << "XXX link2: " << link2 << endl;
-    cout << "XXX link3: " << link3 << endl;
-
-    db->delete_link(link3, true);
-
-    //db->delete_link(link3);
-    //db->delete_link(link2);
-    //db->delete_link(link1);
-    //db->delete_link(node1);
-    //db->delete_link(node2);
-    //db->delete_link(node3);
-    //db->delete_link(node4);
-    //db->delete_link(node5);
-    //db->delete_link(node6);
-}
-*/
-
 TEST(Context, basics) {
     TestConfig::load_environment();
     AtomDBSingleton::init();
@@ -102,6 +61,7 @@ TEST(Context, basics) {
         } else {
             EXPECT_TRUE(importance[i] > 0);
         }
+        cout << "importance[" << i << "]: " << importance[i] << endl;
     }
     EXPECT_TRUE(double_equals(importance[5], importance[6]));
     EXPECT_TRUE(double_equals(importance[5], importance[7]));
@@ -109,6 +69,9 @@ TEST(Context, basics) {
     AttentionBrokerClient::stimulate({{node2, 1}}, context->get_key());
     importance.clear();
     AttentionBrokerClient::get_importance(handles, context->get_key(), importance);
+    for (unsigned int i = 0; i < handles.size(); i++) {
+        cout << "importance[" << i << "]: " << importance[i] << endl;
+    }
     EXPECT_TRUE(importance[0] == 0);
     EXPECT_TRUE(importance[1] > 0);
     EXPECT_TRUE(importance[2] == 0);

--- a/src/tests/cpp/context_test.cc
+++ b/src/tests/cpp/context_test.cc
@@ -1,0 +1,117 @@
+#include "AtomDBSingleton.h"
+#include "AttentionBrokerClient.h"
+#include "Context.h"
+#include "Hasher.h"
+#include "TestConfig.h"
+#include "test_utils.h"
+#include "Utils.h"
+#include "gtest/gtest.h"
+
+#include "UntypedVariable.h"
+
+#define LOG_LEVEL INFO_LEVEL
+#include "Logger.h"
+
+using namespace atomdb;
+using namespace atom_space;
+using namespace attention_broker;
+
+class TestContext : public Context {
+   public:
+    TestContext(const string& name, Atom& atom_key) : Context(name, atom_key) {}
+};
+
+/*
+TEST(Context, basics) {
+    TestConfig::load_environment();
+    AtomDBSingleton::init();
+    shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
+
+    // (outter (intermediate (inner a) b) c)
+    string node1 = db->add_node(new Node("Symbol", "outter"));
+    string node2 = db->add_node(new Node("Symbol", "intermediate"));
+    string node3 = db->add_node(new Node("Symbol", "inner"));
+    string node4 = db->add_node(new Node("Symbol", "a"));
+    string node5 = db->add_node(new Node("Symbol", "b"));
+    string node6 = db->add_node(new Node("Symbol", "c"));
+    string link1 = db->add_link(new Link("Expression", {node3, node4}));
+    string link2 = db->add_link(new Link("Expression", {node2, link1, node5}));
+    string link3 = db->add_link(new Link("Expression", {node1, link2, node6}, true));
+
+    cout << "XXX node1: " << node1 << endl;
+    cout << "XXX node2: " << node2 << endl;
+    cout << "XXX node3: " << node3 << endl;
+    cout << "XXX node4: " << node4 << endl;
+    cout << "XXX node5: " << node5 << endl;
+    cout << "XXX node6: " << node6 << endl;
+    cout << "XXX link1: " << link1 << endl;
+    cout << "XXX link2: " << link2 << endl;
+    cout << "XXX link3: " << link3 << endl;
+
+    db->delete_link(link3, true);
+
+    //db->delete_link(link3);
+    //db->delete_link(link2);
+    //db->delete_link(link1);
+    //db->delete_link(node1);
+    //db->delete_link(node2);
+    //db->delete_link(node3);
+    //db->delete_link(node4);
+    //db->delete_link(node5);
+    //db->delete_link(node6);
+}
+*/
+
+TEST(Context, basics) {
+    TestConfig::load_environment();
+    AtomDBSingleton::init();
+    shared_ptr<AtomDB> db = AtomDBSingleton::get_instance();
+    random_init();
+
+    string node1 = Hasher::node_handle("Symbol", "\"human\"");
+    string node2 = Hasher::node_handle("Symbol", "\"monkey\"");
+    string node3 = Hasher::node_handle("Symbol", "\"chimp\"");
+    string node4 = Hasher::node_handle("Symbol", "\"ent\"");
+    string node5 = Hasher::node_handle("Symbol", "Similarity");
+    string link1 = Hasher::link_handle("Expression", {node5, node1, node2});
+    string link2 = Hasher::link_handle("Expression", {node5, node1, node3});
+    string link3 = Hasher::link_handle("Expression", {node5, node1, node4});
+
+    vector<string> tokens = {
+        "LINK_TEMPLATE", "Expression", "3",
+            "NODE", "Symbol", "Similarity",
+            "NODE", "Symbol", "\"human\"",
+            "VARIABLE", "v1"
+    };
+    LinkSchema atom_key(tokens);
+    TestContext* context = new TestContext(random_handle(), atom_key);
+
+    vector<string> handles = {node1, node2, node3, node4, node5, link1, link2, link3};
+    vector<float> importance;
+    vector<float> expected;
+
+    AttentionBrokerClient::get_importance(handles, context->get_key(), importance);
+    for (unsigned int i = 0; i < handles.size(); i++) {
+        if (i <= 4) {
+            EXPECT_TRUE(importance[i] == 0);
+        } else {
+            EXPECT_TRUE(importance[i] > 0);
+        }
+    }
+    EXPECT_TRUE(double_equals(importance[5], importance[6]));
+    EXPECT_TRUE(double_equals(importance[5], importance[7]));
+
+    AttentionBrokerClient::stimulate({{node2, 1}}, context->get_key());
+    importance.clear();
+    AttentionBrokerClient::get_importance(handles, context->get_key(), importance);
+    EXPECT_TRUE(importance[0] == 0);
+    EXPECT_TRUE(importance[1] > 0);
+    EXPECT_TRUE(importance[2] == 0);
+    EXPECT_TRUE(importance[3] == 0);
+    EXPECT_TRUE(importance[4] == 0);
+    EXPECT_TRUE(importance[5] > 0);
+    EXPECT_TRUE(importance[6] > 0);
+    EXPECT_TRUE(importance[7] > 0);
+    EXPECT_TRUE(importance[5] > importance[6]);
+    EXPECT_TRUE(double_equals(importance[6], importance[7]));
+}

--- a/src/tests/cpp/context_test.cc
+++ b/src/tests/cpp/context_test.cc
@@ -1,13 +1,13 @@
+#include "Context.h"
+
 #include "AtomDBSingleton.h"
 #include "AttentionBrokerClient.h"
-#include "Context.h"
 #include "Hasher.h"
 #include "TestConfig.h"
-#include "test_utils.h"
+#include "UntypedVariable.h"
 #include "Utils.h"
 #include "gtest/gtest.h"
-
-#include "UntypedVariable.h"
+#include "test_utils.h"
 
 #define LOG_LEVEL INFO_LEVEL
 #include "Logger.h"
@@ -77,12 +77,17 @@ TEST(Context, basics) {
     string link2 = Hasher::link_handle("Expression", {node5, node1, node3});
     string link3 = Hasher::link_handle("Expression", {node5, node1, node4});
 
-    vector<string> tokens = {
-        "LINK_TEMPLATE", "Expression", "3",
-            "NODE", "Symbol", "Similarity",
-            "NODE", "Symbol", "\"human\"",
-            "VARIABLE", "v1"
-    };
+    vector<string> tokens = {"LINK_TEMPLATE",
+                             "Expression",
+                             "3",
+                             "NODE",
+                             "Symbol",
+                             "Similarity",
+                             "NODE",
+                             "Symbol",
+                             "\"human\"",
+                             "VARIABLE",
+                             "v1"};
     LinkSchema atom_key(tokens);
     TestContext* context = new TestContext(random_handle(), atom_key);
 

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -814,6 +814,8 @@ TEST_F(RedisMongoDBTest, GetMatchingAtoms) {
 
     auto matching_atoms = db->get_matching_atoms(false, *similarity_node);
     EXPECT_EQ(matching_atoms.size(), 1);
+    string named_type = matching_atoms[0]->get("named_type");
+    EXPECT_EQ(named_type, string("Symbol"));
     matching_atoms = db->get_matching_atoms(true, *similarity_node);
     EXPECT_EQ(matching_atoms.size(), 0);
 

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -515,41 +515,6 @@ TEST_F(RedisMongoDBTest, DeleteLinkAndDeleteItsTargets) {
     EXPECT_EQ(db->nodes_exist(nodes_handles).size(), 0);
 }
 
-TEST_F(RedisMongoDBTest, DeleteNestedLink) {
-    // (outter (intermediate (inner a) b) c)
-    string node1 = db->add_node(new Node("Symbol", "outter"));
-    string node2 = db->add_node(new Node("Symbol", "intermediate"));
-    string node3 = db->add_node(new Node("Symbol", "inner"));
-    string node4 = db->add_node(new Node("Symbol", "a"));
-    string node5 = db->add_node(new Node("Symbol", "b"));
-    string node6 = db->add_node(new Node("Symbol", "c"));
-    string link1 = db->add_link(new Link("Expression", {node3, node4}));
-    string link2 = db->add_link(new Link("Expression", {node2, link1, node5}));
-    string link3 = db->add_link(new Link("Expression", {node1, link2, node6}, true));
-
-    cout << "XXX node1: " << node1 << endl;
-    cout << "XXX node2: " << node2 << endl;
-    cout << "XXX node3: " << node3 << endl;
-    cout << "XXX node4: " << node4 << endl;
-    cout << "XXX node5: " << node5 << endl;
-    cout << "XXX node6: " << node6 << endl;
-    cout << "XXX link1: " << link1 << endl;
-    cout << "XXX link2: " << link2 << endl;
-    cout << "XXX link3: " << link3 << endl;
-
-    db->delete_link(link3, true);
-
-    EXPECT_FALSE(db->link_exists(node1));
-    EXPECT_FALSE(db->link_exists(node2));
-    EXPECT_FALSE(db->link_exists(node3));
-    EXPECT_FALSE(db->link_exists(node4));
-    EXPECT_FALSE(db->link_exists(node5));
-    EXPECT_FALSE(db->link_exists(node6));
-    EXPECT_FALSE(db->link_exists(link1));
-    EXPECT_FALSE(db->link_exists(link2));
-    EXPECT_FALSE(db->link_exists(link3));
-}
-
 TEST_F(RedisMongoDBTest, DeleteLinkWithNestedLink) {
     // Delete a link with a nested links
     // (TestLinkName (TestNestedLinkName1 (TestNestedLinkName2 N1 N2) N3) N4)

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -515,6 +515,41 @@ TEST_F(RedisMongoDBTest, DeleteLinkAndDeleteItsTargets) {
     EXPECT_EQ(db->nodes_exist(nodes_handles).size(), 0);
 }
 
+TEST_F(RedisMongoDBTest, DeleteNestedLink) {
+    // (outter (intermediate (inner a) b) c)
+    string node1 = db->add_node(new Node("Symbol", "outter"));
+    string node2 = db->add_node(new Node("Symbol", "intermediate"));
+    string node3 = db->add_node(new Node("Symbol", "inner"));
+    string node4 = db->add_node(new Node("Symbol", "a"));
+    string node5 = db->add_node(new Node("Symbol", "b"));
+    string node6 = db->add_node(new Node("Symbol", "c"));
+    string link1 = db->add_link(new Link("Expression", {node3, node4}));
+    string link2 = db->add_link(new Link("Expression", {node2, link1, node5}));
+    string link3 = db->add_link(new Link("Expression", {node1, link2, node6}, true));
+
+    cout << "XXX node1: " << node1 << endl;
+    cout << "XXX node2: " << node2 << endl;
+    cout << "XXX node3: " << node3 << endl;
+    cout << "XXX node4: " << node4 << endl;
+    cout << "XXX node5: " << node5 << endl;
+    cout << "XXX node6: " << node6 << endl;
+    cout << "XXX link1: " << link1 << endl;
+    cout << "XXX link2: " << link2 << endl;
+    cout << "XXX link3: " << link3 << endl;
+
+    db->delete_link(link3, true);
+
+    EXPECT_FALSE(db->link_exists(node1));
+    EXPECT_FALSE(db->link_exists(node2));
+    EXPECT_FALSE(db->link_exists(node3));
+    EXPECT_FALSE(db->link_exists(node4));
+    EXPECT_FALSE(db->link_exists(node5));
+    EXPECT_FALSE(db->link_exists(node6));
+    EXPECT_FALSE(db->link_exists(link1));
+    EXPECT_FALSE(db->link_exists(link2));
+    EXPECT_FALSE(db->link_exists(link3));
+}
+
 TEST_F(RedisMongoDBTest, DeleteLinkWithNestedLink) {
     // Delete a link with a nested links
     // (TestLinkName (TestNestedLinkName1 (TestNestedLinkName2 N1 N2) N3) N4)

--- a/src/tests/cpp/test_utils.cc
+++ b/src/tests/cpp/test_utils.cc
@@ -25,9 +25,7 @@ static char REVERSE_TLB[16] = {
     'f',
 };
 
-void random_init() {
-    std::srand(static_cast<unsigned int>(std::time(0)));
-}
+void random_init() { std::srand(static_cast<unsigned int>(std::time(0))); }
 
 double random_importance() { return ((double) rand()) / RAND_MAX; }
 

--- a/src/tests/cpp/test_utils.cc
+++ b/src/tests/cpp/test_utils.cc
@@ -25,6 +25,10 @@ static char REVERSE_TLB[16] = {
     'f',
 };
 
+void random_init() {
+    std::srand(static_cast<unsigned int>(std::time(0)));
+}
+
 double random_importance() { return ((double) rand()) / RAND_MAX; }
 
 string random_handle() {

--- a/src/tests/cpp/test_utils.h
+++ b/src/tests/cpp/test_utils.h
@@ -7,6 +7,7 @@
 
 using namespace std;
 
+void random_init();
 double random_importance();
 string random_handle();
 string sequential_label(unsigned int& count, string prefix = "v");


### PR DESCRIPTION
Resolves #695 

Upon creation, Context objects initialize importance of pertinent handles in the AttentionBroker and set up importance determiner relationships between top-level links and their constituents. For instance, given a top-level link (contains (sentence "blah blah blah") (word "blah")), the importance of the outer "contains" would be the greatest value among its importance itself and the importance of (sentence "blah blah blah") and (word "blah").