### PR TITLE
[#750] Added a parameter for metta expression in ParserActions

### DIFF
--- a/src/agents/query_engine/MettaParserActions.cc
+++ b/src/agents/query_engine/MettaParserActions.cc
@@ -99,8 +99,8 @@ void MettaParserActions::expression_begin() {
     this->current_expression_type = LINK;
 }
 
-void MettaParserActions::expression_end(bool toplevel) {
-    ParserActions::expression_end(toplevel);
+void MettaParserActions::expression_end(bool toplevel, const string& metta_expression) {
+    ParserActions::expression_end(toplevel, metta_expression);
     unsigned int arity = this->current_expression_size;
     if (element_stack.size() < arity) {
         Utils::error("Invalid query expression: too few arguments for expression. Expected: " +

--- a/src/agents/query_engine/MettaParserActions.h
+++ b/src/agents/query_engine/MettaParserActions.h
@@ -58,7 +58,7 @@ class MettaParserActions : public ParserActions {
      *
      * @param toplevel A flag to indicate whether the expression is a toplevel onr or not.
      */
-    void expression_end(bool toplevel);
+    void expression_end(bool toplevel, const string& metta_expression);
 
     stack<shared_ptr<QueryElement>> element_stack;
 

--- a/src/metta/MettaLexer.cc
+++ b/src/metta/MettaLexer.cc
@@ -32,7 +32,7 @@ void MettaLexer::_init(unsigned int input_buffer_size) {
     this->input_buffer_size = input_buffer_size;
     this->single_string_flag = false;
     this->file_input_flag = true;
-    this->current_metta_string.reserve(1000); // any small number is OK
+    this->current_metta_string.reserve(1000);  // any small number is OK
 }
 
 MettaLexer::~MettaLexer() { free(this->input_buffer); }
@@ -218,7 +218,6 @@ unique_ptr<Token> MettaLexer::next() {
 }
 
 void MettaLexer::stack_metta_string() {
-
     this->current_metta_string.pop_back();
     this->metta_string_stack.push(this->current_metta_string);
     this->current_metta_string = "(";

--- a/src/metta/MettaLexer.h
+++ b/src/metta/MettaLexer.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <queue>
+#include <stack>
 #include <string>
 
 #include "Token.h"
@@ -69,7 +70,11 @@ class MettaLexer {
      */
     unique_ptr<Token> next();
 
+    void stack_metta_string();
+    void pop_metta_string();
+
     unsigned int line_number;
+    string current_metta_string;
 
    private:
     void _init(unsigned int input_buffer_size);
@@ -91,6 +96,7 @@ class MettaLexer {
     queue<string> attached_strings;
     queue<string> attached_file_names;
     map<string, long> current_offset;
+    stack<string> metta_string_stack;
 };
 
 }  // namespace metta

--- a/src/metta/MettaParser.cc
+++ b/src/metta/MettaParser.cc
@@ -39,6 +39,7 @@ bool MettaParser::parse(bool throw_on_parse_error) {
         if (token->type == MettaTokens::OPEN_PARENTHESIS) {
             this->actions->expression_begin();
             token_stack.push(move(token));
+            this->lexer->stack_metta_string();
         } else if (token->type == MettaTokens::CLOSE_PARENTHESIS) {
             while ((token_stack.size() > 0) &&
                    (token_stack.top()->type != MettaTokens::OPEN_PARENTHESIS)) {
@@ -49,7 +50,8 @@ bool MettaParser::parse(bool throw_on_parse_error) {
                 return true;
             }
             token_stack.pop();
-            this->actions->expression_end(token_stack.size() == 0);
+            this->actions->expression_end(token_stack.size() == 0, this->lexer->current_metta_string);
+            this->lexer->pop_metta_string();
         } else if (token->type == MettaTokens::SYMBOL) {
             this->actions->symbol(token->text);
             token_stack.push(move(token));

--- a/src/metta/ParserActions.cc
+++ b/src/metta/ParserActions.cc
@@ -24,6 +24,6 @@ void ParserActions::literal(float value) { LOG_DEBUG("FLOAT_LITERAL: <" + std::t
 
 void ParserActions::expression_begin() { LOG_DEBUG("BEGIN_EXPRESSION"); }
 
-void ParserActions::expression_end(bool toplevel) {
-    LOG_DEBUG(((toplevel ? "TOPLEVEL_" : "") + string("EXPRESSION")));
+void ParserActions::expression_end(bool toplevel, const string& metta_string) {
+    LOG_DEBUG(((toplevel ? "TOPLEVEL_" : "") + string("EXPRESSION: ") + metta_string));
 }

--- a/src/metta/ParserActions.h
+++ b/src/metta/ParserActions.h
@@ -59,7 +59,7 @@ class ParserActions {
      *
      * @param toplevel A flag to indicate whether the expression is a toplevel onr or not.
      */
-    virtual void expression_end(bool toplevel);
+    virtual void expression_end(bool toplevel, const string& metta_string);
 };
 
 }  // namespace metta

--- a/src/tests/cpp/metta_parser_test.cc
+++ b/src/tests/cpp/metta_parser_test.cc
@@ -39,9 +39,9 @@ class TestActions : public ParserActions {
         ParserActions::expression_begin();
         actions.push_back("BEGIN_EXPRESSION");
     }
-    void expression_end(bool toplevel) override {
-        ParserActions::expression_end(toplevel);
-        actions.push_back((toplevel ? "TOPLEVEL_" : "") + string("EXPRESSION"));
+    void expression_end(bool toplevel, const string& metta_expression) override {
+        ParserActions::expression_end(toplevel, metta_expression);
+        actions.push_back((toplevel ? "TOPLEVEL_" : "") + string("EXPRESSION ") + metta_expression);
     }
 };
 
@@ -296,7 +296,7 @@ TEST(MettaParser, basics) {
                     "BEGIN_EXPRESSION",
                     "VARIABLE a",
                     "INTEGER_LITERAL 1",
-                    "TOPLEVEL_EXPRESSION",
+                    "TOPLEVEL_EXPRESSION ($a 1)",
                 });
     check_parse("09",
                 "(($v1 n1) $v2 n2)",
@@ -306,10 +306,10 @@ TEST(MettaParser, basics) {
                     "BEGIN_EXPRESSION",
                     "VARIABLE v1",
                     "SYMBOL n1",
-                    "EXPRESSION",
+                    "EXPRESSION ($v1 n1)",
                     "VARIABLE v2",
                     "SYMBOL n2",
-                    "TOPLEVEL_EXPRESSION",
+                    "TOPLEVEL_EXPRESSION (($v1 n1) $v2 n2)",
                 });
     check_parse("10",
                 "($a \"blah\\\"bleh\\\"blih\\\"\")",
@@ -318,7 +318,7 @@ TEST(MettaParser, basics) {
                     "BEGIN_EXPRESSION",
                     "VARIABLE a",
                     "STRING_LITERAL \"blah\\\"bleh\\\"blih\\\"\"",
-                    "TOPLEVEL_EXPRESSION",
+                    "TOPLEVEL_EXPRESSION ($a \"blah\\\"bleh\\\"blih\\\"\")",
                 });
     // clang-format off
     check_parse(
@@ -330,17 +330,17 @@ TEST(MettaParser, basics) {
             "BEGIN_EXPRESSION",
             "VARIABLE v1",
             "SYMBOL n1",
-            "EXPRESSION",
+            "EXPRESSION ($v1 n1)",
             "BEGIN_EXPRESSION",
             "INTEGER_LITERAL 2",
-            "EXPRESSION",
+            "EXPRESSION (2)",
             "VARIABLE v2",
             "BEGIN_EXPRESSION",
             "SYMBOL n8",
-            "EXPRESSION",
+            "EXPRESSION (n8)",
             "BEGIN_EXPRESSION",
             "VARIABLE v4",
-            "EXPRESSION",
+            "EXPRESSION ($v4)",
             "INTEGER_LITERAL 1",
             "SYMBOL n2",
             "BEGIN_EXPRESSION",
@@ -351,14 +351,14 @@ TEST(MettaParser, basics) {
             "BEGIN_EXPRESSION",
             "SYMBOL n7",
             "VARIABLE v3",
-            "EXPRESSION",
-            "EXPRESSION",
-            "EXPRESSION",
-            "TOPLEVEL_EXPRESSION",
+            "EXPRESSION (n7 $v3)",
+            "EXPRESSION (n6 (n7 $v3))",
+            "EXPRESSION (n4 n5 (n6 (n7 $v3)))",
+            "TOPLEVEL_EXPRESSION (($v1 n1) (2) $v2 (n8) ($v4) 1 n2 (n4 n5 (n6 (n7 $v3))))",
             "BEGIN_EXPRESSION",
             "SYMBOL n10",
             "SYMBOL n11",
-            "TOPLEVEL_EXPRESSION",
+            "TOPLEVEL_EXPRESSION (n10 n11)",
         });
     // clang-format on
 }


### PR DESCRIPTION
Resolves #750 

```
    virtual void expression_end(bool toplevel, const string& metta_string);
```

Now a `metta_string` containing the actual metta string is passed when `expression_end()` is called. The other methods (`literal()`, `symbol()`, etc) haven't been changed because the passed value is the metta expression already.