### PR TITLE
[HE Client] Add `LinkCreationProxy`

### DIFF
--- a/3rd_party_slots/rust_metta_bus_client/src/context_broker_proxy.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/context_broker_proxy.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use hyperon_atom::Atom;
-use md5;
 
 use crate::{
 	base_proxy_query::{BaseQueryProxy, BaseQueryProxyT},
@@ -146,10 +145,6 @@ impl BaseQueryProxyT for ContextBrokerProxy {
 	fn drop_runtime(&mut self) {
 		self.base.lock().unwrap().drop_runtime()
 	}
-}
-
-pub fn hash_context(context: &str) -> String {
-	format!("{:x}", md5::compute(context.as_bytes()))
 }
 
 pub fn parse_context_broker_parameters(atom: &Atom) -> Result<ContextBrokerParams, BoxError> {

--- a/3rd_party_slots/rust_metta_bus_client/src/helpers/mod.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/helpers/mod.rs
@@ -58,6 +58,10 @@ pub fn split_ignore_quoted(s: &str) -> Vec<String> {
 	result
 }
 
+pub fn compute_hash(data: &str) -> String {
+	format!("{:x}", md5::compute(data.as_bytes()))
+}
+
 pub fn get_networking_params(params: &Properties) -> Result<(String, u16, u16, String), BoxError> {
 	let hostname =
 		params.try_get(properties::HOSTNAME).ok_or(BoxError::from("Hostname not found"))?;

--- a/3rd_party_slots/rust_metta_bus_client/src/link_creation_proxy.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/link_creation_proxy.rs
@@ -1,0 +1,125 @@
+use std::sync::{Arc, Mutex};
+
+use hyperon_atom::Atom;
+
+use crate::{
+	base_proxy_query::{BaseQueryProxy, BaseQueryProxyT},
+	bus::LINK_CREATION_CMD,
+	helpers::compute_hash,
+	properties::{self, PropertyValue},
+	types::BoxError,
+	QueryParams,
+};
+
+pub static LINK_CREATION_PARSER_ERROR_MESSAGE: &str =
+	"LINK_CREATION command must have ((query) (template)) eg:
+(
+	!(das-link-creation! ((and (PREDICATE %P1) (PREDICATE %P2)) (IMPLICATION %P1 %P2)))
+)";
+
+#[derive(Clone)]
+pub struct LinkCreationParams {
+	pub query: Atom,
+	pub templates: Vec<Atom>,
+}
+
+#[derive(Clone)]
+pub struct LinkCreationProxy {
+	pub base: Arc<Mutex<BaseQueryProxy>>,
+	pub id: String,
+	pub query: Atom,
+	pub templates: Vec<Atom>,
+}
+
+impl LinkCreationProxy {
+	pub fn new(
+		params: &QueryParams, link_creation_params: &LinkCreationParams,
+	) -> Result<Self, BoxError> {
+		let mut base = BaseQueryProxy::new(LINK_CREATION_CMD.to_string(), params.clone())?;
+
+		let context_name = params.properties.get::<String>(properties::CONTEXT);
+		let mut properties = params.properties.clone();
+		properties.insert(
+			properties::CONTEXT.to_string(),
+			PropertyValue::String(compute_hash(&context_name)),
+		);
+
+		let mut args = vec![];
+		args.extend(properties.to_vec());
+
+		args.push(link_creation_params.query.to_string());
+		args.extend(link_creation_params.templates.iter().map(|template| template.to_string()));
+
+		let original_id = format!("{}{}", base.proxy_node.peer_id, base.serial);
+		let id = compute_hash(&original_id);
+
+		log::debug!(target: "das", "Query              : <{}>", link_creation_params.query);
+		log::debug!(target: "das", "Templates          : <{}>", link_creation_params.templates.iter().map(|t| t.to_string()).collect::<Vec<String>>().join(" | "));
+		log::debug!(target: "das", "Context (name, key): <{}, {}>", context_name, base.context);
+		log::debug!(target: "das", "ID                 : <{id}>");
+		log::debug!(target: "das", "Repeat count       : <{}>", params.properties.get::<u64>(properties::REPEAT_COUNT));
+		log::debug!(target: "das", "Query interval     : <{}>", params.properties.get::<u64>(properties::QUERY_INTERVAL));
+		log::debug!(target: "das", "Query timeout      : <{}>", params.properties.get::<u64>(properties::QUERY_TIMEOUT));
+		base.args = args;
+
+		Ok(Self {
+			base: Arc::new(Mutex::new(base)),
+			id,
+			query: link_creation_params.query.clone(),
+			templates: link_creation_params.templates.clone(),
+		})
+	}
+}
+
+impl BaseQueryProxyT for LinkCreationProxy {
+	fn finished(&self) -> bool {
+		self.base.lock().unwrap().finished()
+	}
+
+	fn pop(&mut self) -> Option<String> {
+		self.base.lock().unwrap().pop()
+	}
+
+	fn push(&mut self, query_answer: String) -> Result<(), BoxError> {
+		self.base.lock().unwrap().push(query_answer)
+	}
+
+	fn get_count(&self) -> u64 {
+		self.base.lock().unwrap().get_count()
+	}
+
+	fn abort(&mut self) {
+		self.base.lock().unwrap().abort()
+	}
+
+	fn setup_proxy_node(
+		&mut self, proxy_arc: Arc<Mutex<BaseQueryProxy>>, client_id: Option<String>,
+		server_id: Option<String>,
+	) -> Result<(), BoxError> {
+		self.base.lock().unwrap().setup_proxy_node(proxy_arc, client_id, server_id)?;
+		Ok(())
+	}
+
+	fn to_remote_peer(&self, command: String, args: Vec<String>) -> Result<(), BoxError> {
+		self.base.lock().unwrap().to_remote_peer(command, args)
+	}
+
+	fn drop_runtime(&mut self) {
+		self.base.lock().unwrap().drop_runtime()
+	}
+}
+
+pub fn parse_link_creation_parameters(atom: &Atom) -> Result<LinkCreationParams, BoxError> {
+	if let Atom::Expression(exp_atom) = &atom {
+		let children = exp_atom.children();
+		if children.len() < 2 {
+			return Err(LINK_CREATION_PARSER_ERROR_MESSAGE.to_string().into());
+		}
+
+		let query = children[0].clone();
+		let templates = children[1..].to_vec();
+
+		return Ok(LinkCreationParams { query, templates });
+	}
+	Err(LINK_CREATION_PARSER_ERROR_MESSAGE.to_string().into())
+}

--- a/3rd_party_slots/rust_metta_bus_client/src/properties.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/properties.rs
@@ -32,6 +32,11 @@ pub static INITIAL_RENT_RATE: &str = "initial_rent_rate";
 pub static INITIAL_SPREADING_RATE_LOWERBOUND: &str = "initial_spreading_rate_lowerbound";
 pub static INITIAL_SPREADING_RATE_UPPERBOUND: &str = "initial_spreading_rate_upperbound";
 
+// Link Creation
+pub static REPEAT_COUNT: &str = "repeat_count";
+pub static QUERY_INTERVAL: &str = "query_interval";
+pub static QUERY_TIMEOUT: &str = "query_timeout";
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum PropertyValue {
 	String(String),
@@ -142,6 +147,10 @@ impl Properties {
 		println!("    {}", self.print_with_set_param(POPULATION_SIZE).unwrap());
 		println!("    {}", self.print_with_set_param(SELECTION_RATE).unwrap());
 		println!("    {}", self.print_with_set_param(TOTAL_ATTENTION_TOKENS).unwrap());
+		println!("  Link Creation:");
+		println!("    {}", self.print_with_set_param(REPEAT_COUNT).unwrap());
+		println!("    {}", self.print_with_set_param(QUERY_INTERVAL).unwrap());
+		println!("    {}", self.print_with_set_param(QUERY_TIMEOUT).unwrap());
 	}
 
 	fn print_with_set_param(&self, key: &str) -> Result<String, String> {
@@ -163,7 +172,7 @@ impl Default for Properties {
 		map.insert(KNOWN_PEER_ID.to_string(), PropertyValue::String(String::new()));
 
 		// Query
-		map.insert(MAX_ANSWERS.to_string(), PropertyValue::UnsignedInt(0));
+		map.insert(MAX_ANSWERS.to_string(), PropertyValue::UnsignedInt(100));
 		map.insert(MAX_BUNDLE_SIZE.to_string(), PropertyValue::UnsignedInt(1_000));
 		map.insert(UNIQUE_ASSIGNMENT_FLAG.to_string(), PropertyValue::Bool(true));
 		map.insert(POSITIVE_IMPORTANCE_FLAG.to_string(), PropertyValue::Bool(false));
@@ -185,6 +194,11 @@ impl Default for Properties {
 		map.insert(INITIAL_RENT_RATE.to_string(), PropertyValue::Double(0.25));
 		map.insert(INITIAL_SPREADING_RATE_LOWERBOUND.to_string(), PropertyValue::Double(0.50));
 		map.insert(INITIAL_SPREADING_RATE_UPPERBOUND.to_string(), PropertyValue::Double(0.70));
+
+		// Link Creation
+		map.insert(REPEAT_COUNT.to_string(), PropertyValue::UnsignedInt(1));
+		map.insert(QUERY_INTERVAL.to_string(), PropertyValue::UnsignedInt(0));
+		map.insert(QUERY_TIMEOUT.to_string(), PropertyValue::UnsignedInt(0));
 
 		Self(map)
 	}


### PR DESCRIPTION
This PR adds the `LinkCreationProxy` that is called by the HE's `das-link-creation!` op:
```
!(import! &self das)
>>>
[()]
!(bind! &das (new-das! (localhost:42000-42499) (localhost:40002)))
>>>
[()]

!(match &das (IMPLICATION $P1 $P2) (IMPLICATION $P1 $P2))
>>>
[()]

!(das-link-creation! (and (PREDICATE $P1) (PREDICATE $P2)) (IMPLICATION $P1 $P2) (PATTERNS $P1) (PATTERNS $P2))
>>>
[(das-link-creation! Done)]

!(match &das (IMPLICATION $P1 $P2) (IMPLICATION $P1 $P2))
>>>
[(IMPLICATION "has_horns" "is_dinosaur"), (IMPLICATION "no_legs" "is_dinosaur"),  ..., (IMPLICATION "is_plant" "is_reptile"), (IMPLICATION "is_animal" "is_plant")]

!(match &das (PATTERNS $P) (PATTERNS $P))
>>>
[(PATTERNS "is_reptile"), (PATTERNS "no_legs"), (PATTERNS "has_horns"), (PATTERNS "two_legs"), (PATTERNS "is_animal"), (PATTERNS "four_legs"), (PATTERNS "is_dinosaur"), (PATTERNS "is_mammal"), (PATTERNS "is_plant")]
```