### PR TITLE
[#707] Separate cache per runner to avoid Bazel conflicts

### DIFF
--- a/src/scripts/run_benchmark.sh
+++ b/src/scripts/run_benchmark.sh
@@ -351,7 +351,7 @@ scenario_data() {
 
 consolidate_reports() {
     local benchmark=$1
-    python3 ./src/scripts/python/consolidate_benchmark.py "/tmp/${benchmark}_benchmark/${TIMESTAMP}" --scenario "$(scenario_data)" --type "$benchmark" --output-file "/tmp/${benchmark}_benchmark/${TIMESTAMP}/consolidated_report.txt" --header-text "$(header_to_report)" --db-path "/home/$USER/.cache/das/benchmark.db"
+    python3 ./src/scripts/python/consolidate_benchmark.py "/tmp/${benchmark}_benchmark/${TIMESTAMP}" --scenario "$(scenario_data)" --type "$benchmark" --output-file "/tmp/${benchmark}_benchmark/${TIMESTAMP}/consolidated_report.txt" --header-text "$(header_to_report)" --db-path "/home/$USER/.cache/shared/benchmark.db"
     echo ""
     echo -e "\r\033[K${GREEN}Consolidated reports saved to database${RESET}"
 }


### PR DESCRIPTION
Closes #707 

In this task I’m adding a new volume to store data that needs to be shared across all runners. It gets mounted at /home/`$USER/.cache/shared` inside the container, and I moved the database there so every runner can access it. The old volume at `/home/$USER/.cache/das` won’t be shared anymore, now it’s just for the Bazel cache, with each runner keeping its own separate cache.