### PR TITLE
Remove `SHUTDOWN` from `ContextBrokerProxy`

### DIFF
--- a/src/agents/context_broker/ContextBrokerProcessor.cc
+++ b/src/agents/context_broker/ContextBrokerProcessor.cc
@@ -90,7 +90,17 @@ void ContextBrokerProcessor::thread_process_one_query(shared_ptr<StoppableThread
         proxy->raise_error_on_peer(exception.what());
     }
 
-    // keep alive till client kills it
+    // Keep alive till peer (client) kills it or the on going parameters update is done
+    while (!(proxy->finished() || proxy->is_aborting()) || proxy->update_attention_broker_parameters) {
+        if (proxy->update_attention_broker_parameters) {
+            this->set_attention_broker_parameters(
+                proxy->rent_rate, proxy->spreading_rate_lowerbound, proxy->spreading_rate_upperbound);
+            proxy->update_attention_broker_parameters = false;
+            proxy->to_remote_peer(ContextBrokerProxy::ATTENTION_BROKER_SET_PARAMETERS_FINISHED, {});
+            break;
+        }
+        Utils::sleep();
+    }
 
     LOG_DEBUG("Command finished: <" << proxy->get_command() << ">");
     // TODO add a call to remove_query_thread(monitor->get_id());
@@ -167,22 +177,9 @@ void ContextBrokerProcessor::create_context(shared_ptr<StoppableThread> monitor,
     this->update_attention_broker(proxy);
 
     LOG_INFO("Context created: name<" << proxy->get_name() << "> with key<" << proxy->get_key() << ">");
-    Utils::sleep(1000);
 
     // Notify caller that context has been created
     proxy->to_remote_peer(ContextBrokerProxy::CONTEXT_CREATED, {});
-
-    // Keep alive till peer (client) kills it
-    while (proxy->running() || proxy->update_attention_broker_parameters) {
-        if (proxy->update_attention_broker_parameters) {
-            this->set_attention_broker_parameters(
-                proxy->rent_rate, proxy->spreading_rate_lowerbound, proxy->spreading_rate_upperbound);
-            proxy->update_attention_broker_parameters = false;
-            proxy->to_remote_peer(ContextBrokerProxy::ATTENTION_BROKER_SET_PARAMETERS_FINISHED, {});
-            break;
-        }
-        Utils::sleep();
-    }
 }
 
 void ContextBrokerProcessor::set_attention_broker_parameters(double rent_rate,

--- a/src/agents/context_broker/ContextBrokerProcessor.cc
+++ b/src/agents/context_broker/ContextBrokerProcessor.cc
@@ -90,14 +90,13 @@ void ContextBrokerProcessor::thread_process_one_query(shared_ptr<StoppableThread
         proxy->raise_error_on_peer(exception.what());
     }
 
-    // Keep alive till peer (client) kills it or the on going parameters update is done
+    // Keep alive till peer (client) kills it (processing any ongoing parameters update)
     while (!(proxy->finished() || proxy->is_aborting()) || proxy->update_attention_broker_parameters) {
         if (proxy->update_attention_broker_parameters) {
             this->set_attention_broker_parameters(
                 proxy->rent_rate, proxy->spreading_rate_lowerbound, proxy->spreading_rate_upperbound);
             proxy->update_attention_broker_parameters = false;
             proxy->to_remote_peer(ContextBrokerProxy::ATTENTION_BROKER_SET_PARAMETERS_FINISHED, {});
-            break;
         }
         Utils::sleep();
     }

--- a/src/agents/context_broker/ContextBrokerProxy.cc
+++ b/src/agents/context_broker/ContextBrokerProxy.cc
@@ -28,7 +28,6 @@ string ContextBrokerProxy::ATTENTION_BROKER_SET_PARAMETERS = "attention_broker_s
 string ContextBrokerProxy::ATTENTION_BROKER_SET_PARAMETERS_FINISHED =
     "attention_broker_set_parameters_finished";
 string ContextBrokerProxy::CONTEXT_CREATED = "context_created";
-string ContextBrokerProxy::SHUTDOWN = "shutdown";
 
 // Properties
 string ContextBrokerProxy::USE_CACHE = "use_cache";
@@ -54,7 +53,6 @@ ContextBrokerProxy::ContextBrokerProxy() {
     this->update_attention_broker_parameters = false;
     this->ongoing_attention_broker_set_parameters = false;
     this->context_created = false;
-    this->keep_alive = true;
 }
 
 ContextBrokerProxy::ContextBrokerProxy(
@@ -72,10 +70,9 @@ ContextBrokerProxy::ContextBrokerProxy(
     this->update_attention_broker_parameters = false;
     this->ongoing_attention_broker_set_parameters = false;
     this->context_created = false;
-    this->keep_alive = true;
 }
 
-ContextBrokerProxy::~ContextBrokerProxy() { to_remote_peer(SHUTDOWN, {}); }
+ContextBrokerProxy::~ContextBrokerProxy() { this->abort(); }
 
 // -------------------------------------------------------------------------------------------------
 // BaseQueryProxy overrides
@@ -161,8 +158,6 @@ void ContextBrokerProxy::pack_command_line_args() { tokenize(this->args); }
 
 bool ContextBrokerProxy::is_context_created() { return this->context_created; }
 
-bool ContextBrokerProxy::running() { return this->keep_alive; }
-
 // -------------------------------------------------------------------------------------------------
 // Private methods
 
@@ -193,20 +188,17 @@ bool ContextBrokerProxy::from_remote_peer(const string& command, const vector<st
         this->spreading_rate_lowerbound = Utils::string_to_float(args[1]);
         this->spreading_rate_upperbound = Utils::string_to_float(args[2]);
         this->update_attention_broker_parameters = true;
-        return true;
     } else if (command == CONTEXT_CREATED) {
         this->context_created = true;
-        return true;
     } else if (command == ATTENTION_BROKER_SET_PARAMETERS_FINISHED) {
         this->ongoing_attention_broker_set_parameters = false;
-        return true;
-    } else if (command == SHUTDOWN) {
-        this->keep_alive = false;
-        return true;
+    } else if (command == BaseProxy::ABORT) {
+        this->abort(args);
     } else {
         Utils::error("Invalid ContextBrokerProxy command: <" + command + ">");
         return false;
     }
+    return true;
 }
 
 void ContextBrokerProxy::attention_broker_set_parameters(double rent_rate,
@@ -219,8 +211,6 @@ void ContextBrokerProxy::attention_broker_set_parameters(double rent_rate,
     this->ongoing_attention_broker_set_parameters = true;
     to_remote_peer(ATTENTION_BROKER_SET_PARAMETERS, args);
 }
-
-void ContextBrokerProxy::shutdown() { to_remote_peer(SHUTDOWN, {}); }
 
 // -------------------------------------------------------------------------------------------------
 // Public accessor methods

--- a/src/agents/context_broker/ContextBrokerProxy.cc
+++ b/src/agents/context_broker/ContextBrokerProxy.cc
@@ -192,8 +192,6 @@ bool ContextBrokerProxy::from_remote_peer(const string& command, const vector<st
         this->context_created = true;
     } else if (command == ATTENTION_BROKER_SET_PARAMETERS_FINISHED) {
         this->ongoing_attention_broker_set_parameters = false;
-    } else if (command == BaseProxy::ABORT) {
-        this->abort(args);
     } else {
         Utils::error("Invalid ContextBrokerProxy command: <" + command + ">");
         return false;

--- a/src/agents/context_broker/ContextBrokerProxy.h
+++ b/src/agents/context_broker/ContextBrokerProxy.h
@@ -35,7 +35,6 @@ class ContextBrokerProxy : public BaseQueryProxy {
     static string ATTENTION_BROKER_SET_PARAMETERS;
     static string ATTENTION_BROKER_SET_PARAMETERS_FINISHED;
     static string CONTEXT_CREATED;
-    static string SHUTDOWN;
 
     // Query command's optional parameters
     static string USE_CACHE;                          // Whether to use cache
@@ -75,12 +74,6 @@ class ContextBrokerProxy : public BaseQueryProxy {
     // Context-specific API
 
     /**
-     * Check if the proxy is still running.
-     * @return Whether the proxy is still running
-     */
-    bool running();
-
-    /**
      * Get the context created flag.
      * @return Whether the context has been created
      */
@@ -102,11 +95,6 @@ class ContextBrokerProxy : public BaseQueryProxy {
      * @return Whether the attention broker parameters have been set
      */
     bool attention_broker_set_parameters_finished();
-
-    /**
-     * Send a shutdown command to the remote proxy.
-     */
-    void shutdown();
 
     /**
      * Get the context name.
@@ -200,7 +188,6 @@ class ContextBrokerProxy : public BaseQueryProxy {
 
     // Control flags
     bool context_created;
-    bool keep_alive;
     bool ongoing_attention_broker_set_parameters;
 };
 


### PR DESCRIPTION
This PR replaces the `SHUTDOWN` command by `BaseProxy::ABORT` in `ContextBrokerProxy`.
It also fixes a bug and now it allows multiple `attention_broker_set_parameters()` calls to the same processor.