### PR TITLE
[#807] Add serialization/deserialization methods to AttentionBroker API

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -94,8 +94,8 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 
 http_archive(
     name = "com_github_singnet_das_proto",
-    strip_prefix = "das-proto-0.1.17",
-    urls = ["https://github.com/singnet/das-proto/archive/refs/tags/0.1.17.tar.gz"],
+    strip_prefix = "das-proto-0.1.18",
+    urls = ["https://github.com/singnet/das-proto/archive/refs/tags/0.1.18.tar.gz"],
 )
 
 # Deps for formatting and linting BUILD files

--- a/src/attention_broker/AttentionBrokerClient.cc
+++ b/src/attention_broker/AttentionBrokerClient.cc
@@ -200,7 +200,8 @@ void AttentionBrokerClient::save_context(const string& context, const string& fi
     auto stub = dasproto::AttentionBroker::NewStub(
         grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
 
-    LOG_INFO("Calling AttentionBroker GRPC. Saving context contents into a file. Context: " + context + " File name: " + file_name);
+    LOG_INFO("Calling AttentionBroker GRPC. Saving context contents into a file. Context: " + context +
+             " File name: " + file_name);
     stub->drop_and_load_context(new grpc::ClientContext(), request, &ack);
     if (ack.msg() != "SAVE_CONTEXT") {
         Utils::error("Failed GRPC command: AttentionBroker::save_context()");
@@ -217,7 +218,9 @@ void AttentionBrokerClient::drop_and_load_context(const string& context, const s
     auto stub = dasproto::AttentionBroker::NewStub(
         grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
 
-    LOG_INFO("Calling AttentionBroker GRPC. Dropping context info and loading contents from file. Context: " + context + " File name: " + file_name);
+    LOG_INFO(
+        "Calling AttentionBroker GRPC. Dropping context info and loading contents from file. Context: " +
+        context + " File name: " + file_name);
     stub->drop_and_load_context(new grpc::ClientContext(), request, &ack);
     if (ack.msg() != "DROP_AND_LOAD_CONTEXT") {
         Utils::error("Failed GRPC command: AttentionBroker::drop_and_load_context()");

--- a/src/attention_broker/AttentionBrokerClient.cc
+++ b/src/attention_broker/AttentionBrokerClient.cc
@@ -189,3 +189,37 @@ bool AttentionBrokerClient::health_check(bool throw_on_error) {
         return false;
     }
 }
+
+void AttentionBrokerClient::save_context(const string& context, const string& file_name) {
+    dasproto::ContextPersistence request;
+    dasproto::Ack ack;
+
+    request.set_context(context);
+    request.set_file_name(file_name);
+
+    auto stub = dasproto::AttentionBroker::NewStub(
+        grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
+
+    LOG_INFO("Calling AttentionBroker GRPC. Saving context contents into a file. Context: " + context + " File name: " + file_name);
+    stub->drop_and_load_context(new grpc::ClientContext(), request, &ack);
+    if (ack.msg() != "SAVE_CONTEXT") {
+        Utils::error("Failed GRPC command: AttentionBroker::save_context()");
+    }
+}
+
+void AttentionBrokerClient::drop_and_load_context(const string& context, const string& file_name) {
+    dasproto::ContextPersistence request;
+    dasproto::Ack ack;
+
+    request.set_context(context);
+    request.set_file_name(file_name);
+
+    auto stub = dasproto::AttentionBroker::NewStub(
+        grpc::CreateChannel(SERVER_ADDRESS, grpc::InsecureChannelCredentials()));
+
+    LOG_INFO("Calling AttentionBroker GRPC. Dropping context info and loading contents from file. Context: " + context + " File name: " + file_name);
+    stub->drop_and_load_context(new grpc::ClientContext(), request, &ack);
+    if (ack.msg() != "DROP_AND_LOAD_CONTEXT") {
+        Utils::error("Failed GRPC command: AttentionBroker::drop_and_load_context()");
+    }
+}

--- a/src/attention_broker/AttentionBrokerClient.h
+++ b/src/attention_broker/AttentionBrokerClient.h
@@ -33,6 +33,8 @@ class AttentionBrokerClient {
                                float spreading_rate_lowerbound,
                                float spreading_rate_upperbound);
     static bool health_check(bool throw_on_error = false);
+    static void save_context(const string& context, const string& file_name);
+    static void drop_and_load_context(const string& context, const string& file_name);
 
    private:
     static mutex api_mutex;

--- a/src/attention_broker/AttentionBrokerServer.cc
+++ b/src/attention_broker/AttentionBrokerServer.cc
@@ -206,11 +206,12 @@ Status AttentionBrokerServer::set_parameters(ServerContext* grpc_context,
 Status AttentionBrokerServer::save_context(ServerContext* grpc_context,
                                            const dasproto::ContextPersistence* request,
                                            dasproto::Ack* reply) {
-    LOG_INFO("Saving contents of context: " + request->context() + " into file: " + request->file_name());
+    LOG_INFO("Saving contents of context: " + request->context() +
+             " into file: " + request->file_name());
     if (this->rpc_api_enabled) {
         HebbianNetwork* network = select_hebbian_network(request->context());
         ofstream file(request->file_name());
-        if (! file.is_open()) {
+        if (!file.is_open()) {
             LOG_ERROR("Couldn't open file: " + request->file_name());
             return Status::CANCELLED;
         }
@@ -232,12 +233,13 @@ Status AttentionBrokerServer::save_context(ServerContext* grpc_context,
 Status AttentionBrokerServer::drop_and_load_context(ServerContext* grpc_context,
                                                     const dasproto::ContextPersistence* request,
                                                     dasproto::Ack* reply) {
-    LOG_INFO("Dropping contents of context: " + request->context() + " Reading from file: " + request->file_name());
+    LOG_INFO("Dropping contents of context: " + request->context() +
+             " Reading from file: " + request->file_name());
     if (this->rpc_api_enabled) {
         HebbianNetwork* network = select_hebbian_network(request->context());
         network->clear();
         ifstream file(request->file_name());
-        if (! file.is_open()) {
+        if (!file.is_open()) {
             LOG_ERROR("Couldn't open file: " + request->file_name());
             return Status::CANCELLED;
         }

--- a/src/attention_broker/AttentionBrokerServer.h
+++ b/src/attention_broker/AttentionBrokerServer.h
@@ -172,6 +172,30 @@ class AttentionBrokerServer final : public AttentionBroker::Service {
                           const dasproto::Parameters* request,
                           dasproto::Ack* reply) override;
 
+    /**
+     * Save contents of the passed context into a file.
+     * File is a flat file name (no paths).
+     *
+     * @param request Context and the name of the file to be saved.
+     * @param reply The message which will be send back to the caller with a simple ACK.
+     * @return GRPC status OK if request were properly processed or CANCELLED otherwise.
+     */
+    Status save_context(ServerContext* grpc_context,
+                        const dasproto::ContextPersistence* request,
+                        dasproto::Ack* reply) override;
+
+    /**
+     * Drop current contexts of the passed context and load data from the passed file.
+     * File is a flat file name (no paths).
+     *
+     * @param request Context and the name of the file to be loaded.
+     * @param reply The message which will be send back to the caller with a simple ACK.
+     * @return GRPC status OK if request were properly processed or CANCELLED otherwise.
+     */
+    Status drop_and_load_context(ServerContext* grpc_context,
+                                 const dasproto::ContextPersistence* request,
+                                 dasproto::Ack* reply) override;
+
     // Other public methods
 
     /**

--- a/src/attention_broker/HebbianNetwork.cc
+++ b/src/attention_broker/HebbianNetwork.cc
@@ -12,6 +12,12 @@ using namespace attention_broker;
 // Public methods
 
 HebbianNetwork::HebbianNetwork() {
+    init();
+}
+
+HebbianNetwork::~HebbianNetwork() { delete nodes; }
+
+void HebbianNetwork::init() {
     nodes = new HandleTrie(HANDLE_HASH_SIZE - 1);
     largest_arity = 0;
     tokens_mutex.lock();
@@ -19,7 +25,10 @@ HebbianNetwork::HebbianNetwork() {
     tokens_mutex.unlock();
 }
 
-HebbianNetwork::~HebbianNetwork() { delete nodes; }
+void HebbianNetwork::clear() { 
+    delete nodes;
+    init();
+}
 
 string HebbianNetwork::Node::to_string() {
     return "(" + std::to_string(count) + ", " + std::to_string(importance) + ", " +

--- a/src/attention_broker/HebbianNetwork.cc
+++ b/src/attention_broker/HebbianNetwork.cc
@@ -11,9 +11,7 @@ using namespace attention_broker;
 // --------------------------------------------------------------------------------
 // Public methods
 
-HebbianNetwork::HebbianNetwork() {
-    init();
-}
+HebbianNetwork::HebbianNetwork() { init(); }
 
 HebbianNetwork::~HebbianNetwork() { delete nodes; }
 
@@ -25,7 +23,7 @@ void HebbianNetwork::init() {
     tokens_mutex.unlock();
 }
 
-void HebbianNetwork::clear() { 
+void HebbianNetwork::clear() {
     delete nodes;
     init();
 }

--- a/src/attention_broker/HebbianNetwork.h
+++ b/src/attention_broker/HebbianNetwork.h
@@ -184,11 +184,13 @@ class HebbianNetwork : public Serializable {
 
     ImportanceType alienate_tokens();
 
+    void clear();
     void serialize(ostream& os);
     void deserialize(istream& is);
 
    private:
     void deserialize_node(istream& is, unsigned int& determiner_count, unsigned int& neighbors_count);
+    void init();
 
     HandleTrie* nodes;
     ImportanceType tokens_to_distribute;

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -435,7 +435,7 @@ cc_test(
 
 cc_test(
     name = "service_bus_test",
-    size = "small",
+    size = "medium",
     srcs = ["service_bus_test.cc"],
     copts = [
         "-Iexternal/gtest/googletest/include",


### PR DESCRIPTION
Resolves #807 

AttentionBrokerClient now have two new methods:

```
    static void save_context(const string& context, const string& file_name);
    static void drop_and_load_context(const string& context, const string& file_name);
```

They allow persistence of contexts in disk.