### PR TITLE
Add MorkDB `add_link()` and `delete_link()`.

### DIFF
--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -179,4 +179,34 @@ shared_ptr<atomdb_api_types::HandleSet> MorkDB::query_for_pattern(const LinkSche
     return handle_set;
 }
 
+string MorkDB::add_link(const atoms::Link* link) {
+    auto existing_targets = get_atom_documents(link->targets, {MONGODB_FIELD_NAME[MONGODB_FIELD::ID]});
+    if (existing_targets.size() != link->targets.size()) {
+        Utils::error("Failed to insert link: " + link->handle() + " has " +
+                     to_string(link->targets.size() - existing_targets.size()) + " missing targets");
+        return "";
+    }
+
+    auto metta_expression = link->metta_representation(*this);
+    this->mork_client->post(metta_expression, "$x", "$x");
+
+    auto mongodb_pool = this->get_mongo_pool();
+    auto conn = mongodb_pool->acquire();
+    auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_LINKS_COLLECTION_NAME];
+
+    auto mongodb_doc = atomdb_api_types::MongodbDocument(link, *this);
+    auto reply = mongodb_collection.insert_one(mongodb_doc.value());
+
+    if (!reply) {
+        Utils::error("Failed to insert link into MongoDB");
+    }
+
+    return link->handle();
+}
+
+bool MorkDB::delete_link(const string& handle, bool delete_targets) {
+    Utils::error("MORKDB does not support deleting links.");
+    return false;
+}
+
 // <--

--- a/src/atomdb/morkdb/MorkDB.h
+++ b/src/atomdb/morkdb/MorkDB.h
@@ -43,7 +43,7 @@ class MorkDB : public RedisMongoDB {
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const LinkSchema& link_schema) override;
 
-    string add_link(const atoms::Link* link) override;
+    string add_link(const atoms::Link* link, bool throw_if_exists = false) override;
 
     // TODO: Implement this once MORK supports deleting links (S-Expressions)
     bool delete_link(const string& handle, bool delete_targets) override;

--- a/src/atomdb/morkdb/MorkDB.h
+++ b/src/atomdb/morkdb/MorkDB.h
@@ -43,6 +43,11 @@ class MorkDB : public RedisMongoDB {
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const LinkSchema& link_schema) override;
 
+    string add_link(const atoms::Link* link) override;
+
+    // TODO: Implement this once MORK supports deleting links (S-Expressions)
+    bool delete_link(const string& handle, bool delete_targets) override;
+
    private:
     shared_ptr<AtomDBCache> atomdb_cache;
     shared_ptr<MorkClient> mork_client;

--- a/src/tests/cpp/morkdb_test.cc
+++ b/src/tests/cpp/morkdb_test.cc
@@ -195,10 +195,16 @@ TEST_F(MorkDBTest, AddGetAndDeleteLink) {
     auto node1_handle = db->add_node(node1);
     auto node2 = new Node("Symbol", "Node2");
     auto node2_handle = db->add_node(node2);
+    auto node3 = new Node("Symbol", "Node3");
+    auto node3_handle = db->add_node(node3);
+    auto node4 = new Node("Symbol", "Node4");
+    auto node4_handle = db->add_node(node4);
 
     ASSERT_TRUE(db->node_exists(similarity_node_handle));
     ASSERT_TRUE(db->node_exists(node1_handle));
     ASSERT_TRUE(db->node_exists(node2_handle));
+    ASSERT_TRUE(db->node_exists(node3_handle));
+    ASSERT_TRUE(db->node_exists(node4_handle));
 
     auto link = new Link("Expression", {similarity_node_handle, node1_handle, node2_handle});
     auto link_handle = db->add_link(link);
@@ -211,12 +217,28 @@ TEST_F(MorkDBTest, AddGetAndDeleteLink) {
     EXPECT_EQ(string(link_document->get("targets", 1)), string(node1_handle));
     EXPECT_EQ(string(link_document->get("targets", 2)), string(node2_handle));
 
-    ASSERT_TRUE(db->delete_link(link_handle, true));
+    // clang-format off
+    LinkSchema link_schema({
+        link_template, expression, "3", 
+            node, symbol, "Similarity", 
+            node, symbol, "Node1",
+            variable, "S"});
+    // clang-format on
 
-    ASSERT_FALSE(db->link_exists(link_handle));
-    ASSERT_FALSE(db->node_exists(similarity_node_handle));
-    ASSERT_FALSE(db->node_exists(node1_handle));
-    ASSERT_FALSE(db->node_exists(node2_handle));
+    auto handle_set = db->query_for_pattern(link_schema);
+    EXPECT_EQ(handle_set->size(), 1);
+
+    auto link_13 = new Link("Expression", {similarity_node_handle, node1_handle, node3_handle});
+    auto link_14 = new Link("Expression", {similarity_node_handle, node1_handle, node4_handle});
+
+    auto new_link_handles = db->add_links({link_13, link_14});
+    EXPECT_EQ(new_link_handles.size(), 2);
+
+    handle_set = db->query_for_pattern(link_schema);
+    EXPECT_EQ(handle_set->size(), 3);
+
+    // MORKDB does not support deleting links, so expecting an exception
+    EXPECT_THROW(db->delete_link(link_handle, true), runtime_error);
 }
 
 TEST_F(MorkDBTest, AddGetAndDeleteLinks) {
@@ -240,11 +262,8 @@ TEST_F(MorkDBTest, AddGetAndDeleteLinks) {
     auto links_documents = db->get_atom_documents(links_handles, {"_id"});
     EXPECT_EQ(links_documents.size(), links.size());
 
-    ASSERT_TRUE(db->delete_links(links_handles, true));
-
-    for (auto link_handle : links_handles) {
-        ASSERT_FALSE(db->link_exists(link_handle));
-    }
+    // MORKDB does not support deleting links, so expecting an exception
+    EXPECT_THROW(db->delete_links(links_handles, true), runtime_error);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This PR adds `MorkDB::add_link()` and `MorkDB::delete_link()`.

For now, `MorkDB::delete_link()` is throwing an exception as we do not support removing S-Expressions in `mork-server`.