### PR TITLE
Add `RedisContext` ping before returning it to the pool

### DIFF
--- a/src/atomdb/redis_mongodb/RedisContext.cc
+++ b/src/atomdb/redis_mongodb/RedisContext.cc
@@ -39,6 +39,13 @@ redisReply* RedisContext::execute(const char* command) {
     }
 }
 
+bool RedisContext::ping() {
+    redisReply* reply = this->execute("PING");
+    if (reply == NULL) return false;
+    if (reply->type != REDIS_REPLY_STATUS) return false;
+    return string(reply->str) == string("PONG");
+}
+
 void RedisContext::append_command(const char* command) {
     if (cluster_flag) {
         if (redisClusterAppendCommand(cluster_ctx, command) == REDIS_OK) {

--- a/src/atomdb/redis_mongodb/RedisContext.h
+++ b/src/atomdb/redis_mongodb/RedisContext.h
@@ -17,6 +17,7 @@ class RedisContext {
     void set_context(redisClusterContext* ctx);
 
     redisReply* execute(const char* command);
+    bool ping();
     void append_command(const char* command);
     void flush_commands();
     bool has_error() const;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -170,6 +170,7 @@ class RedisMongoDB : public AtomDB {
 
     uint get_next_score(const string& key);
     void set_next_score(const string& key, uint score);
+    void set_next_score_with_context(shared_ptr<RedisContext> ctx, const string& key, uint score);
     void reset_scores();
 
     void add_pattern(const string& handle, const string& pattern_handle);

--- a/src/main/tests_db_loader.cc
+++ b/src/main/tests_db_loader.cc
@@ -32,10 +32,14 @@ int main(int argc, char* argv[]) {
     TestConfig::load_environment();
     TestConfig::set_atomdb_cache(false);
 
-    //                          OPTIONS="context atomdb_type num_links arity chunck_size"
+    //                          OPTIONS="context atomdb_type num_threads num_links arity chunck_size"
     //
-    // make run-tests-db-loader OPTIONS="test_1m_ redismongodb 1000000 3 5000"
-    // make run-tests-db-loader OPTIONS="test_1m_ morkdb 1000000 3 5000"
+    // make run-tests-db-loader OPTIONS="test_1m_ redismongodb 8 1000000 3 5000"
+    // make run-tests-db-loader OPTIONS="test_1m_ morkdb 8 1000000 3 5000"
+    // make run-tests-db-loader OPTIONS="test_1m_ redismongodb 8 1000000 3 5000"
+
+    // From file
+    // make run-tests-db-loader OPTIONS="test_1m_ redismongodb 8 file /path/to/file.metta 5000"
 
     string context = "";
     if (argc > 1) context = string(argv[1]);
@@ -62,22 +66,28 @@ int main(int argc, char* argv[]) {
         db->drop_all();
         LOG_INFO("Databases dropped");
 
-        string arg3 = string(argv[3]);
+        int num_threads = Utils::string_to_int(argv[3]);
+
+        string arg4 = string(argv[4]);
         vector<string> file_keywords = {"file", "--file", "FILE"};
-        bool is_file_mode = find(file_keywords.begin(), file_keywords.end(), arg3) != file_keywords.end();
-        
+        bool is_file_mode =
+            find(file_keywords.begin(), file_keywords.end(), arg4) != file_keywords.end();
+
         if (is_file_mode) {
             STOP_WATCH_START(tests_db_loader_from_file);
 
-            if (argc < 5) {
-                Utils::error("File mode requires file path as argument. Usage: context atomdb_type file <file_path> [chunk_size]");
+            if (argc < 6) {
+                Utils::error(
+                    "File mode requires file path as argument. Usage: context atomdb_type num_threads "
+                    "file "
+                    "<file_path> [chunk_size]");
                 return 1;
             }
-            
-            string file_path = argv[4];
+
+            string file_path = argv[5];
             int chunk_size = 1000;  // Batch size for adding atoms to DB
-            if (argc > 5) {
-                chunk_size = Utils::string_to_int(argv[5]);
+            if (argc > 6) {
+                chunk_size = Utils::string_to_int(argv[6]);
             }
 
             // First, read all lines from the file to determine line ranges for each thread
@@ -102,53 +112,49 @@ int main(int argc, char* argv[]) {
                 return 0;
             }
 
-            uint num_threads = static_cast<uint>(std::thread::hardware_concurrency());
-            if (num_threads == 0) num_threads = 1;
-            if (lines.size() < num_threads) {
-                num_threads = static_cast<uint>(lines.size());
-            }
-
             // Calculate lines per thread
             size_t lines_per_thread = lines.size() / num_threads;
             size_t remainder = lines.size() % num_threads;
 
-            LOG_INFO("Processing " + to_string(lines.size()) + " lines with " + 
-                     to_string(num_threads) + " threads (chunk size: " + to_string(chunk_size) + " | lines per thread: " + to_string(lines_per_thread) + " | remainder: " + to_string(remainder) + ")");
+            LOG_INFO("Processing " + to_string(lines.size()) + " lines with " + to_string(num_threads) +
+                     " threads (chunk size: " + to_string(chunk_size) + " | lines per thread: " +
+                     to_string(lines_per_thread) + " | remainder: " + to_string(remainder) + ")");
 
             vector<thread> threads;
             atomic<size_t> total_atoms_processed(0);
 
-            for (uint i = 0; i < num_threads; i++) {
+            for (int i = 0; i < num_threads; i++) {
                 size_t start_line = i * lines_per_thread;
                 size_t end_line = start_line + lines_per_thread;
 
-                //Remainder must be added to the last thread
+                // Remainder must be added to the last thread
                 if (i == num_threads - 1) {
                     end_line++;
                 }
 
-                threads.emplace_back([&, start_line, end_line, i]() {
+                threads.emplace_back([&, start_line, end_line, i]() -> void {
                     auto thread_atomdb = AtomDBSingleton::get_instance();
                     vector<Atom*> batch_atoms;
-                    vector<shared_ptr<MettaParserActions>> parser_actions_list;  // Keep parser_actions alive
+                    vector<shared_ptr<MettaParserActions>>
+                        parser_actions_list;  // Keep parser_actions alive
                     size_t thread_atoms_count = 0;
-                    set<string> handles;  // Avoid deduplication
+                    set<string> handles;      // Avoid deduplication
 
                     for (size_t line_idx = start_line; line_idx < end_line; line_idx++) {
                         const string& metta_expr = lines[line_idx];
-                        
+
                         try {
                             // Create parser actions for this line
-                            shared_ptr<MettaParserActions> parser_actions = 
+                            shared_ptr<MettaParserActions> parser_actions =
                                 make_shared<MettaParserActions>();
-                            
+
                             // Parse the S-Expression
                             MettaParser parser(metta_expr, parser_actions);
                             bool parse_error = parser.parse(false);  // Don't throw on error
-                            
+
                             if (parse_error) {
-                                LOG_ERROR("Thread " + to_string(i) + " failed to parse line " + 
-                                         to_string(line_idx) + ": " + metta_expr);
+                                LOG_ERROR("Thread " + to_string(i) + " failed to parse line " +
+                                          to_string(line_idx) + ": " + metta_expr);
                                 continue;
                             }
 
@@ -172,14 +178,14 @@ int main(int argc, char* argv[]) {
                                     // Clear old parser_actions that are no longer needed
                                     // Keep only the last few to avoid memory buildup
                                     if (parser_actions_list.size() > 10) {
-                                        parser_actions_list.erase(parser_actions_list.begin(), 
+                                        parser_actions_list.erase(parser_actions_list.begin(),
                                                                   parser_actions_list.end() - 5);
                                     }
                                 }
                             }
                         } catch (const exception& e) {
-                            LOG_ERROR("Thread " + to_string(i) + " exception on line " + 
-                                     to_string(line_idx) + ": " + string(e.what()));
+                            LOG_ERROR("Thread " + to_string(i) + " exception on line " +
+                                      to_string(line_idx) + ": " + string(e.what()));
                         }
                     }
 
@@ -189,9 +195,9 @@ int main(int argc, char* argv[]) {
                     }
 
                     total_atoms_processed += thread_atoms_count;
-                    LOG_DEBUG("Thread " + to_string(i) + " processed " + 
-                              to_string(thread_atoms_count) + " atoms " +
-                              "(lines " + to_string(start_line) + "-" + to_string(end_line - 1) + ")");
+                    LOG_DEBUG("Thread " + to_string(i) + " processed " + to_string(thread_atoms_count) +
+                              " atoms " + "(lines " + to_string(start_line) + "-" +
+                              to_string(end_line - 1) + ")");
                 });
             }
 
@@ -200,89 +206,114 @@ int main(int argc, char* argv[]) {
                 thread.join();
             }
 
-            LOG_INFO("Completed processing. Total atoms processed: " + 
+            LOG_INFO("Completed processing. Total atoms processed: " +
                      to_string(total_atoms_processed.load()));
-            
+
             STOP_WATCH_FINISH(tests_db_loader_from_file, "TestsDBLoaderFromFile");
 
         } else {
-            int num_links = Utils::string_to_int(argv[3]);
-            int arity = Utils::string_to_int(argv[4]);
-            int chunck_size = Utils::string_to_int(argv[5]);
+            int num_links = Utils::string_to_int(argv[4]);
+            int arity = Utils::string_to_int(argv[5]);
+            int chunck_size = Utils::string_to_int(argv[6]);
 
-            vector<Link*> links;
-            vector<Node*> nodes;
+            int links_per_thread = num_links / num_threads;
+            int remainder = num_links % num_threads;
+
+            vector<thread> threads;
 
             STOP_WATCH_START(tests_db_loader);
 
-            for (int i = 1; i <= num_links; i++) {
-                string metta_expression = "(";
-                vector<string> node_names;
-                vector<string> targets;
-                for (int j = 1; j <= arity; j++) {
-                    string name = "add-links-" + to_string(i) + "-" + to_string(j);
-                    auto node = new Node("Symbol", name);
-                    targets.push_back(node->handle());
-                    nodes.push_back(node);
-                    node_names.push_back(name);
-                    metta_expression += name;
-                    if (j != arity) {
-                        metta_expression += " ";
+            for (int i = 0; i < num_threads; i++) {
+                threads.emplace_back([&, thread_id = i, links_per_thread, remainder]() -> void {
+                    auto db = AtomDBSingleton::get_instance();
+
+                    vector<Link*> links;
+                    vector<Node*> nodes;
+
+                    int links_to_add = links_per_thread;
+                    if (thread_id == num_threads - 1) {
+                        links_to_add += remainder;
                     }
-                }
-                metta_expression += ")";
 
-                auto link = new Link("Expression", targets, true, {}, metta_expression);
-                links.push_back(link);
+                    LOG_DEBUG("[" + to_string(thread_id) + "] Adding " + to_string(links_to_add * 2) +
+                              " links and " + to_string(links_to_add * arity) + " nodes");
 
-                vector<string> nested_targets = {targets[0], targets[1], link->handle()};
-                string nested_metta_expression =
-                    "(" + node_names[0] + " " + node_names[1] + " " + metta_expression + ")";
-                auto link_with_nested =
-                    new Link("Expression", nested_targets, true, {}, nested_metta_expression);
-                links.push_back(link_with_nested);
+                    for (int j = 1; j <= links_to_add; j++) {
+                        string metta_expression = "(";
+                        vector<string> node_names;
+                        vector<string> targets;
+                        for (int k = 1; k <= arity; k++) {
+                            string name = "add-links-T" + to_string(thread_id) + "-" + to_string(j) +
+                                          "-" + to_string(k);
+                            auto node = new Node("Symbol", name);
+                            targets.push_back(node->handle());
+                            nodes.push_back(node);
+                            node_names.push_back(name);
+                            metta_expression += name;
+                            if (k != arity) {
+                                metta_expression += " ";
+                            }
+                        }
+                        metta_expression += ")";
 
-                if (i % chunck_size == 0) {
-                    LOG_DEBUG("Adding " + to_string(nodes.size()) + " nodes");
-                    db->add_nodes(nodes, false, true);
-                    LOG_DEBUG("Adding " + to_string(links.size()) + " links");
-                    db->add_links(links, false, true);
-                    nodes.clear();
-                    links.clear();
-                }
+                        auto link = new Link("Expression", targets, true, {}, metta_expression);
+                        links.push_back(link);
+
+                        vector<string> nested_targets = {targets[0], targets[1], link->handle()};
+                        string nested_metta_expression =
+                            "(" + node_names[0] + " " + node_names[1] + " " + metta_expression + ")";
+                        auto link_with_nested =
+                            new Link("Expression", nested_targets, true, {}, nested_metta_expression);
+                        links.push_back(link_with_nested);
+
+                        if (j % chunck_size == 0) {
+                            db->add_nodes(nodes, false, true);
+                            db->add_links(links, false, true);
+                            nodes.clear();
+                            links.clear();
+                        }
+                    }
+
+                    if (!nodes.empty()) {
+                        LOG_DEBUG("[" + to_string(thread_id) + "] Final - Adding " +
+                                  to_string(nodes.size()) + " nodes");
+                        db->add_nodes(nodes, false, true);
+                    }
+                    if (!links.empty()) {
+                        LOG_DEBUG("[" + to_string(thread_id) + "] Final - Adding " +
+                                  to_string(links.size()) + " links");
+                        db->add_links(links, false, true);
+                    }
+
+                    // clang-format off
+                    LinkSchema link_schema({
+                        "LINK_TEMPLATE", "Expression", "3", 
+                        "NODE", "Symbol", "add-links-T" + to_string(thread_id) + "-1-1", 
+                        "NODE", "Symbol", "add-links-T" + to_string(thread_id) + "-1-2",
+                        "VARIABLE", "V"
+                    });
+                    // clang-format on
+
+                    auto result = db->query_for_pattern(link_schema);
+                    if (result->size() != 2) {
+                        Utils::error("[" + to_string(thread_id) + "] Expected 2 results, got " +
+                                     to_string(result->size()));
+                        return;
+                    }
+
+                    auto iterator = result->get_iterator();
+                    char* handle;
+                    while ((handle = iterator->next()) != nullptr) {
+                        LOG_DEBUG("[" + to_string(thread_id) + "] Match: " + string(handle));
+                    }
+                });
             }
 
-            if (!nodes.empty()) {
-                LOG_DEBUG("Final - Adding " + to_string(nodes.size()) + " nodes");
-                db->add_nodes(nodes, false, true);
-            }
-            if (!links.empty()) {
-                LOG_DEBUG("Final - Adding " + to_string(links.size()) + " links");
-                db->add_links(links, false, true);
+            for (auto& thread : threads) {
+                thread.join();
             }
 
             STOP_WATCH_FINISH(tests_db_loader, "TestsDBLoader");
-
-            // clang-format off
-            LinkSchema link_schema({
-                "LINK_TEMPLATE", "Expression", "3", 
-                "NODE", "Symbol", "add-links-1-1", 
-                "NODE", "Symbol", "add-links-1-2",
-                "VARIABLE", "V"
-            });
-            // clang-format on
-
-            auto result = db->query_for_pattern(link_schema);
-            if (result->size() != 2) {
-                Utils::error("Expected 2 results, got " + to_string(result->size()));
-                return 1;
-            }
-
-            auto iterator = result->get_iterator();
-            char* handle;
-            while ((handle = iterator->next()) != nullptr) {
-                LOG_DEBUG("Match: " + string(handle));
-            }
         }
     } else {
         LOG_INFO("Starting tests_db_loader (context: '" + context + "')");

--- a/src/scripts/run.sh
+++ b/src/scripts/run.sh
@@ -31,6 +31,7 @@ docker run --rm \
     --name="${CONTAINER_NAME}" \
     --network host \
     --volume .:/opt/das \
+    --volume /tmp:/tmp \
     --workdir /opt/das \
     $ENV_VARS \
     "${IMAGE_NAME}" \

--- a/src/tests/cpp/redis_mongodb_test_2.cc
+++ b/src/tests/cpp/redis_mongodb_test_2.cc
@@ -215,11 +215,11 @@ TEST_F(RedisMongoDBTest, MongodbDocumentGetSize) {
 }
 
 TEST_F(RedisMongoDBTest, ConcurrentAddLinks) {
-    int num_links = 5000;
+    int num_links = 2000;
     int arity = 3;
-    int chunck_size = 500;
+    int chunck_size = 250;
 
-    const int num_threads = 100;
+    const int num_threads = 120;
     vector<thread> threads;
     atomic<int> success_count{0};
 


### PR DESCRIPTION
This PR prevents broken `RedisContext` from being returned to the `RedisContextPool`.
Solves #870 

It also adds multithread and load from file logic to `tests_db_loader` (used to stress test this PR)