### PR TITLE
Add retry logic to `RedisContextPool::acquire()`

### DIFF
--- a/src/atomdb/redis_mongodb/RedisContextPool.cc
+++ b/src/atomdb/redis_mongodb/RedisContextPool.cc
@@ -65,12 +65,12 @@ shared_ptr<RedisContext> RedisContextPool::acquire() {
         } catch (const std::exception& e) {
             retries++;
             LOG_ERROR(string(e.what()));
-            Utils::sleep(retry_delay);
+            if (retries <= MAX_RETRY_COUNT) Utils::sleep(retry_delay);
             retry_delay *= 2;
         }
     }
 
-    if (retries == MAX_RETRY_COUNT) {
+    if (retries > MAX_RETRY_COUNT) {
         Utils::error("Redis connection error: Failed to connect to Redis after " +
                      to_string(MAX_RETRY_COUNT) + " retries");
     }

--- a/src/tests/cpp/atomdb_broker_test.cc
+++ b/src/tests/cpp/atomdb_broker_test.cc
@@ -54,11 +54,11 @@ class AtomDBTest : public ::testing::Test {
 };
 
 TEST_F(AtomDBTest, AddAtoms) {
-    string query_agent_id = "0.0.0.0:42000";
-    string atomdb_broker_server_id = "0.0.0.0:42010";
-    string atomdb_broker_client_id = "0.0.0.0:42020";
+    string query_agent_id = "0.0.0.0:51000";
+    string atomdb_broker_server_id = "0.0.0.0:51001";
+    string atomdb_broker_client_id = "0.0.0.0:51002";
 
-    ServiceBusSingleton::init(query_agent_id, atomdb_broker_server_id, 42000, 42999);
+    ServiceBusSingleton::init(query_agent_id, atomdb_broker_server_id, 51003, 51999);
 
     shared_ptr<ServiceBus> service_bus = ServiceBusSingleton::get_instance();
     service_bus->register_processor(make_shared<PatternMatchingQueryProcessor>());

--- a/src/tests/cpp/context_test.cc
+++ b/src/tests/cpp/context_test.cc
@@ -115,11 +115,11 @@ TEST_F(ContextTest, basics) {
 }
 
 TEST_F(ContextTest, ContextBroker) {
-    string query_agent_id = "localhost:42070";
-    string context_processor_id = "localhost:42071";
-    string context_client_id = "localhost:42072";
+    string query_agent_id = "localhost:50000";
+    string context_processor_id = "localhost:50001";
+    string context_client_id = "localhost:50002";
 
-    ServiceBusSingleton::init(context_processor_id, query_agent_id, 42000, 42999);
+    ServiceBusSingleton::init(context_processor_id, query_agent_id, 50003, 50999);
     shared_ptr<ServiceBus> context_bus = ServiceBusSingleton::get_instance();
     context_bus->register_processor(make_shared<ContextBrokerProcessor>());
     Utils::sleep(500);


### PR DESCRIPTION
This PR adds a retry logic to `RedisContextPool::acquire()`.

It is hardcoded to 5 max retries, meaning it will retry after 1, 2, 4, 8 and 16 seconds.