### PR TITLE
[AtomDB] Add upsert logic.

### DIFF
--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -50,13 +50,16 @@ class AtomDB : public HandleDecoder {
     virtual set<string> nodes_exist(const vector<string>& handles) = 0;
     virtual set<string> links_exist(const vector<string>& handles) = 0;
 
-    virtual string add_atom(const atoms::Atom* atom) = 0;
-    virtual string add_node(const atoms::Node* node) = 0;
-    virtual string add_link(const atoms::Link* link) = 0;
+    virtual string add_atom(const atoms::Atom* atom, bool throw_if_exists = false) = 0;
+    virtual string add_node(const atoms::Node* node, bool throw_if_exists = false) = 0;
+    virtual string add_link(const atoms::Link* link, bool throw_if_exists = false) = 0;
 
-    virtual vector<string> add_atoms(const vector<atoms::Atom*>& atoms) = 0;
-    virtual vector<string> add_nodes(const vector<atoms::Node*>& nodes) = 0;
-    virtual vector<string> add_links(const vector<atoms::Link*>& links) = 0;
+    virtual vector<string> add_atoms(const vector<atoms::Atom*>& atoms,
+                                     bool throw_if_exists = false) = 0;
+    virtual vector<string> add_nodes(const vector<atoms::Node*>& nodes,
+                                     bool throw_if_exists = false) = 0;
+    virtual vector<string> add_links(const vector<atoms::Link*>& links,
+                                     bool throw_if_exists = false) = 0;
 
     virtual bool delete_atom(const string& handle, bool delete_link_targets = false) = 0;
     virtual bool delete_node(const string& handle, bool delete_link_targets = false) = 0;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -92,13 +92,13 @@ class RedisMongoDB : public AtomDB {
     set<string> nodes_exist(const vector<string>& handles);
     set<string> links_exist(const vector<string>& handles);
 
-    string add_atom(const atoms::Atom* atom);
-    string add_node(const atoms::Node* node);
-    string add_link(const atoms::Link* link);
+    string add_atom(const atoms::Atom* atom, bool throw_if_exists = false);
+    string add_node(const atoms::Node* node, bool throw_if_exists = false);
+    string add_link(const atoms::Link* link, bool throw_if_exists = false);
 
-    vector<string> add_atoms(const vector<atoms::Atom*>& atoms);
-    vector<string> add_nodes(const vector<atoms::Node*>& nodes);
-    vector<string> add_links(const vector<atoms::Link*>& links);
+    vector<string> add_atoms(const vector<atoms::Atom*>& atoms, bool throw_if_exists = false);
+    vector<string> add_nodes(const vector<atoms::Node*>& nodes, bool throw_if_exists = false);
+    vector<string> add_links(const vector<atoms::Link*>& links, bool throw_if_exists = false);
 
     bool delete_atom(const string& handle, bool delete_link_targets = false);
     bool delete_node(const string& handle, bool delete_link_targets = false);
@@ -107,6 +107,11 @@ class RedisMongoDB : public AtomDB {
     uint delete_atoms(const vector<string>& handles, bool delete_link_targets = false);
     uint delete_nodes(const vector<string>& handles, bool delete_link_targets = false);
     uint delete_links(const vector<string>& handles, bool delete_link_targets = false);
+
+    bool upsert_document(const bsoncxx::v_noabi::document::value& document,
+                         const string& collection_name);
+    uint upsert_documents(const vector<bsoncxx::document::value>& documents,
+                          const string& collection_name);
 
     vector<shared_ptr<atomdb_api_types::AtomDocument>> get_filtered_documents(
         const string& collection_name,

--- a/src/tests/cpp/atom_space_test.cc
+++ b/src/tests/cpp/atom_space_test.cc
@@ -117,24 +117,30 @@ class MockAtomDB : public AtomDB {
         return {};
     }
 
-    string add_atom(const atoms::Atom* atom) override { return ""; }
+    string add_atom(const atoms::Atom* atom, bool throw_if_exists) override { return ""; }
 
-    string add_node(const atoms::Node* node) override {
+    string add_node(const atoms::Node* node, bool throw_if_exists) override {
         add_node_calls.push_back({node->type, node->name, node->custom_attributes});
         // string handle = string("node_") + node->type + "_" + node->name;
         atoms[node->handle()] = (Atom*) node;
         return node->handle();
     }
 
-    string add_link(const atoms::Link* link) override {
+    string add_link(const atoms::Link* link, bool throw_if_exists) override {
         add_link_calls.push_back({link->type, link->targets, link->custom_attributes});
         atoms[link->handle()] = (Atom*) link;
         return link->handle();
     }
 
-    vector<string> add_atoms(const vector<atoms::Atom*>& atoms) override { return {}; }
-    vector<string> add_nodes(const vector<atoms::Node*>& nodes) override { return {}; }
-    vector<string> add_links(const vector<atoms::Link*>& links) override { return {}; }
+    vector<string> add_atoms(const vector<atoms::Atom*>& atoms, bool throw_if_exists) override {
+        return {};
+    }
+    vector<string> add_nodes(const vector<atoms::Node*>& nodes, bool throw_if_exists) override {
+        return {};
+    }
+    vector<string> add_links(const vector<atoms::Link*>& links, bool throw_if_exists) override {
+        return {};
+    }
 
     bool atom_exists(const string& handle) override { return false; }
     bool node_exists(const string& handle) override { return false; }

--- a/src/tests/cpp/test_commons/mocks/MockAtomDB.h
+++ b/src/tests/cpp/test_commons/mocks/MockAtomDB.h
@@ -78,13 +78,22 @@ class AtomDBMock : public AtomDB {
     MOCK_METHOD(set<string>, nodes_exist, (const vector<string>& handles), (override));
     MOCK_METHOD(set<string>, links_exist, (const vector<string>& link_handles), (override));
 
-    MOCK_METHOD(string, add_node, (const Node* node), (override));
-    MOCK_METHOD(string, add_link, (const Link* link), (override));
-    MOCK_METHOD(string, add_atom, (const Atom* atom), (override));
+    MOCK_METHOD(string, add_node, (const Node* node, bool throw_if_exists), (override));
+    MOCK_METHOD(string, add_link, (const Link* link, bool throw_if_exists), (override));
+    MOCK_METHOD(string, add_atom, (const Atom* atom, bool throw_if_exists), (override));
 
-    MOCK_METHOD(vector<string>, add_atoms, (const vector<Atom*>& atoms), (override));
-    MOCK_METHOD(vector<string>, add_nodes, (const vector<Node*>& nodes), (override));
-    MOCK_METHOD(vector<string>, add_links, (const vector<Link*>& links), (override));
+    MOCK_METHOD(vector<string>,
+                add_atoms,
+                (const vector<Atom*>& atoms, bool throw_if_exists),
+                (override));
+    MOCK_METHOD(vector<string>,
+                add_nodes,
+                (const vector<Node*>& nodes, bool throw_if_exists),
+                (override));
+    MOCK_METHOD(vector<string>,
+                add_links,
+                (const vector<Link*>& links, bool throw_if_exists),
+                (override));
 
     MOCK_METHOD(bool, delete_atom, (const string& handle, bool delete_link_targets), (override));
     MOCK_METHOD(bool, delete_node, (const string& handle, bool delete_link_targets), (override));


### PR DESCRIPTION
This PR adds `upsert` logic to `AtomDB` by adding the `throw_if_exists` flag to:
```
    string add_atom(const atoms::Atom* atom, bool throw_if_exists = false);
    string add_node(const atoms::Node* node, bool throw_if_exists = false);
    string add_link(const atoms::Link* link, bool throw_if_exists = false);

    vector<string> add_atoms(const vector<atoms::Atom*>& atoms, bool throw_if_exists = false);
    vector<string> add_nodes(const vector<atoms::Node*>& nodes, bool throw_if_exists = false);
    vector<string> add_links(const vector<atoms::Link*>& links, bool throw_if_exists = false);
```
The flag default value is `false`, meaning AtomDB will update an existing entry.