### PR TITLE
[#957] Add handle properties and optimize tokenization logic

### DIFF
--- a/3rd_party_slots/python_client/hyperon_das/commons/atoms/atom.py
+++ b/3rd_party_slots/python_client/hyperon_das/commons/atoms/atom.py
@@ -20,14 +20,26 @@ class Atom:
         other=None,
     ) -> None:
         if other:
-            self.type = other.type
+            self._type = other.type
             self.is_toplevel = other.is_toplevel
             self.custom_attributes = copy.deepcopy(other.custom_attributes)
         else:
-            self.type = type
+            self._type = type
             self.is_toplevel = is_toplevel
             self.custom_attributes = custom_attributes if custom_attributes is not None else Properties()
             self.validate()
+
+    @property
+    def type(self) -> str:
+        return self._type
+
+    @type.setter
+    def type(self, value: str) -> None:
+        self._type = value
+
+        # If the handle has already been calculated, delete it.
+        if "handle" in self.__dict__:
+            del self.__dict__["handle"]
 
     def __eq__(self, other: 'Atom') -> bool:
         if not isinstance(other, Atom):
@@ -72,17 +84,17 @@ class Atom:
         return self.named_type_hash()
 
     def schema_handle(self) -> str:
-        return self.handle()
+        return self.handle
 
     def arity(self) -> int:
         return 0
 
     def tokenize(self, output: list[str]) -> None:
+        output.append(self.type)
+        output.append("true" if self.is_toplevel else "false")
         parameters_tokens = self.custom_attributes.tokenize()
         parameters_tokens.insert(0, str(len(parameters_tokens)))
-        output[0:0] = parameters_tokens
-        output.insert(0, "true" if self.is_toplevel else "false")
-        output.insert(0, self.type)
+        output.extend(parameters_tokens)
 
     def untokenize(self, tokens: list[str]) -> None:
         self.type = tokens[0]

--- a/3rd_party_slots/python_client/hyperon_das/service_bus/proxy.py
+++ b/3rd_party_slots/python_client/hyperon_das/service_bus/proxy.py
@@ -98,9 +98,13 @@ class AtomSpaceNodeManager:
 
         with grpc.insecure_channel(self.peer_id) as channel:
             stub = AtomSpaceNodeStub(channel)
-            log.debug(f"Sending command: {self.PROXY_COMMAND} with args: {args} to target: {self.peer_id}")
+            log.debug(f"Sending command: {self.PROXY_COMMAND} to target: {self.peer_id}")
             message = atom__space__node__pb2.MessageData(
-                command=self.PROXY_COMMAND, args=args, sender=self.node_id, is_broadcast=False, visited_recipients=[]
+                command=self.PROXY_COMMAND,
+                args=new_args,
+                sender=self.node_id,
+                is_broadcast=False,
+                visited_recipients=[],
             )
             try:
                 stub.execute_message(message)

--- a/3rd_party_slots/python_client/hyperon_das/service_clients/atomdb.py
+++ b/3rd_party_slots/python_client/hyperon_das/service_clients/atomdb.py
@@ -67,7 +67,7 @@ class AtomDBProxy(BaseProxy):
         """
         Serialize atoms, send `ADD_ATOMS` to the remote peer, and return their handles.
 
-        Each atom must implement `tokenize(args: list[str])` and `handle() -> str`.
+        Each atom must implement `tokenize(args: list[str])` and `handle -> str`.
         The method prepends the atom-type token ("NODE" / "LINK") to each atom's
         token block before sending.
 
@@ -76,27 +76,15 @@ class AtomDBProxy(BaseProxy):
 
         Returns:
             List of handles corresponding to the provided atoms, in the same order.
-
-        Raises:
-            ValueError: If an atom is neither `Node` nor `Link`.
         """
         args = []
         handles = []
-        atom_type = ""
 
         for atom in atoms:
+            atom_type = "NODE" if atom.arity() == 0 else "LINK"
+            args.append(atom_type)
             atom.tokenize(args)
-
-            if isinstance(atom, Node):
-                atom_type = "NODE"
-            elif isinstance(atom, Link):
-                atom_type = "LINK"
-            else:
-                log.error("Invalid Atom Type")
-                raise ValueError("Invalid Atom Type")
-
-            args.insert(0, atom_type)
-            handles.append(atom.handle())
+            handles.append(atom.handle)
 
         self.to_remote_peer(self.ADD_ATOMS, args)
 

--- a/3rd_party_slots/python_client/tests/integration/test_atomdb.py
+++ b/3rd_party_slots/python_client/tests/integration/test_atomdb.py
@@ -78,10 +78,10 @@ def test_atomdb_proxy_simple_client():
 
     decoder = AtomDecoder()
 
-    node_db1 = decoder.get_atom(node1.handle())
-    node_db2 = decoder.get_atom(node2.handle())
-    node_db3 = decoder.get_atom(node3.handle())
-    link_db = decoder.get_atom(link.handle())
+    node_db1 = decoder.get_atom(node1.handle)
+    node_db2 = decoder.get_atom(node2.handle)
+    node_db3 = decoder.get_atom(node3.handle)
+    link_db = decoder.get_atom(link.handle)
 
     assert node1 == node_db1
     assert node2 == node_db2

--- a/3rd_party_slots/python_client/tests/unit/test_atoms.py
+++ b/3rd_party_slots/python_client/tests/unit/test_atoms.py
@@ -110,7 +110,7 @@ class TestNode:
     def test_handle_and_match_true_and_false(self):
         n = Node(type='T', name='N')
         expected_handle = Hasher.node_handle('T', 'N')
-        assert n.handle() == expected_handle
+        assert n.handle == expected_handle
         assert n.match(expected_handle, Assignment(), HandleDecoderMock())
         assert not n.match('some:other:handle', Assignment(), HandleDecoderMock())
 
@@ -271,7 +271,7 @@ class TestLink:
     def test_handle_and_match_true_and_false(self):
         link = Link(type='MyType', targets=['t'])
         expected = Hasher.link_handle('MyType', ['t'])
-        assert link.handle() == expected
+        assert link.handle == expected
         assert link.match(expected, Assignment(), HandleDecoderMock())
         assert not link.match('other', Assignment(), HandleDecoderMock())
 


### PR DESCRIPTION
Resolves #957 

The target of the change is to improve performance on the adapter side, which uses `tokenize` millions of times, as does the `handle` itself.

- Add a property to the `handle()` of Node and Link
- Changed the `tokenize()` logic 