### PR TITLE
[#727] Fix `MongodbDocument::get_size()`

### DIFF
--- a/src/MODULE.bazel.lock
+++ b/src/MODULE.bazel.lock
@@ -240,8 +240,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.4.0/MODULE.bazel": "a592852f8a3dd539e82ee6542013bf2cadfc4c6946be8941e189d224500a8934",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.12.0/MODULE.bazel": "8e6590b961f2defdfc2811c089c75716cb2f06c8a4edeb9a8d85eaa64ee2a761",
-    "https://bcr.bazel.build/modules/rules_java/8.12.0/source.json": "cbd5d55d9d38d4008a7d00bee5b5a5a4b6031fcd4a56515c9accbcd42c7be2ba",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
+    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
@@ -368,7 +368,7 @@
     },
     "@@buildifier_prebuilt+//:defs.bzl%buildifier_prebuilt_deps_extension": {
       "general": {
-        "bzlTransitiveDigest": "X67aPQER7Ge9vxgB16pXU8HvbgAOOUzmz+S0EgyRtNc=",
+        "bzlTransitiveDigest": "6uZYZvpDTJWhBtMT+LOymWBnJEkn4/W7jsVIvUzG9dU=",
         "usagesDigest": "E92htUw9elHOT0ZHIEdwgPVnslFqL2iu3pcplYXXAxk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -741,7 +741,7 @@
     },
     "@@rules_buf+//buf:extensions.bzl%ext": {
       "general": {
-        "bzlTransitiveDigest": "Fk4QK5kj/HKxKVGAfyZEJNUAOC+Ic+kKMcXb20jecDE=",
+        "bzlTransitiveDigest": "SDu9W4CQUvGE9A6LTAEbu5g75w34Inmz0/AX9wecDv4=",
         "usagesDigest": "RTc2BMQ2b0wGU8CRvN3EoPz34m3LMe+K/oSkFkN83+M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -765,7 +765,7 @@
     },
     "@@rules_foreign_cc+//foreign_cc:extensions.bzl%tools": {
       "general": {
-        "bzlTransitiveDigest": "ginC3lIGOKKivBi0nyv2igKvSiz42Thm8yaX2RwVaHg=",
+        "bzlTransitiveDigest": "jO6HNyY7/eIylNs2RYABjCfbAgUNb1oiXpl3aY4V/hI=",
         "usagesDigest": "9LXdVp01HkdYQT8gYPjYLO6VLVJHo9uFfxWaU1ymiRE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1079,7 +1079,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
+        "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1143,7 +1143,7 @@
     },
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
-        "bzlTransitiveDigest": "hb4P9W+UouOR3GTf2pDXbhhQFSTElj+EgJVbrB5U+cQ=",
+        "bzlTransitiveDigest": "PlbDlTkTjipL4rJTSM7NFGKQWgR5KMJGAfophD4adeo=",
         "usagesDigest": "8OoyQ05AfTDe1T/jKkylUFidWxQge7e3HN2eOIIA6xM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -6482,7 +6482,7 @@
     },
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
-        "bzlTransitiveDigest": "c7CepP0Yj264OYMqO5rjhtkrLqAnrHo+oagUNiAYKVw=",
+        "bzlTransitiveDigest": "oeHZVRBsbR1q0Wiu9J7hKek7CJOJZvDdpa+OPo78thk=",
         "usagesDigest": "IzLZJo6jscH0wDdOUqR2z5ZKOHfkhS4PKLUmCbhjU2I=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
@@ -134,17 +134,8 @@ bool MongodbDocument::contains(const string& key) {
 }
 
 unsigned int MongodbDocument::get_size(const string& array_key) {
-    // NOTE TO REVIEWER
-    // TODO: this implementation is wrong and need to be fixed before integration in das-atom-db
-    // I couldn't figure out a way to discover the number of elements in a BSON array.
-    // cout << "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" << endl;
-    // cout << "XXXXXXXXXXXXXXXXXXX MongodbDocument::get_size()" << endl;
-    // cout << "XXXXXXXXXXXXXXXXXXX MongodbDocument::get_size() length: " <<
-    // ((*this->document)[array_key]).get_array().value.length() << endl; cout << "XXXXXXXXXXXXXXXXXXX
-    // MongodbDocument::get_size() HASH: " << HANDLE_HASH_SIZE << endl; cout << "XXXXXXXXXXXXXXXXXXX
-    // MongodbDocument::get_size() size: " << ((*this->document)[array_key]).get_array().value.length() /
-    // HANDLE_HASH_SIZE << endl;
-    return ((*this->document)[array_key]).get_array().value.length() / HANDLE_HASH_SIZE;
+    auto array = ((*this->document)[array_key]).get_array().value;
+    return std::distance(array.begin(), array.end());
 }
 
 bsoncxx::v_noabi::document::view MongodbDocument::get_object(const string& key) {

--- a/src/tests/cpp/redis_mongodb_test_2.cc
+++ b/src/tests/cpp/redis_mongodb_test_2.cc
@@ -196,12 +196,10 @@ TEST_F(RedisMongoDBTest, MongodbDocumentGetSize) {
     string node9 = db2->add_node(new Node("Symbol", "9"));
     string node10 = db2->add_node(new Node("Symbol", "10"));
 
-    string link1 = db2->add_link(
-        new Link("Expression", {node1, node2, node3, node4, node5}));
-    string link2 = db2->add_link(
-        new Link("Expression", {node1, node2, node3, node4, node5, node6}));
-    string link3 = db2->add_link(
-        new Link("Expression", {node1, node2, node3, node4, node5, node6, node7, node8}));
+    string link1 = db2->add_link(new Link("Expression", {node1, node2, node3, node4, node5}));
+    string link2 = db2->add_link(new Link("Expression", {node1, node2, node3, node4, node5, node6}));
+    string link3 =
+        db2->add_link(new Link("Expression", {node1, node2, node3, node4, node5, node6, node7, node8}));
     string link4 = db2->add_link(
         new Link("Expression", {node1, node2, node3, node4, node5, node6, node7, node8, node9, node10}));
 

--- a/src/tests/cpp/redis_mongodb_test_2.cc
+++ b/src/tests/cpp/redis_mongodb_test_2.cc
@@ -184,6 +184,38 @@ TEST_F(RedisMongoDBTest, DeleteNestedLink) {
     EXPECT_FALSE(db2->link_exists(link3));
 }
 
+TEST_F(RedisMongoDBTest, MongodbDocumentGetSize) {
+    string node1 = db2->add_node(new Node("Symbol", "1"));
+    string node2 = db2->add_node(new Node("Symbol", "2"));
+    string node3 = db2->add_node(new Node("Symbol", "3"));
+    string node4 = db2->add_node(new Node("Symbol", "4"));
+    string node5 = db2->add_node(new Node("Symbol", "5"));
+    string node6 = db2->add_node(new Node("Symbol", "6"));
+    string node7 = db2->add_node(new Node("Symbol", "7"));
+    string node8 = db2->add_node(new Node("Symbol", "8"));
+    string node9 = db2->add_node(new Node("Symbol", "9"));
+    string node10 = db2->add_node(new Node("Symbol", "10"));
+
+    string link1 = db2->add_link(
+        new Link("Expression", {node1, node2, node3, node4, node5}));
+    string link2 = db2->add_link(
+        new Link("Expression", {node1, node2, node3, node4, node5, node6}));
+    string link3 = db2->add_link(
+        new Link("Expression", {node1, node2, node3, node4, node5, node6, node7, node8}));
+    string link4 = db2->add_link(
+        new Link("Expression", {node1, node2, node3, node4, node5, node6, node7, node8, node9, node10}));
+
+    auto link1_document = db2->get_atom_document(link1);
+    auto link2_document = db2->get_atom_document(link2);
+    auto link3_document = db2->get_atom_document(link3);
+    auto link4_document = db2->get_atom_document(link4);
+
+    EXPECT_EQ(link1_document->get_size("targets"), 5);
+    EXPECT_EQ(link2_document->get_size("targets"), 6);
+    EXPECT_EQ(link3_document->get_size("targets"), 8);
+    EXPECT_EQ(link4_document->get_size("targets"), 10);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(new RedisMongoDBTestEnvironment());


### PR DESCRIPTION
This solves #727 for `len(targets) >= 4`.

Just added a test, without this fix the `redis_mongodb_test_2.MongodbDocumentGetSize` test breaks with:
```
[ RUN      ] RedisMongoDBTest.MongodbDocumentGetSize
tests/cpp/redis_mongodb_test_2.cc:210: Failure
Expected equality of these values:
  link1_document->get_size("targets")
    Which is: 6
  5

tests/cpp/redis_mongodb_test_2.cc:211: Failure
Expected equality of these values:
  link2_document->get_size("targets")
    Which is: 7
  6

tests/cpp/redis_mongodb_test_2.cc:212: Failure
Expected equality of these values:
  link3_document->get_size("targets")
    Which is: 9
  8

tests/cpp/redis_mongodb_test_2.cc:213: Failure
Expected equality of these values:
  link4_document->get_size("targets")
    Which is: 12
  10

[  FAILED  ] RedisMongoDBTest.MongodbDocumentGetSize (445 ms)
```