### PR TITLE
[FIX] Fix benchmark report to include hostname setting after macOS das-cli update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ build-all: build-image
 run-query-agent:
 	@PORT=$$(bash src/scripts/gkctl_auto_join_and_reserve.sh | tail -n 1); \
 	PORT_RANGE=$$(bash src/scripts/gkctl_auto_join_and_reserve.sh --range=999 | tail -n 1); \
-	bash -x src/scripts/run.sh query_broker $$PORT $$PORT_RANGE
+	bash -x src/scripts/run.sh query_broker 0.0.0.0:$$PORT $$PORT_RANGE
 
 run-attention-broker:
-	@bash -x src/scripts/run.sh attention_broker_service 40001
+	@bash -x src/scripts/run.sh attention_broker_service 0.0.0.0:40001
 
 run-link-creation-agent:
 	@bash -x src/scripts/run.sh link_creation_server $(OPTIONS)

--- a/src/scripts/run_benchmark.sh
+++ b/src/scripts/run_benchmark.sh
@@ -204,7 +204,11 @@ init_environment() {
     DAS_MONGODB_PORT="28000"
     DAS_MONGODB_USERNAME="dbadmin"
     DAS_MONGODB_PASSWORD="dassecret"
-    echo -e "$DAS_REDIS_PORT\nN\n$DAS_MONGODB_PORT\n$DAS_MONGODB_USERNAME\n$DAS_MONGODB_PASSWORD\nN\n8888\n\n\n\n\n\n\n\n\n\n\n\n" | das-cli config set > /dev/null
+    JUPYTER_NOTEBOOK_PORT="8888"
+    ATTENTION_BROKER_PORT="40001"
+    QUERY_AGENT_PORT="40002"
+    LINK_CREATION_PORT="40003"
+    echo -e "$DAS_REDIS_PORT\nN\n$DAS_MONGODB_PORT\n$DAS_MONGODB_USERNAME\n$DAS_MONGODB_PASSWORD\nN\n$JUPYTER_NOTEBOOK_PORT\n$ATTENTION_BROKER_PORT\n$QUERY_AGENT_PORT\n$LINK_CREATION_PORT\n\n\n\n\n\n\n\n\n" | das-cli config set > /dev/null
     das-cli db stop > /dev/null
     das-cli db start
     das-cli metta load "$METTA_PATH"
@@ -231,7 +235,7 @@ DAS_ATTENTION_BROKER_ADDRESS=localhost
 DAS_ATTENTION_BROKER_PORT=40001
 EOF
         ./src/scripts/build.sh --copt=-DLOG_LEVEL=DEBUG_LEVEL
-        ./src/scripts/run.sh query_broker 35700 3000:3100 | stdbuf -oL grep "Benchmark::" > "$log_file" || true &
+        ./src/scripts/run.sh query_broker localhost:35700 3000:3100 | stdbuf -oL grep "Benchmark::" > "$log_file" || true &
         echo -e "\r\033[K${GREEN}Query Agent initialization completed!${RESET}"
     fi
 
@@ -316,10 +320,12 @@ run_benchmark() {
                 echo -e "\n== Running benchmarks for Query Agent: $type | Action: $action =="
                 local log_file="/tmp/${BENCHMARK}_benchmark/${TIMESTAMP}/${type}_${action}_server_log.txt"
                 local client_log_file="/tmp/${BENCHMARK}_benchmark/${TIMESTAMP}/${type}_${action}_client_log.txt"
+                local server_id="localhost:35700"
+                local client_id="localhost:9000"
                 init_environment "$log_file"
                 echo -e "\r\033[K${GREEN}Running test START${RESET}"
                 echo -e "\r\033[K${GREEN}Partial results in /tmp/${BENCHMARK}_benchmark/${TIMESTAMP}/${RESET}"
-                stdbuf -oL ./src/scripts/bazel.sh run //tests/benchmark/query_agent:query_agent_main --copt=-DLOG_LEVEL=DEBUG_LEVEL -- "$report_base_directory" "$type" "$action" "$CACHE_ENABLED" "$ITERATIONS" "/tmp/${BENCHMARK}_benchmark/${TIMESTAMP}/${type}_${action}_" | tee "$client_log_file"
+                stdbuf -oL ./src/scripts/bazel.sh run //tests/benchmark/query_agent:query_agent_main --copt=-DLOG_LEVEL=DEBUG_LEVEL -- "$report_base_directory" "$type" "$action" "$CACHE_ENABLED" "$ITERATIONS" "/tmp/${BENCHMARK}_benchmark/${TIMESTAMP}/${type}_${action}_" "$server_id" "$client_id" | tee "$client_log_file"
                 echo -e "\r\033[K${GREEN}Running test END${RESET}"
             done
         done

--- a/src/tests/benchmark/query_agent/query_agent_main.cc
+++ b/src/tests/benchmark/query_agent/query_agent_main.cc
@@ -58,8 +58,7 @@ int main(int argc, char** argv) {
     if (argc < 6) {
         cerr << "Usage: " << argv[0]
              << " <report_base_directory> <atomdb_type> <action> <cache_enabled> <num_iterations> "
-             << "[server_host:port] [client_host:port]"
-             << endl;
+             << "[server_host:port] [client_host:port]" << endl;
         exit(1);
     }
 

--- a/src/tests/benchmark/query_agent/query_agent_main.cc
+++ b/src/tests/benchmark/query_agent/query_agent_main.cc
@@ -35,7 +35,7 @@ using namespace atomdb;
 mutex global_mutex;
 map<string, Metrics> global_metrics;
 
-void setup(bool cache_enable, string atomdb_type) {
+void setup(bool cache_enable, string atomdb_type, string client_id, string server_id) {
     setenv("DAS_REDIS_HOSTNAME", "localhost", 1);
     setenv("DAS_REDIS_PORT", "29000", 1);
     setenv("DAS_USE_REDIS_CLUSTER", "false", 1);
@@ -51,8 +51,6 @@ void setup(bool cache_enable, string atomdb_type) {
     } else if (atomdb_type == "morkdb") {
         AtomDBSingleton::init(atomdb_api_types::ATOMDB_TYPE::MORKDB);
     }
-    string client_id = "0.0.0.0:9000";
-    string server_id = "0.0.0.0:35700";
     ServiceBusSingleton::init(client_id, server_id, 4000, 4100);
 }
 
@@ -60,6 +58,7 @@ int main(int argc, char** argv) {
     if (argc < 6) {
         cerr << "Usage: " << argv[0]
              << " <report_base_directory> <atomdb_type> <action> <cache_enabled> <num_iterations> "
+             << "[server_host:port] [client_host:port]"
              << endl;
         exit(1);
     }
@@ -70,8 +69,17 @@ int main(int argc, char** argv) {
     bool cache_enable = (string(argv[4]) == "true" || string(argv[4]) == "1");
     int iterations = stoi(argv[5]);
     string base_log_file = argv[6];
+    string server_id = "0.0.0.0:35700";
+    string client_id = "0.0.0.0:9000";
 
-    setup(cache_enable, atomdb_type);
+    if (argc > 7) {
+        server_id = argv[7];
+    }
+    if (argc > 8) {
+        client_id = argv[8];
+    }
+
+    setup(cache_enable, atomdb_type, client_id, server_id);
 
     auto atom_space = make_shared<AtomSpace>();
     PatternMatchingQuery benchmark(1, atom_space, iterations);


### PR DESCRIPTION
After merging the PR [\[#639\] Investigate das-cli Compatibility and Execution on macOS](https://github.com/singnet/das/pull/752/), where setting the hostname became necessary to bind the server address, we forgot to apply this change in the benchmark report.