### PR TITLE
[rust-metta-bus-client] New `QueryEvolutionProxy` params + `ContextBrokerProxy`

### DIFF
--- a/3rd_party_slots/rust_metta_bus_client/Cargo.lock
+++ b/3rd_party_slots/rust_metta_bus_client/Cargo.lock
@@ -462,28 +462,38 @@ dependencies = [
 
 [[package]]
 name = "hyperon-atom"
-version = "0.2.6"
-source = "git+https://github.com/trueagi-io/hyperon-experimental.git#bd27e25a08447085a15e3ef7448693da11e0e1eb"
+version = "0.2.8"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#080e2f4f5d9677db93211c9cff9051214e866616"
 dependencies = [
  "bitset",
  "hyperon-common",
+ "hyperon-macros",
  "log",
  "smallvec",
+ "unescaper",
 ]
 
 [[package]]
 name = "hyperon-common"
-version = "0.2.6"
-source = "git+https://github.com/trueagi-io/hyperon-experimental.git#bd27e25a08447085a15e3ef7448693da11e0e1eb"
+version = "0.2.8"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#080e2f4f5d9677db93211c9cff9051214e866616"
 dependencies = [
  "itertools 0.13.0",
  "log",
 ]
 
 [[package]]
+name = "hyperon-macros"
+version = "0.2.8"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#080e2f4f5d9677db93211c9cff9051214e866616"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "hyperon-space"
-version = "0.2.6"
-source = "git+https://github.com/trueagi-io/hyperon-experimental.git#bd27e25a08447085a15e3ef7448693da11e0e1eb"
+version = "0.2.8"
+source = "git+https://github.com/trueagi-io/hyperon-experimental.git#080e2f4f5d9677db93211c9cff9051214e866616"
 dependencies = [
  "bimap",
  "hyperon-atom",
@@ -549,6 +559,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "litrs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4cf394bcd88ba72eb3b2862e21ef6458b0e1586654e213b0176e667bb9d19e"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,7 +594,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metta-bus-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "env_logger",
  "hyperon-atom",
@@ -998,6 +1014,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1212,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unescaper"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01d12e3a56a4432a8b436f293c25f4808bdf9e9f9f98f9260bba1f1bc5a1f26"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/3rd_party_slots/rust_metta_bus_client/Cargo.toml
+++ b/3rd_party_slots/rust_metta_bus_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metta-bus-client"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]
@@ -11,9 +11,9 @@ regex = "1.11.0"
 log = "0.4.0"
 env_logger = "0.8.4"
 
-hyperon-common = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.6" }
-hyperon-atom = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.6" }
-hyperon-space = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.6" }
+hyperon-common = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.8" }
+hyperon-atom = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.8" }
+hyperon-space = { git = "https://github.com/trueagi-io/hyperon-experimental.git", version = "0.2.8" }
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/3rd_party_slots/rust_metta_bus_client/src/base_proxy_query.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/base_proxy_query.rs
@@ -53,6 +53,9 @@ pub struct BaseQueryProxy {
 	pub proxy_port: u16,
 	pub proxy_node: ProxyNode,
 
+	// Context Broker
+	pub context_created: bool,
+
 	// Evolution
 	pub eval_fitness_queue: VecDeque<String>,
 
@@ -108,6 +111,8 @@ impl BaseQueryProxy {
 
 			command,
 			args: vec![],
+
+			context_created: false,
 
 			eval_fitness_queue: VecDeque::new(),
 

--- a/3rd_party_slots/rust_metta_bus_client/src/bus.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/bus.rs
@@ -4,6 +4,7 @@ pub static PATTERN_MATCHING_QUERY_CMD: &str = "pattern_matching_query";
 pub static QUERY_EVOLUTION_CMD: &str = "query_evolution";
 pub static LINK_CREATION_CMD: &str = "link_creation";
 pub static INFERENCE_CMD: &str = "inference";
+pub static CONTEXT_CMD: &str = "context";
 
 #[derive(Debug, Default, Clone)]
 pub struct Bus {

--- a/3rd_party_slots/rust_metta_bus_client/src/context_broker_proxy.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/context_broker_proxy.rs
@@ -1,0 +1,278 @@
+use std::sync::{Arc, Mutex};
+
+use hyperon_atom::Atom;
+
+use crate::{
+	base_proxy_query::{BaseQueryProxy, BaseQueryProxyT},
+	bus::CONTEXT_CMD,
+	helpers::query_element::QueryElement,
+	properties::{
+		PropertyValue, ENFORCE_CACHE_RECREATION, INITIAL_RENT_RATE,
+		INITIAL_SPREADING_RATE_LOWERBOUND, INITIAL_SPREADING_RATE_UPPERBOUND, USE_CACHE,
+	},
+	types::BoxError,
+	QueryParams,
+};
+
+// ContextBrokerProxy Commands
+pub static ATTENTION_BROKER_SET_PARAMETERS: &str = "attention_broker_set_parameters";
+pub static ATTENTION_BROKER_SET_PARAMETERS_FINISHED: &str =
+	"attention_broker_set_parameters_finished";
+pub static CONTEXT_CREATED: &str = "context_created";
+pub static SHUTDOWN: &str = "shutdown";
+
+pub static CONTEXT_BROKER_PARSER_ERROR_MESSAGE: &str = "CONTEXT query must have (parameters) ((query) (determiner schema) (stimulus schema)) eg:
+(
+	CONTEXT
+	(use_cache enforce_cache_recreation initial_rent_rate initial_spreading_rate_lowerbound initial_spreading_rate_upperbound)
+	((Similarity \"human\" $S) ((_0 S) ...) (S ...))
+)";
+
+#[derive(Clone)]
+pub struct ContextBrokerParams {
+	pub use_cache: bool,
+	pub enforce_cache_recreation: bool,
+	pub initial_rent_rate: f64,
+	pub initial_spreading_rate_lowerbound: f64,
+	pub initial_spreading_rate_upperbound: f64,
+
+	pub query_atom: Atom,
+
+	pub determiner_schema: Vec<(QueryElement, QueryElement)>,
+	pub stimulus_schema: Vec<QueryElement>,
+}
+
+#[derive(Clone)]
+pub struct ContextBrokerProxy {
+	pub base: Arc<Mutex<BaseQueryProxy>>,
+
+	pub name: String,
+	pub key: String,
+
+	pub use_cache: bool,
+	pub enforce_cache_recreation: bool,
+	pub initial_rent_rate: f64,
+	pub initial_spreading_rate_lowerbound: f64,
+	pub initial_spreading_rate_upperbound: f64,
+
+	pub determiner_schema: Vec<(QueryElement, QueryElement)>,
+	pub stimulus_schema: Vec<QueryElement>,
+}
+
+impl ContextBrokerProxy {
+	pub fn new(
+		params: &QueryParams, context_broker_params: &ContextBrokerParams,
+	) -> Result<Self, BoxError> {
+		let mut base = BaseQueryProxy::new(CONTEXT_CMD.to_string(), params.clone())?;
+
+		base.properties
+			.insert(USE_CACHE.to_string(), PropertyValue::Bool(context_broker_params.use_cache));
+		base.properties.insert(
+			ENFORCE_CACHE_RECREATION.to_string(),
+			PropertyValue::Bool(context_broker_params.enforce_cache_recreation),
+		);
+		base.properties.insert(
+			INITIAL_RENT_RATE.to_string(),
+			PropertyValue::Double(context_broker_params.initial_rent_rate),
+		);
+		base.properties.insert(
+			INITIAL_SPREADING_RATE_LOWERBOUND.to_string(),
+			PropertyValue::Double(context_broker_params.initial_spreading_rate_lowerbound),
+		);
+		base.properties.insert(
+			INITIAL_SPREADING_RATE_UPPERBOUND.to_string(),
+			PropertyValue::Double(context_broker_params.initial_spreading_rate_upperbound),
+		);
+
+		let mut args = vec![];
+		args.extend(base.properties.to_vec());
+		args.push(base.context.clone());
+		args.push(base.query_tokens.len().to_string());
+		args.extend(base.query_tokens.clone());
+
+		args.push(context_broker_params.stimulus_schema.len().to_string());
+		args.extend(context_broker_params.stimulus_schema.iter().map(|e| e.to_string()));
+
+		args.push(context_broker_params.determiner_schema.len().to_string());
+		for (source, target) in context_broker_params.determiner_schema.iter() {
+			args.push(source.to_string());
+			args.push(target.to_string());
+		}
+
+		let name = params.context.clone();
+		let key = hash_context(&name);
+
+		args.push(key.clone());
+		args.push(name.clone());
+
+		log::debug!(target: "das", "Use cache                        : <{}>", context_broker_params.use_cache);
+		log::debug!(target: "das", "Enforce cache recreation         : <{}>", context_broker_params.enforce_cache_recreation);
+		log::debug!(target: "das", "Initial rent rate                : <{}>", context_broker_params.initial_rent_rate);
+		log::debug!(target: "das", "Initial spreading rate lowerbound: <{}>", context_broker_params.initial_spreading_rate_lowerbound);
+		log::debug!(target: "das", "Initial spreading rate upperbound: <{}>", context_broker_params.initial_spreading_rate_upperbound);
+		log::debug!(target: "das", "Determiner schema                : <{}>", context_broker_params.determiner_schema
+			.iter()
+			.map(|(source, target)| format!("({source}, {target})"))
+			.collect::<Vec<String>>().join(","));
+		log::debug!(target: "das", "Stimulus schema                  : <{}>", context_broker_params.stimulus_schema.iter().map(|e| e.to_string()).collect::<Vec<String>>().join(","));
+
+		base.args = args;
+
+		Ok(Self {
+			base: Arc::new(Mutex::new(base)),
+			name,
+			key,
+			use_cache: context_broker_params.use_cache,
+			enforce_cache_recreation: context_broker_params.enforce_cache_recreation,
+			initial_rent_rate: context_broker_params.initial_rent_rate,
+			initial_spreading_rate_lowerbound: context_broker_params
+				.initial_spreading_rate_lowerbound,
+			initial_spreading_rate_upperbound: context_broker_params
+				.initial_spreading_rate_upperbound,
+			determiner_schema: context_broker_params.determiner_schema.clone(),
+			stimulus_schema: context_broker_params.stimulus_schema.clone(),
+		})
+	}
+
+	pub fn get_name(&self) -> String {
+		self.name.clone()
+	}
+
+	pub fn get_key(&self) -> String {
+		self.key.clone()
+	}
+
+	pub fn is_context_created(&self) -> bool {
+		self.base.lock().unwrap().context_created
+	}
+}
+
+impl BaseQueryProxyT for ContextBrokerProxy {
+	fn finished(&self) -> bool {
+		self.base.lock().unwrap().finished()
+	}
+
+	fn pop(&mut self) -> Option<String> {
+		self.base.lock().unwrap().pop()
+	}
+
+	fn push(&mut self, query_answer: String) -> Result<(), BoxError> {
+		self.base.lock().unwrap().push(query_answer)
+	}
+
+	fn get_count(&self) -> u64 {
+		self.base.lock().unwrap().get_count()
+	}
+
+	fn abort(&mut self) {
+		self.base.lock().unwrap().abort()
+	}
+
+	fn setup_proxy_node(
+		&mut self, proxy_arc: Arc<Mutex<BaseQueryProxy>>, client_id: Option<String>,
+		server_id: Option<String>,
+	) {
+		self.base.lock().unwrap().setup_proxy_node(proxy_arc, client_id, server_id)
+	}
+
+	fn to_remote_peer(&self, command: String, args: Vec<String>) -> Result<(), BoxError> {
+		self.base.lock().unwrap().to_remote_peer(command, args)
+	}
+
+	fn drop_runtime(&mut self) {
+		self.base.lock().unwrap().drop_runtime()
+	}
+}
+
+pub fn hash_context(context: &str) -> String {
+	use std::collections::hash_map::DefaultHasher;
+	use std::hash::{Hash, Hasher};
+
+	let mut hasher = DefaultHasher::new();
+	context.hash(&mut hasher);
+	format!("{:x}", hasher.finish())
+}
+
+pub fn parse_context_broker_parameters(
+	atom: &Atom,
+) -> Result<Option<ContextBrokerParams>, BoxError> {
+	if let Atom::Expression(exp_atom) = &atom {
+		let children = exp_atom.children();
+		if let Some(Atom::Symbol(s)) = children.first() {
+			if s.name() == "CONTEXT" {
+				if children.len() < 3 {
+					return Err(CONTEXT_BROKER_PARSER_ERROR_MESSAGE.to_string().into());
+				}
+
+				// Parameters
+				let mut use_cache = true;
+				let mut enforce_cache_recreation = false;
+				let mut initial_rent_rate = 0.75;
+				let mut initial_spreading_rate_lowerbound = 0.1;
+				let mut initial_spreading_rate_upperbound = 0.1;
+				if let Atom::Expression(exp_atom) = children[1].clone() {
+					let exp_atom = if let Some(Atom::Expression(inner_exp_atom)) =
+						exp_atom.children().first()
+					{
+						inner_exp_atom.clone()
+					} else {
+						exp_atom.clone()
+					};
+					let children = exp_atom.children();
+					if children.len() != 5 {
+						return Err(CONTEXT_BROKER_PARSER_ERROR_MESSAGE.to_string().into());
+					}
+					use_cache = children[0].to_string().parse::<bool>().unwrap();
+					enforce_cache_recreation = children[1].to_string().parse::<bool>().unwrap();
+					initial_rent_rate = children[2].to_string().parse::<f64>().unwrap();
+					initial_spreading_rate_lowerbound =
+						children[3].to_string().parse::<f64>().unwrap();
+					initial_spreading_rate_upperbound =
+						children[4].to_string().parse::<f64>().unwrap();
+				}
+
+				let mut query_atom = Atom::expr([]);
+				let mut determiner_schema = vec![];
+				let mut stimulus_schema = vec![];
+				if let Atom::Expression(exp_atom) = children[2].clone() {
+					let children = exp_atom.children();
+					if children.len() != 3 {
+						return Err(CONTEXT_BROKER_PARSER_ERROR_MESSAGE.to_string().into());
+					}
+					query_atom = children[0].clone();
+					determiner_schema =
+						vec![(QueryElement::new_handle(0), QueryElement::new_variable("S"))];
+					stimulus_schema = vec![QueryElement::new_variable("S")];
+				}
+
+				return Ok(Some(ContextBrokerParams {
+					use_cache,
+					enforce_cache_recreation,
+					initial_rent_rate,
+					initial_spreading_rate_lowerbound,
+					initial_spreading_rate_upperbound,
+					query_atom,
+					determiner_schema,
+					stimulus_schema,
+				}));
+			}
+		}
+	}
+	Ok(None)
+}
+
+pub fn default_context_broker_params() -> ContextBrokerParams {
+	ContextBrokerParams {
+		use_cache: true,
+		enforce_cache_recreation: false,
+		initial_rent_rate: 0.25,
+		initial_spreading_rate_lowerbound: 0.50,
+		initial_spreading_rate_upperbound: 0.70,
+		query_atom: Atom::expr([]),
+		determiner_schema: vec![
+			(QueryElement::new_handle(0), QueryElement::new_variable("sentence1")),
+			(QueryElement::new_variable("sentence1"), QueryElement::new_variable("word1")),
+		],
+		stimulus_schema: vec![],
+	}
+}

--- a/3rd_party_slots/rust_metta_bus_client/src/helpers/mod.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/helpers/mod.rs
@@ -1,4 +1,5 @@
 pub mod query_answer;
+pub mod query_element;
 
 use std::collections::HashSet;
 
@@ -126,4 +127,14 @@ pub fn map_variables(atom_str: &str) -> HashSet<VariableAtom> {
 	}
 
 	variables
+}
+
+pub fn map_atom<T, F>(atom: &Atom, map_func: F) -> Vec<T>
+where
+	F: Fn(&Atom) -> T,
+{
+	match atom {
+		Atom::Expression(exp_atom) => exp_atom.children().iter().map(map_func).collect(),
+		_ => vec![map_func(atom)],
+	}
 }

--- a/3rd_party_slots/rust_metta_bus_client/src/helpers/query_element.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/helpers/query_element.rs
@@ -1,0 +1,25 @@
+use std::fmt::{Display, Formatter, Result};
+
+#[derive(Clone, Debug)]
+pub enum QueryElement {
+	Handle(u32),
+	Variable(String),
+}
+
+impl QueryElement {
+	pub fn new_handle(element: u32) -> Self {
+		Self::Handle(element)
+	}
+	pub fn new_variable(element: &str) -> Self {
+		Self::Variable(element.to_string())
+	}
+}
+
+impl Display for QueryElement {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self {
+			Self::Handle(handle) => write!(f, "_{handle}"),
+			Self::Variable(variable) => write!(f, "${variable}"),
+		}
+	}
+}

--- a/3rd_party_slots/rust_metta_bus_client/src/inference_proxy.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/inference_proxy.rs
@@ -13,7 +13,8 @@ use crate::{
 pub const PROOF_OF_IMPLICATION: &str = "PROOF_OF_IMPLICATION";
 pub const PROOF_OF_EQUIVALENCE: &str = "PROOF_OF_EQUIVALENCE";
 
-pub static INFERENCE_PARSER_ERROR_MESSAGE: &str = "INFERENCE query must have (request_type handle1 handle2 max_proof_length) eg:
+pub static INFERENCE_PARSER_ERROR_MESSAGE: &str =
+	"INFERENCE query must have (request_type handle1 handle2 max_proof_length) eg:
 (
 	INFERENCE
 	(PROOF_OF_IMPLICATION cf07db895a5656bfd3652ba565727554 c4d0ef92e7265f9298f8dd6d3ae1e014 1)
@@ -53,10 +54,7 @@ impl InferenceProxy {
 	}
 
 	pub fn request_types() -> Vec<String> {
-		vec![
-			PROOF_OF_IMPLICATION.to_string(),
-			PROOF_OF_EQUIVALENCE.to_string(),
-		]
+		vec![PROOF_OF_IMPLICATION.to_string(), PROOF_OF_EQUIVALENCE.to_string()]
 	}
 }
 

--- a/3rd_party_slots/rust_metta_bus_client/src/main.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), BoxError> {
 	let count_only = false;
 	let populate_metta_mapping = true;
 	let use_metta_as_query_tokens = true;
-	let max_bundle_size = 10_000;
+	let max_bundle_size = 1_000;
 
 	let mut tokens_start_position = 5;
 	let max_query_answers = match (args[5]).parse::<u32>() {

--- a/3rd_party_slots/rust_metta_bus_client/src/properties.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/properties.rs
@@ -14,6 +14,13 @@ pub static ELITISM_RATE: &str = "elitism_rate";
 pub static SELECTION_RATE: &str = "selection_rate";
 pub static TOTAL_ATTENTION_TOKENS: &str = "total_attention_tokens";
 
+// Context Broker
+pub static USE_CACHE: &str = "use_cache";
+pub static ENFORCE_CACHE_RECREATION: &str = "enforce_cache_recreation";
+pub static INITIAL_RENT_RATE: &str = "initial_rent_rate";
+pub static INITIAL_SPREADING_RATE_LOWERBOUND: &str = "initial_spreading_rate_lowerbound";
+pub static INITIAL_SPREADING_RATE_UPPERBOUND: &str = "initial_spreading_rate_upperbound";
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum PropertyValue {
 	String(String),

--- a/3rd_party_slots/rust_metta_bus_client/src/service_bus_singleton.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/service_bus_singleton.rs
@@ -1,7 +1,10 @@
 use std::sync::OnceLock;
 
 use crate::{
-	bus::{INFERENCE_CMD, LINK_CREATION_CMD, PATTERN_MATCHING_QUERY_CMD, QUERY_EVOLUTION_CMD},
+	bus::{
+		CONTEXT_CMD, INFERENCE_CMD, LINK_CREATION_CMD, PATTERN_MATCHING_QUERY_CMD,
+		QUERY_EVOLUTION_CMD,
+	},
 	service_bus::ServiceBus,
 	types::BoxError,
 };
@@ -25,6 +28,7 @@ impl ServiceBusSingleton {
 				QUERY_EVOLUTION_CMD.to_string(),
 				LINK_CREATION_CMD.to_string(),
 				INFERENCE_CMD.to_string(),
+				CONTEXT_CMD.to_string(),
 			],
 			port_lower,
 			port_upper,


### PR DESCRIPTION
This PR updates the rust `metta-bus-client` with new `QueryEvolutionProxy` params and it also adds the `ContextBrokerProxy` logic.