### PR TITLE
[Fix] Evolution client refactor

### DIFF
--- a/src/main/README.md
+++ b/src/main/README.md
@@ -36,10 +36,7 @@ make run-busnode OPTIONS="--service=<SERVICE_NAME> --endpoint=<ENDPOINT> --ports
 ```
 
 ### Examples
-#### AtomDB
-```
-make run-busnode OPTIONS="--service=atomdb-broker --endpoint=localhost:8888 --ports-range=25000:26000"
-```
+
 #### Query Engine
 ```
 make run-busnode OPTIONS="--service=query-engine --endpoint=localhost:9000 --ports-range=3000:3100 --attention-broker-endpoint=localhost:37007"
@@ -56,7 +53,10 @@ make run-busnode OPTIONS="--service=link-creation-agent --endpoint=localhost:900
 ```
 make run-busnode OPTIONS="--service=inference-agent --endpoint=localhost:9003 --ports-range=5000:5100 --attention-broker-endpoint=localhost:37007 --bus-endpoint=localhost:9000"
 ```
-
+#### AtomDB
+```
+make run-busnode OPTIONS="--service=atomdb-broker --endpoint=localhost:9004 --ports-range=25000:26000 --bus-endpoint=localhost:9000"
+```
 
 ## Running Client
 
@@ -71,7 +71,7 @@ make run-client OPTIONS="--service=<SERVICE_NAME> --endpoint=<ENDPOINT> --bus-en
 ### Examples
 #### AtomDB:
 ```
-make run-client OPTIONS="--service=atomdb-broker --endpoint=localhost:8887 --bus-endpoint=localhost:8888 --ports-range=27000:28000 --action=add_atoms --tokens=LINK Expression 2 NODE Symbol A NODE Symbol B"
+make run-client OPTIONS="--service=atomdb-broker --endpoint=localhost:8887 --bus-endpoint=localhost:9000 --ports-range=27000:28000 --action=add_atoms --tokens=LINK Expression 2 NODE Symbol A NODE Symbol B"
 ```
 #### Query Engine:
 ```
@@ -79,17 +79,27 @@ make run-client OPTIONS="--service=query-engine --endpoint=localhost:8085 --bus-
 ```
 #### LCA:
 ```
-make run-client OPTIONS="--service=link-creation-agent --endpoint=localhost:8085 --bus-endpoint=localhost:9002 --ports-range=41000:41999 --use-metta-as-query-tokens --max-answers=5 --request='(and (Concept %C1) (Concept %C2)) EQUIVALENCE_RELATION'"
+make run-client OPTIONS="--service=link-creation-agent --endpoint=localhost:8085 --bus-endpoint=localhost:9000 --ports-range=41000:41999 --use-metta-as-query-tokens --max-answers=5 --request='(and (Concept %C1) (Concept %C2)) EQUIVALENCE_RELATION'"
 ```
 or
 ```
-make run-client OPTIONS="--service=link-creation-agent --endpoint=localhost:8085 --bus-endpoint=localhost:9002 --ports-range=41000:41999 --max-answers=5 --request=AND 2 LINK_TEMPLATE Expression 2 NODE Symbol PREDICATE VARIABLE P1 LINK_TEMPLATE Expression 2 NODE Symbol PREDICATE VARIABLE P2 LINK_CREATE Similarity3 2 0 VARIABLE P1 VARIABLE P2"
+make run-client OPTIONS="--service=link-creation-agent --endpoint=localhost:8085 --bus-endpoint=localhost:9000 --ports-range=41000:41999 --max-answers=5 --request=AND 2 LINK_TEMPLATE Expression 2 NODE Symbol PREDICATE VARIABLE P1 LINK_TEMPLATE Expression 2 NODE Symbol PREDICATE VARIABLE P2 LINK_CREATE Similarity3 2 0 VARIABLE P1 VARIABLE P2"
 ```
 #### Inference Agent
 ```
- make run-client OPTIONS="--service=inference-agent --endpoint=localhost:8085 --bus-endpoint=localhost:9003 --ports-range=41000:41999 --max-answers=5 --request=PROOF_OF_IMPLICATION 2d01b94c549678aa84840e5901f8d449 ba8267a5c1411eb4bc32d9062e3398ad 2 TOY"
+ make run-client OPTIONS="--service=inference-agent --endpoint=localhost:8085 --bus-endpoint=localhost:9000 --ports-range=41000:41999 --max-answers=5 --request=PROOF_OF_IMPLICATION 2d01b94c549678aa84840e5901f8d449 ba8267a5c1411eb4bc32d9062e3398ad 2 TOY"
  ```
 
+#### Context Broker
+```
+ make run-client OPTIONS="--service=context-broker --endpoint=localhost:8086 --bus-endpoint=localhost:9000 --ports-range=41000:41999  --query=OR 3 AND 4 LINK_TEMPLATE Expression 3 NODE Symbol Evaluation VARIABLE V0 LINK_TEMPLATE Expression 2 NODE Symbol Concept VARIABLE S1 LINK_TEMPLATE Expression 3 NODE Symbol Contains VARIABLE S1 VARIABLE W1 LINK_TEMPLATE Expression 3 NODE Symbol Contains VARIABLE S2 VARIABLE W1 LINK_TEMPLATE Expression 3 NODE Symbol Evaluation VARIABLE V1 LINK_TEMPLATE Expression 2 NODE Symbol Concept VARIABLE S2 LINK_TEMPLATE Expression 3 NODE Symbol Implication VARIABLE V0 VARIABLE V1 LINK_TEMPLATE Expression 3 NODE Symbol Implication VARIABLE V1 VARIABLE V0 --determiner-schema=V0:V1,V0:S2 --stimulus-schema=V0"
+ ```
+
+#### Evolution Agent
+
+```
+make run-client OPTIONS="--service=evolution-agent --endpoint=localhost:8085 --bus-endpoint=localhost:9000 --ports-range=41000:41999  --query='(Contains %sentence1 (Word \"bbb\"))' --correlation-queries='(Contains %placeholder1 %word1)' --correlation-replacements=%placeholder1:sentence1 --correlation-mappings=sentence1:%word1 --max-generations=3 --fitness-function-tag=count_letter --context=Aaa --use-metta-as-query-tokens --max-answers=50"
+```
 
 ## Adding a New Element
 

--- a/src/main/bus_client.cc
+++ b/src/main/bus_client.cc
@@ -1,5 +1,6 @@
 #include <signal.h>
 
+#include "FitnessFunctionRegistry.h"
 #include "Helper.h"
 #include "Logger.h"
 #include "Properties.h"
@@ -50,6 +51,11 @@ int main(int argc, char* argv[]) {
             AtomDBSingleton::init(atomdb_api_types::ATOMDB_TYPE::MORKDB);
         } else {
             AtomDBSingleton::init();
+        }
+        if (Helper::processor_type_from_string(cmd_args[Helper::SERVICE]) ==
+            mains::ProcessorType::EVOLUTION_AGENT) {
+            LOG_INFO("Initializing Fitness Function Registry statics...");
+            FitnessFunctionRegistry::initialize_statics();
         }
         auto proxy = ProxyFactory::create_proxy(cmd_args[Helper::SERVICE], props);
         if (proxy == nullptr) {

--- a/src/main/helpers/Helper.cc
+++ b/src/main/helpers/Helper.cc
@@ -23,6 +23,11 @@ string Helper::CORRELATION_QUERIES = "correlation-queries";
 string Helper::CORRELATION_REPLACEMENTS = "correlation-replacements";
 string Helper::CORRELATION_MAPPINGS = "correlation-mappings";
 string Helper::FITNESS_FUNCTION_TAG = "fitness-function-tag";
+string Helper::POPULATION_SIZE = "population-size";
+string Helper::MAX_GENERATIONS = "max-generations";
+string Helper::ELITISM_RATE = "elitism-rate";
+string Helper::SELECTION_RATE = "selection-rate";
+string Helper::TOTAL_ATTENTION_TOKENS = "total-attention-tokens";
 string Helper::USE_CONTEXT_CACHE = "use-context-cache";
 string Helper::ENFORCE_CACHE_RECREATION = "enforce-cache-recreation";
 string Helper::INITIAL_RENT_RATE = "initial-rent-rate";
@@ -127,8 +132,11 @@ This client sends query evolution requests to the Evolution Agent via the servic
 It requires the following arguments:
     - query: The query to be processed.
     - correlation-queries: The correlation queries associated with the evolution request.
+        Example format: "query1,query2,query3"
     - correlation-replacements: The correlation replacements for the evolution request.
+        Example format: "C1:S1,C2:S2;C3:S3,C4:S4"
     - correlation-mappings: The correlation mappings for the evolution request.
+        Example format: "C1:S1,C2:S2"
     - context: The context in which the evolution should be evaluated.
     - fitness-function-tag: The fitness function tag to be used.
 )")},
@@ -247,7 +255,12 @@ vector<string> Helper::get_required_arguments(const string& processor_type,
             }
         case ProcessorType::EVOLUTION_AGENT:
             if (caller_type == ServiceCallerType::CLIENT) {
-                return {REQUEST, MAX_ANSWERS, ATTENTION_UPDATE_FLAG, REPEAT_COUNT};
+                return {QUERY,
+                        CORRELATION_QUERIES,
+                        CORRELATION_REPLACEMENTS,
+                        CORRELATION_MAPPINGS,
+                        CONTEXT,
+                        FITNESS_FUNCTION_TAG};
             } else {
                 return {ATTENTION_BROKER_ENDPOINT};
             }

--- a/src/main/helpers/Helper.h
+++ b/src/main/helpers/Helper.h
@@ -42,6 +42,11 @@ class Helper {
     static string CORRELATION_REPLACEMENTS;
     static string CORRELATION_MAPPINGS;
     static string FITNESS_FUNCTION_TAG;
+    static string POPULATION_SIZE;
+    static string MAX_GENERATIONS;
+    static string ELITISM_RATE;
+    static string SELECTION_RATE;
+    static string TOTAL_ATTENTION_TOKENS;
     static string USE_CONTEXT_CACHE;
     static string ENFORCE_CACHE_RECREATION;
     static string INITIAL_RENT_RATE;

--- a/src/main/helpers/ProxyFactory.h
+++ b/src/main/helpers/ProxyFactory.h
@@ -29,7 +29,7 @@ class ProxyFactory {
 
     enum class ParamType { STRING, LONG, UINT, DOUBLE, BOOL };
 
-    static void set_param(Properties& proxy_params,
+    static void set_param(shared_ptr<BaseProxy> proxy,
                           const string& param_name,
                           const string& param_value,
                           const ParamType param_type) {
@@ -38,19 +38,19 @@ class ProxyFactory {
         }
         switch (param_type) {
             case ParamType::UINT:
-                proxy_params[param_name] = (unsigned int) stoi(param_value);
+                proxy->parameters[param_name] = (unsigned int) stoi(param_value);
                 return;
             case ParamType::DOUBLE:
-                proxy_params[param_name] = (double) stod(param_value);
+                proxy->parameters[param_name] = (double) stod(param_value);
                 return;
             case ParamType::LONG:
-                proxy_params[param_name] = (long) stol(param_value);
+                proxy->parameters[param_name] = (long) stol(param_value);
                 return;
             case ParamType::BOOL:
-                proxy_params[param_name] = (param_value == "true" || param_value == "1");
+                proxy->parameters[param_name] = (param_value == "true" || param_value == "1");
                 return;
             case ParamType::STRING:
-                proxy_params[param_name] = param_value;
+                proxy->parameters[param_name] = param_value;
                 return;
             default:
                 Utils::error("Unknown proxy parameter type");
@@ -83,7 +83,11 @@ class ProxyFactory {
 
     static vector<vector<string>> parse_correlation_queries(const string& correlation_queries_str,
                                                             const string& use_metta_as_query_tokens) {
-        vector<string> correlation_queries_vec = Utils::split(correlation_queries_str, ',');
+        string parsed_correlation_queries_str = correlation_queries_str;
+        if (use_metta_as_query_tokens == "true") {
+            parsed_correlation_queries_str = parse_metta_expression(correlation_queries_str);
+        }
+        vector<string> correlation_queries_vec = Utils::split(parsed_correlation_queries_str, ',');
         vector<vector<string>> correlation_queries;
         for (auto& q : correlation_queries_vec) {
             correlation_queries.push_back(parse_request(q, use_metta_as_query_tokens, true));
@@ -92,8 +96,12 @@ class ProxyFactory {
     }
 
     static vector<map<string, QueryAnswerElement>> parse_correlation_replacements(
-        const string& correlation_replacements_str) {
-        auto constants_list = Utils::split(correlation_replacements_str, ';');
+        const string& correlation_replacements_str, const string& use_metta_as_query_tokens) {
+        string parsed_correlation_replacements_str = correlation_replacements_str;
+        if (use_metta_as_query_tokens == "true") {
+            parsed_correlation_replacements_str = parse_metta_expression(correlation_replacements_str);
+        }
+        auto constants_list = Utils::split(parsed_correlation_replacements_str, ';');
         vector<map<string, QueryAnswerElement>> correlation_replacements;
         for (auto value : constants_list) {
             auto mapping = Utils::split(value, ',');
@@ -110,9 +118,13 @@ class ProxyFactory {
     }
 
     static vector<pair<QueryAnswerElement, QueryAnswerElement>> parse_correlation_mappings(
-        const string& correlation_mappings_str) {
+        const string& correlation_mappings_str, const string& use_metta_as_query_tokens) {
+        string parsed_correlation_mappings_str = correlation_mappings_str;
+        if (use_metta_as_query_tokens == "true") {
+            parsed_correlation_mappings_str = parse_metta_expression(correlation_mappings_str);
+        }
         vector<pair<QueryAnswerElement, QueryAnswerElement>> correlation_mappings;
-        auto mapping_list = Utils::split(correlation_mappings_str, ',');
+        auto mapping_list = Utils::split(parsed_correlation_mappings_str, ',');
         for (auto value : mapping_list) {
             auto pair = Utils::split(value, ':');
             if (pair.size() == 2) {
@@ -123,8 +135,7 @@ class ProxyFactory {
         return correlation_mappings;
     }
 
-    static shared_ptr<BaseProxy> create_proxy(const string& proxy_type, const Properties& params) {
-        auto processor_type = Helper::processor_type_from_string(proxy_type);
+    static void set_base_query_params(shared_ptr<BaseProxy> proxy, const Properties& params) {
         string context = params.get<string>(Helper::CONTEXT);
         string uaf = params.get_or<string>(Helper::UNIQUE_ASSIGNMENT_FLAG, "");
         string auf = params.get_or<string>(Helper::ATTENTION_UPDATE_FLAG, "");
@@ -132,18 +143,29 @@ class ProxyFactory {
         string ultc = params.get_or<string>(Helper::USE_LINK_TEMPLATE_CACHE, "");
         string pmm = params.get_or<string>(Helper::POPULATE_METTA_MAPPING, "");
         string umaqt = params.get_or<string>(Helper::USE_METTA_AS_QUERY_TOKENS, "");
+        set_param(proxy, BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG, uaf, ParamType::BOOL);
+        set_param(proxy, BaseQueryProxy::ATTENTION_UPDATE_FLAG, auf, ParamType::BOOL);
+        set_param(proxy, BaseQueryProxy::MAX_ANSWERS, max_answers, ParamType::UINT);
+        set_param(proxy, BaseQueryProxy::USE_LINK_TEMPLATE_CACHE, ultc, ParamType::BOOL);
+        set_param(proxy, BaseQueryProxy::POPULATE_METTA_MAPPING, pmm, ParamType::BOOL);
+        set_param(proxy, BaseQueryProxy::USE_METTA_AS_QUERY_TOKENS, umaqt, ParamType::BOOL);
+    }
+
+    static shared_ptr<BaseProxy> create_proxy(const string& proxy_type, const Properties& params) {
+        auto processor_type = Helper::processor_type_from_string(proxy_type);
+        string context = params.get<string>(Helper::CONTEXT);
         string pif = params.get_or<string>(Helper::POSITIVE_IMPORTANCE_FLAG, "");
+        string umaqt = params.get_or<string>(Helper::USE_METTA_AS_QUERY_TOKENS, "");
+
         switch (processor_type) {
             case ProcessorType::INFERENCE_AGENT: {
                 string request = params.get_or<string>(Helper::REQUEST, "");
                 string timeout = params.get_or<string>(Helper::TIMEOUT, "");
                 string repeat_count = params.get_or<string>(Helper::REPEAT_COUNT, "");
                 auto proxy = make_shared<InferenceProxy>(Utils::split(request, ' '));
-                auto params = &proxy->parameters;
-                set_param(*params, InferenceProxy::INFERENCE_REQUEST_TIMEOUT, timeout, ParamType::UINT);
-                set_param(*params, InferenceProxy::MAX_ANSWERS, max_answers, ParamType::UINT);
-                set_param(*params, InferenceProxy::ATTENTION_UPDATE_FLAG, auf, ParamType::BOOL);
-                set_param(*params, InferenceProxy::REPEAT_COUNT, repeat_count, ParamType::UINT);
+                set_param(proxy, InferenceProxy::INFERENCE_REQUEST_TIMEOUT, timeout, ParamType::UINT);
+                set_base_query_params(proxy, params);
+                set_param(proxy, InferenceProxy::REPEAT_COUNT, repeat_count, ParamType::UINT);
                 return proxy;
             }
             case ProcessorType::LINK_CREATION_AGENT: {
@@ -151,49 +173,40 @@ class ProxyFactory {
                 string repeat_count = params.get_or<string>(Helper::REPEAT_COUNT, "");
                 auto request = parse_request(request_str, umaqt);
                 auto proxy = make_shared<LinkCreationRequestProxy>(request);
-                auto params = &proxy->parameters;
-                set_param(*params, LinkCreationRequestProxy::MAX_ANSWERS, max_answers, ParamType::UINT);
                 set_param(
-                    *params, LinkCreationRequestProxy::REPEAT_COUNT, repeat_count, ParamType::UINT);
-                set_param(*params, LinkCreationRequestProxy::CONTEXT, context, ParamType::STRING);
-                set_param(
-                    *params, LinkCreationRequestProxy::ATTENTION_UPDATE_FLAG, auf, ParamType::BOOL);
-                set_param(
-                    *params, LinkCreationRequestProxy::POSITIVE_IMPORTANCE_FLAG, pif, ParamType::BOOL);
-                set_param(*params,
-                          LinkCreationRequestProxy::USE_METTA_AS_QUERY_TOKENS,
-                          umaqt,
-                          ParamType::BOOL);
+                    proxy, LinkCreationRequestProxy::POSITIVE_IMPORTANCE_FLAG, pif, ParamType::BOOL);
+                set_param(proxy, LinkCreationRequestProxy::REPEAT_COUNT, repeat_count, ParamType::UINT);
+                set_base_query_params(proxy, params);
                 return proxy;
             }
             case ProcessorType::CONTEXT_BROKER: {
-                string query = params.get_or<string>(
-                    "query", "");  // Note to reviewer: Helper::QUERY is not linking
+                string query_str = params.get_or<string>("query", "");
+                auto query = parse_request(query_str, umaqt, true);
                 string determiner_schema = params.get<string>(Helper::DETERMINER_SCHEMA);
                 string stimulus_schema = params.get<string>(Helper::STIMULUS_SCHEMA);
-                auto proxy = make_shared<ContextBrokerProxy>(
-                    context, Utils::split(query, ' '), determiner_schema, stimulus_schema);
-                auto params = &proxy->parameters;
-                set_param(*params,
+                auto proxy =
+                    make_shared<ContextBrokerProxy>(context, query, determiner_schema, stimulus_schema);
+                set_param(proxy,
                           ContextBrokerProxy::USE_CACHE,
-                          params->get_or<string>(Helper::USE_CONTEXT_CACHE, ""),
+                          params.get_or<string>(Helper::USE_CONTEXT_CACHE, ""),
                           ParamType::BOOL);
-                set_param(*params,
+                set_param(proxy,
                           ContextBrokerProxy::ENFORCE_CACHE_RECREATION,
-                          params->get_or<string>(Helper::ENFORCE_CACHE_RECREATION, ""),
+                          params.get_or<string>(Helper::ENFORCE_CACHE_RECREATION, ""),
                           ParamType::BOOL);
-                set_param(*params,
+                set_param(proxy,
                           ContextBrokerProxy::INITIAL_RENT_RATE,
-                          params->get_or<string>(Helper::INITIAL_RENT_RATE, ""),
+                          params.get_or<string>(Helper::INITIAL_RENT_RATE, ""),
                           ParamType::DOUBLE);
-                set_param(*params,
+                set_param(proxy,
                           ContextBrokerProxy::INITIAL_SPREADING_RATE_LOWERBOUND,
-                          params->get_or<string>(Helper::INITIAL_SPREADING_RATE_LOWERBOUND, ""),
+                          params.get_or<string>(Helper::INITIAL_SPREADING_RATE_LOWERBOUND, ""),
                           ParamType::DOUBLE);
-                set_param(*params,
+                set_param(proxy,
                           ContextBrokerProxy::INITIAL_SPREADING_RATE_UPPERBOUND,
-                          params->get_or<string>(Helper::INITIAL_SPREADING_RATE_UPPERBOUND, ""),
+                          params.get_or<string>(Helper::INITIAL_SPREADING_RATE_UPPERBOUND, ""),
                           ParamType::DOUBLE);
+                set_base_query_params(proxy, params);
                 return proxy;
             }
             case ProcessorType::EVOLUTION_AGENT: {
@@ -204,38 +217,40 @@ class ProxyFactory {
                 string correlation_replacements_str =
                     params.get<string>(Helper::CORRELATION_REPLACEMENTS);
                 auto correlation_replacements =
-                    parse_correlation_replacements(correlation_replacements_str);
+                    parse_correlation_replacements(correlation_replacements_str, umaqt);
                 string correlation_mappings_str = params.get<string>(Helper::CORRELATION_MAPPINGS);
-                auto correlation_mappings = parse_correlation_mappings(correlation_mappings_str);
+                auto correlation_mappings = parse_correlation_mappings(correlation_mappings_str, umaqt);
                 string fitness_function_tag = params.get<string>(Helper::FITNESS_FUNCTION_TAG);
+                string population_size = params.get_or<string>(Helper::POPULATION_SIZE, "");
+                string max_generations = params.get_or<string>(Helper::MAX_GENERATIONS, "");
+                string elitism_rate = params.get_or<string>(Helper::ELITISM_RATE, "");
+                string selection_rate = params.get_or<string>(Helper::SELECTION_RATE, "");
+                string total_attention_tokens =
+                    params.get_or<string>(Helper::TOTAL_ATTENTION_TOKENS, "");
                 auto proxy = make_shared<QueryEvolutionProxy>(query,
                                                               correlation_queries,
                                                               correlation_replacements,
                                                               correlation_mappings,
                                                               context,
                                                               fitness_function_tag);
-                auto params = &proxy->parameters;
-                set_param(*params, BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG, uaf, ParamType::BOOL);
-                set_param(*params, BaseQueryProxy::ATTENTION_UPDATE_FLAG, auf, ParamType::BOOL);
-                set_param(*params, BaseQueryProxy::MAX_ANSWERS, max_answers, ParamType::UINT);
-                set_param(*params, BaseQueryProxy::USE_LINK_TEMPLATE_CACHE, ultc, ParamType::BOOL);
-                set_param(*params, BaseQueryProxy::POPULATE_METTA_MAPPING, pmm, ParamType::BOOL);
-                set_param(*params, BaseQueryProxy::USE_METTA_AS_QUERY_TOKENS, umaqt, ParamType::BOOL);
+                set_base_query_params(proxy, params);
+                set_param(proxy, QueryEvolutionProxy::POPULATION_SIZE, population_size, ParamType::UINT);
+                set_param(proxy, QueryEvolutionProxy::MAX_GENERATIONS, max_generations, ParamType::UINT);
+                set_param(proxy, QueryEvolutionProxy::ELITISM_RATE, elitism_rate, ParamType::DOUBLE);
+                set_param(proxy, QueryEvolutionProxy::SELECTION_RATE, selection_rate, ParamType::DOUBLE);
+                set_param(proxy,
+                          QueryEvolutionProxy::TOTAL_ATTENTION_TOKENS,
+                          total_attention_tokens,
+                          ParamType::UINT);
                 return proxy;
             }
             case ProcessorType::QUERY_ENGINE: {
                 string query_str = params.get<string>("query");
                 auto query = parse_request(query_str, umaqt, true);
                 auto proxy = make_shared<PatternMatchingQueryProxy>(query, context);
-                auto params = &proxy->parameters;
-                set_param(*params, BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG, uaf, ParamType::BOOL);
-                set_param(*params, BaseQueryProxy::ATTENTION_UPDATE_FLAG, auf, ParamType::BOOL);
-                set_param(*params, BaseQueryProxy::MAX_ANSWERS, max_answers, ParamType::UINT);
-                set_param(*params, BaseQueryProxy::USE_LINK_TEMPLATE_CACHE, ultc, ParamType::BOOL);
-                set_param(*params, BaseQueryProxy::POPULATE_METTA_MAPPING, pmm, ParamType::BOOL);
-                set_param(*params, BaseQueryProxy::USE_METTA_AS_QUERY_TOKENS, umaqt, ParamType::BOOL);
+                set_base_query_params(proxy, params);
                 set_param(
-                    *params, PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG, pif, ParamType::BOOL);
+                    proxy, PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG, pif, ParamType::BOOL);
                 return proxy;
             }
             case ProcessorType::ATOMDB_BROKER: {


### PR DESCRIPTION
Relates to #821 

Usage example:
```
make run-client OPTIONS="--service=evolution-agent --endpoint=localhost:8085 --bus-endpoint=localhost:31700 --ports-range=41000:41999  --query='(Contains %sentence1 (Word \"bbb\"))' --correlation-queries='(Contains %placeholder1 %word1)' --correlation-replacements=%placeholder1:sentence1 --correlation-mappings=sentence1:%word1 --max-generations=3 --fitness-function-tag=count_letter --context=Aaa --use-metta-as-query-tokens --max-answers=50"
```