### PR TITLE
Add `MorkDB::query_for_targets()`

### DIFF
--- a/src/atomdb/morkdb/BUILD
+++ b/src/atomdb/morkdb/BUILD
@@ -18,6 +18,7 @@ cc_library(
     includes = ["."],
     deps = [
         "//atomdb:atomdb_api_types",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//commons/atoms:atoms_lib",
     ],
 )

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -184,15 +184,7 @@ shared_ptr<atomdb_api_types::HandleList> MorkDB::query_for_targets(const string&
     if (document == nullptr || !document->contains(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS])) {
         return nullptr;
     }
-
-    vector<string> targets;
-
-    unsigned int arity = document->get_size(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS]);
-    for (unsigned int i = 0; i < arity; i++) {
-        targets.push_back(string(document->get(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS], i)));
-    }
-
-    return make_shared<atomdb_api_types::HandleListMork>(targets);
+    return make_shared<atomdb_api_types::HandleListMork>(document);
 }
 
 string MorkDB::add_link(const atoms::Link* link, bool throw_if_exists) {

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -179,6 +179,22 @@ shared_ptr<atomdb_api_types::HandleSet> MorkDB::query_for_pattern(const LinkSche
     return handle_set;
 }
 
+shared_ptr<atomdb_api_types::HandleList> MorkDB::query_for_targets(const string& handle) {
+    auto document = this->get_atom_document(handle);
+    if (document == nullptr || !document->contains(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS])) {
+        return nullptr;
+    }
+
+    vector<string> targets;
+
+    unsigned int arity = document->get_size(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS]);
+    for (unsigned int i = 0; i < arity; i++) {
+        targets.push_back(string(document->get(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS], i)));
+    }
+
+    return make_shared<atomdb_api_types::HandleListMork>(targets);
+}
+
 string MorkDB::add_link(const atoms::Link* link, bool throw_if_exists) {
     if (throw_if_exists && link_exists(link->handle())) {
         Utils::error("Link already exists: " + link->handle());

--- a/src/atomdb/morkdb/MorkDB.h
+++ b/src/atomdb/morkdb/MorkDB.h
@@ -42,6 +42,7 @@ class MorkDB : public RedisMongoDB {
     bool allow_nested_indexing() override;
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const LinkSchema& link_schema) override;
+    shared_ptr<atomdb_api_types::HandleList> query_for_targets(const string& handle) override;
 
     string add_link(const atoms::Link* link, bool throw_if_exists = false) override;
 

--- a/src/atomdb/morkdb/MorkDBAPITypes.cc
+++ b/src/atomdb/morkdb/MorkDBAPITypes.cc
@@ -1,5 +1,7 @@
 #include "MorkDBAPITypes.h"
 
+#include "RedisMongoDB.h"
+
 using namespace atomdb;
 using namespace atomdb_api_types;
 
@@ -66,9 +68,17 @@ Assignment HandleSetMork::get_assignments_by_handle(const string& handle) {
 // <--
 
 // --> HandleListMork
-HandleListMork::HandleListMork(vector<string> targets) : HandleList() {
-    this->handles_size = targets.size();
-    this->handles = targets;
+HandleListMork::HandleListMork(const shared_ptr<AtomDocument>& document) : HandleList() {
+    unsigned int handles_size = 0;
+    if (document->contains(RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS])) {
+        handles_size = document->get_size(RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS]);
+    }
+    this->handles_size = handles_size;
+    this->handles = new char*[handles_size];
+    for (unsigned int i = 0; i < handles_size; i++) {
+        this->handles[i] =
+            strdup(document->get(RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS], i));
+    }
 }
 
 HandleListMork::~HandleListMork() {}
@@ -78,7 +88,7 @@ const char* HandleListMork::get_handle(unsigned int index) {
         Utils::error("Handle index out of bounds: " + to_string(index) +
                      " Answer handles size: " + to_string(this->handles_size));
     }
-    return handles[index].c_str();
+    return handles[index];
 }
 
 unsigned int HandleListMork::size() { return this->handles_size; }

--- a/src/atomdb/morkdb/MorkDBAPITypes.cc
+++ b/src/atomdb/morkdb/MorkDBAPITypes.cc
@@ -1,5 +1,7 @@
 #include "MorkDBAPITypes.h"
 
+#include <cstring>
+
 #include "RedisMongoDB.h"
 
 using namespace atomdb;
@@ -81,7 +83,12 @@ HandleListMork::HandleListMork(const shared_ptr<AtomDocument>& document) : Handl
     }
 }
 
-HandleListMork::~HandleListMork() {}
+HandleListMork::~HandleListMork() {
+    for (unsigned int i = 0; i < this->handles_size; i++) {
+        free(this->handles[i]);
+    }
+    delete[] this->handles;
+}
 
 const char* HandleListMork::get_handle(unsigned int index) {
     if (index > this->handles_size) {

--- a/src/atomdb/morkdb/MorkDBAPITypes.h
+++ b/src/atomdb/morkdb/MorkDBAPITypes.h
@@ -55,7 +55,7 @@ class HandleSetMorkIterator : public HandleSetIterator {
 
 class HandleListMork : public HandleList {
    public:
-    HandleListMork(vector<string> targets);
+    HandleListMork(const shared_ptr<AtomDocument>& document);
     ~HandleListMork();
 
     const char* get_handle(unsigned int index);
@@ -63,7 +63,7 @@ class HandleListMork : public HandleList {
 
    private:
     unsigned int handles_size;
-    vector<string> handles;
+    char** handles;
 };
 
 }  // namespace atomdb_api_types

--- a/src/tests/cpp/morkdb_test.cc
+++ b/src/tests/cpp/morkdb_test.cc
@@ -86,7 +86,7 @@ TEST_F(MorkDBTest, QueryForPattern) {
     LinkSchema link_schema({
         link_template, expression, "3", 
             node, symbol, inheritance, 
-            variable, "$x",
+            variable, "x",
             node, symbol, mammal});
     // clang-format on
 
@@ -110,8 +110,27 @@ TEST_F(MorkDBTest, QueryForPattern) {
 }
 
 TEST_F(MorkDBTest, QueryForTargets) {
-    string link_handle = exp_hash({"Inheritance", "\"human\"", "\"mammal\""});
-    EXPECT_EQ(db->query_for_targets(link_handle), nullptr);
+    auto node1 = new Node("Symbol", "QueryForTargetsNode1");
+    auto node1_handle = db->add_node(node1);
+    auto node2 = new Node("Symbol", "QueryForTargetsNode2");
+    auto node2_handle = db->add_node(node2);
+    auto node3 = new Node("Symbol", "QueryForTargetsNode3");
+    auto node3_handle = db->add_node(node3);
+
+    auto node1_targets = db->query_for_targets(node1_handle);
+    EXPECT_EQ(node1_targets, nullptr);
+
+    auto link1 = new Link("Expression", {node1_handle, node2_handle, node3_handle});
+    auto link1_handle = db->add_link(link1);
+
+    ASSERT_TRUE(db->link_exists(link1_handle));
+
+    auto link1_targets = db->query_for_targets(link1_handle);
+    EXPECT_NE(link1_targets, nullptr);
+    EXPECT_EQ(link1_targets->size(), 3);
+    EXPECT_EQ(link1_targets->get_handle(0), node1_handle);
+    EXPECT_EQ(link1_targets->get_handle(1), node2_handle);
+    EXPECT_EQ(link1_targets->get_handle(2), node3_handle);
 }
 
 TEST_F(MorkDBTest, ConcurrentQueryForPattern) {
@@ -125,8 +144,8 @@ TEST_F(MorkDBTest, ConcurrentQueryForPattern) {
             LinkSchema link_schema({
                 link_template, expression, "3", 
                     node, symbol, similarity, 
-                    variable, "$x",
-                    variable, "$y"});
+                    variable, "x",
+                    variable, "y"});
             // clang-format on
             auto handle_set = db->query_for_pattern(link_schema);
             ASSERT_NE(handle_set, nullptr);
@@ -152,8 +171,8 @@ TEST_F(MorkDBTest, ConcurrentQueryForPattern) {
     LinkSchema link_schema({
         link_template, expression, "3", 
             node, symbol, "Fake", 
-            variable, "$x",
-            variable, "$y"});
+            variable, "x",
+            variable, "y"});
     // clang-format on
     auto handle_set = db->query_for_pattern(link_schema);
     EXPECT_EQ(handle_set->size(), 0);


### PR DESCRIPTION
This PR implements the `query_for_targets()` for the MorkDB class.

We will just fetch the targets from the MongoDB for now. A next step would be improving this design to use Mork only (issue https://github.com/singnet/das/issues/851).