### PR TITLE
[Fix][AtomDBCache] Split document caching into nodes and links.

### DIFF
--- a/src/atomdb/AtomDBCache.cc
+++ b/src/atomdb/AtomDBCache.cc
@@ -6,24 +6,49 @@
 using namespace std;
 using namespace atomdb;
 
-AtomDBCache::GetAtomDocumentResult AtomDBCache::get_atom_document(const string& handle) {
-    lock_guard<mutex> lock(atom_doc_cache_mutex);
-    if (atom_doc_cache.find(handle) != atom_doc_cache.end()) {
+AtomDBCache::GetAtomDocumentResult AtomDBCache::get_node_document(const string& handle) {
+    lock_guard<mutex> lock(node_doc_cache_mutex);
+    if (node_doc_cache.find(handle) != node_doc_cache.end()) {
         LOG_DEBUG("cache hit " << handle);
-        return {true, atom_doc_cache[handle]};
+        return {true, node_doc_cache[handle]};
     }
     LOG_DEBUG("cache miss " << handle);
     return {false, nullptr};
 }
 
-void AtomDBCache::add_atom_document(const string& handle,
+void AtomDBCache::add_node_document(const string& handle,
                                     shared_ptr<atomdb_api_types::AtomDocument> document) {
-    lock_guard<mutex> lock(atom_doc_cache_mutex);
-    atom_doc_cache[handle] = document;
+    lock_guard<mutex> lock(node_doc_cache_mutex);
+    node_doc_cache[handle] = document;
 }
 
-AtomDBCache::QueryForPatternResult AtomDBCache::query_for_pattern(const LinkSchema& link_schema) {
-    auto pattern_handle = link_schema.handle();
+void AtomDBCache::erase_node_document_cache(const string& handle) {
+    lock_guard<mutex> lock(node_doc_cache_mutex);
+    node_doc_cache.erase(handle);
+}
+
+AtomDBCache::GetAtomDocumentResult AtomDBCache::get_link_document(const string& handle) {
+    lock_guard<mutex> lock(link_doc_cache_mutex);
+    if (link_doc_cache.find(handle) != link_doc_cache.end()) {
+        LOG_DEBUG("cache hit " << handle);
+        return {true, link_doc_cache[handle]};
+    }
+    LOG_DEBUG("cache miss " << handle);
+    return {false, nullptr};
+}
+
+void AtomDBCache::add_link_document(const string& handle,
+                                    shared_ptr<atomdb_api_types::AtomDocument> document) {
+    lock_guard<mutex> lock(link_doc_cache_mutex);
+    link_doc_cache[handle] = document;
+}
+
+void AtomDBCache::erase_link_document_cache(const string& handle) {
+    lock_guard<mutex> lock(link_doc_cache_mutex);
+    link_doc_cache.erase(handle);
+}
+
+AtomDBCache::QueryForPatternResult AtomDBCache::query_for_pattern(const string& pattern_handle) {
     lock_guard<mutex> lock(pattern_matching_cache_mutex);
     if (pattern_matching_cache.find(pattern_handle) != pattern_matching_cache.end()) {
         LOG_DEBUG("cache hit " << pattern_handle);
@@ -44,6 +69,11 @@ void AtomDBCache::erase_pattern_matching_cache(const string& pattern_handle) {
     pattern_matching_cache.erase(pattern_handle);
 }
 
+void AtomDBCache::clear_all_pattern_handles() {
+    lock_guard<mutex> lock(pattern_matching_cache_mutex);
+    pattern_matching_cache.clear();
+}
+
 AtomDBCache::QueryForTargetsResult AtomDBCache::query_for_targets(const string& link_handle) {
     lock_guard<mutex> lock(handle_list_cache_mutex);
     if (handle_list_cache.find(link_handle) != handle_list_cache.end()) {
@@ -54,10 +84,21 @@ AtomDBCache::QueryForTargetsResult AtomDBCache::query_for_targets(const string& 
     return {false, nullptr};
 }
 
-void AtomDBCache::add_handle_list(const string& link_handle,
-                                  shared_ptr<atomdb_api_types::HandleList> results) {
+void AtomDBCache::add_handle_targets(const string& link_handle,
+                                     shared_ptr<atomdb_api_types::HandleList> results) {
     lock_guard<mutex> lock(handle_list_cache_mutex);
     handle_list_cache[link_handle] = results;
+}
+
+void AtomDBCache::erase_handle_targets_cache(const string& link_handle) {
+    lock_guard<mutex> lock(handle_list_cache_mutex);
+    cout << "XXX erase_handle_targets_cache " << link_handle << endl;
+    handle_list_cache.erase(link_handle);
+}
+
+void AtomDBCache::clear_all_targets_handles() {
+    lock_guard<mutex> lock(handle_list_cache_mutex);
+    handle_list_cache.clear();
 }
 
 AtomDBCache::QueryForIncomingResult AtomDBCache::query_for_incoming_set(const string& handle) {
@@ -79,4 +120,9 @@ void AtomDBCache::add_incoming_set(const string& handle,
 void AtomDBCache::erase_incoming_set_cache(const string& handle) {
     lock_guard<mutex> lock(incoming_set_cache_mutex);
     incoming_set_cache.erase(handle);
+}
+
+void AtomDBCache::clear_all_incoming_handles() {
+    lock_guard<mutex> lock(incoming_set_cache_mutex);
+    incoming_set_cache.clear();
 }

--- a/src/atomdb/AtomDBCache.h
+++ b/src/atomdb/AtomDBCache.h
@@ -69,28 +69,58 @@ class AtomDBCache {
     virtual ~AtomDBCache() {}
 
     /**
-     * @brief Get an atom document from the cache.
+     * @brief Get a node document from the cache.
      *
-     * @param handle The handle of the atom document.
-     * @return The atom document if it is cached, nullptr otherwise.
+     * @param handle The handle of the node document.
+     * @return The node document if it is cached, nullptr otherwise.
      */
-    GetAtomDocumentResult get_atom_document(const string& handle);
+    GetAtomDocumentResult get_node_document(const string& handle);
 
     /**
-     * @brief Add an atom document to the cache.
+     * @brief Add a node document to the cache.
      *
-     * @param handle The handle of the atom document.
-     * @param document The atom document to be cached.
+     * @param handle The handle of the node document.
+     * @param document The node document to be cached.
      */
-    void add_atom_document(const string& handle, shared_ptr<atomdb_api_types::AtomDocument> document);
+    void add_node_document(const string& handle, shared_ptr<atomdb_api_types::AtomDocument> document);
+
+    /**
+     * @brief Invalidate the node document cache for a handle.
+     *
+     * @param handle The handle of the node document.
+     */
+    void erase_node_document_cache(const string& handle);
+
+    /**
+     * @brief Get a link document from the cache.
+     *
+     * @param handle The handle of the link document.
+     * @return The link document if it is cached, nullptr otherwise.
+     */
+    GetAtomDocumentResult get_link_document(const string& handle);
+
+    /**
+     * @brief Add a link document to the cache.
+     *
+     * @param handle The handle of the link document.
+     * @param document The link document to be cached.
+     */
+    void add_link_document(const string& handle, shared_ptr<atomdb_api_types::AtomDocument> document);
+
+    /**
+     * @brief Invalidate the link document cache for a handle.
+     *
+     * @param handle The handle of the link document.
+     */
+    void erase_link_document_cache(const string& handle);
 
     /**
      * @brief Query for a pattern matching.
      *
-     * @param link_schema A LinkSchema.
+     * @param pattern_handle The handle of the pattern.
      * @return The result of the query if it is cached, nullptr otherwise.
      */
-    QueryForPatternResult query_for_pattern(const LinkSchema& link_schema);
+    QueryForPatternResult query_for_pattern(const string& pattern_handle);
 
     /**
      * @brief Add a pattern matching to the cache.
@@ -109,6 +139,11 @@ class AtomDBCache {
     void erase_pattern_matching_cache(const string& pattern_handle);
 
     /**
+     * @brief Clear the pattern matching cache for all handles.
+     */
+    void clear_all_pattern_handles();
+
+    /**
      * @brief Query for targets.
      *
      * @param link_handle The handle of the link.
@@ -117,12 +152,24 @@ class AtomDBCache {
     QueryForTargetsResult query_for_targets(const string& link_handle);
 
     /**
-     * @brief Add a handle list to the cache.
+     * @brief Add handle's targets to the cache.
      *
      * @param link_handle The handle of the link.
      * @param results The result of the query to be cached.
      */
-    void add_handle_list(const string& link_handle, shared_ptr<atomdb_api_types::HandleList> results);
+    void add_handle_targets(const string& link_handle, shared_ptr<atomdb_api_types::HandleList> results);
+
+    /**
+     * @brief Invalidate the targets cache for a handle.
+     *
+     * @param link_handle The handle of the link.
+     */
+    void erase_handle_targets_cache(const string& link_handle);
+
+    /**
+     * @brief Clear all targets cache.
+     */
+    void clear_all_targets_handles();
 
     /**
      * @brief Query for incoming set values.
@@ -147,15 +194,29 @@ class AtomDBCache {
      */
     void erase_incoming_set_cache(const string& handle);
 
+    /**
+     * @brief Clear all incoming set cache.
+     */
+    void clear_all_incoming_handles();
+
    private:
     /**
-     * @brief The cache for atom documents.
+     * @brief The cache for node documents.
      */
-    unordered_map<string, shared_ptr<atomdb_api_types::AtomDocument>> atom_doc_cache;
+    unordered_map<string, shared_ptr<atomdb_api_types::AtomDocument>> node_doc_cache;
     /**
-     * @brief The mutex for the atom document cache.
+     * @brief The mutex for the node document cache.
      */
-    mutex atom_doc_cache_mutex;
+    mutex node_doc_cache_mutex;
+
+    /**
+     * @brief The cache for link documents.
+     */
+    unordered_map<string, shared_ptr<atomdb_api_types::AtomDocument>> link_doc_cache;
+    /**
+     * @brief The mutex for the link document cache.
+     */
+    mutex link_doc_cache_mutex;
 
     /**
      * @brief The cache for pattern matching results.

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -107,7 +107,7 @@ void MorkDB::mork_setup() {
 
 shared_ptr<atomdb_api_types::HandleSet> MorkDB::query_for_pattern(const LinkSchema& link_schema) {
     if (this->atomdb_cache != nullptr) {
-        auto cache_result = this->atomdb_cache->query_for_pattern(link_schema);
+        auto cache_result = this->atomdb_cache->query_for_pattern(link_schema.handle());
         if (cache_result.is_cache_hit) return cache_result.result;
     }
     string pattern_metta = link_schema.metta_representation(*this);


### PR DESCRIPTION
Current `AtomDBCache` still deals with only "atoms", this PR split that into "nodes" and "links" in order to reflect the new data structure.