### PR TITLE
[FIX] Small fix on release pipeline message formatting

### DIFF
--- a/.github/workflows/run-semver.yml
+++ b/.github/workflows/run-semver.yml
@@ -127,10 +127,17 @@ jobs:
           
           releaseNote=$(printf %b "$rawReleaseNote")
 
-          message="${title}\n\nDeliverable: ${deliverable}\nNew version available: ${version}\nRepository: https://github.com/${repository}/releases/tag/${version}"
+          message="${title} 
+          Deliverable: ${deliverable} 
+          New version available: ${version} 
+          Repository: https://github.com/${repository}/releases/tag/${version}"
 
           if [ -n "$releaseNote" ]; then
-            message="$message\nChanges:\n$releaseNote"
+            message="
+            $message 
+
+            Changes: 
+            $releaseNote"
           fi
 
           escaped_message=$(printf '%s' "$message" | jq -Rs .)


### PR DESCRIPTION
Just a small fix for the DAS release message format. The current messages look like this:

```New DAS version released\n\nDeliverable: Tagged branch (master) in the repository\nNew version available: 1.0.2\nRepository:```

And now should be displayed as:

```
New DAS version released
Deliverable: Tagged branch (rl/notification-test) 
New version available: 1.0.2 
Repository: https://github.com/singnet/das/releases/tag/1.0.2
```

The release message is currently being processed literally by the pipeline (because of the previous fix applied), so escape characters (like \n) are interpreted as plain text instead of line breaks. Replacing them with actual spaces solves the format.