### PR TITLE
[HE Client][HOTFIX] Use push_back in `PortPool::return_port()`

### DIFF
--- a/3rd_party_slots/rust_metta_bus_client/src/port_pool.rs
+++ b/3rd_party_slots/rust_metta_bus_client/src/port_pool.rs
@@ -59,7 +59,7 @@ impl PortPool {
 		match POOL.get() {
 			Some(locked_pool) => {
 				let write_guard = locked_pool.read().unwrap();
-				write_guard.pool.lock().unwrap().push_front(port);
+				write_guard.pool.lock().unwrap().push_back(port);
 				Ok(())
 			},
 			None => Err(BoxError::from("PortPool not initialized!")),


### PR DESCRIPTION
Using `push_back()` instead of `push_front()` so we get a new port number at `PortPool::get_port()`