### PR TITLE
[Fix][AttentionBroker] Set an initial `stimulate` sum value

### DIFF
--- a/src/attention_broker/AttentionBrokerClient.cc
+++ b/src/attention_broker/AttentionBrokerClient.cc
@@ -73,7 +73,7 @@ void AttentionBrokerClient::stimulate(const map<string, unsigned int>& handle_ma
         grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
 
     handle_count.set_context(context);
-    unsigned int sum;
+    unsigned int sum = 0;
     for (auto pair : handle_map) {
         (*handle_count.mutable_map())[pair.first] = pair.second;
         sum += pair.second;

--- a/src/tests/cpp/context_test.cc
+++ b/src/tests/cpp/context_test.cc
@@ -22,7 +22,6 @@ class TestContext : public Context {
 };
 
 TEST(Context, basics) {
-    /*
     TestConfig::load_environment();
     AtomDBSingleton::init();
 
@@ -85,5 +84,4 @@ TEST(Context, basics) {
     EXPECT_TRUE(importance[7] > 0);
     EXPECT_TRUE(importance[5] > importance[6]);
     EXPECT_TRUE(double_equals(importance[6], importance[7]));
-    */
 }


### PR DESCRIPTION
We are not initializing the `sum` with `0` and that is breaking for MacOS (arm64).