### PR TITLE
[MorkDB] Add `re_index_patterns()`

### DIFF
--- a/.github/workflows/run-coverage-check.yml
+++ b/.github/workflows/run-coverage-check.yml
@@ -73,8 +73,6 @@ jobs:
             echo "Waiting MORK…"
             sleep 1
           done
-          
-          make mork-loader FILE="/tmp/animals.metta"
 
       - name: Execute Coverage check
         working-directory: ./src

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -71,8 +71,6 @@ jobs:
             echo "Waiting MORK…"
             sleep 1
           done
-          
-          make mork-loader FILE="/tmp/animals.metta"
 
       - name: Execute Unit Test Suite
         run: make test-all

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -71,6 +71,8 @@ class AtomDB : public HandleDecoder {
     virtual uint delete_atoms(const vector<string>& handles, bool delete_link_targets = false) = 0;
     virtual uint delete_nodes(const vector<string>& handles, bool delete_link_targets = false) = 0;
     virtual uint delete_links(const vector<string>& handles, bool delete_link_targets = false) = 0;
+
+    virtual void re_index_patterns(bool flush_patterns = true) = 0;
 };
 
 }  // namespace atomdb

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -239,7 +239,10 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
     for (const auto& link : links) {
         auto link_handle = link->handle();
         string metta_expression = link->custom_attributes.get_or<string>("metta_expression", "");
-        if (metta_expression.empty()) metta_expression = link->metta_representation(*this);
+        if (metta_expression.empty()) {
+            metta_expression = link->metta_representation(*this);
+            link->custom_attributes["metta_expression"] = metta_expression;
+        }
         metta_expressions += metta_expression + "\n";
 
         count++;

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -47,6 +47,14 @@ vector<string> MorkClient::get(const string& pattern, const string& template_) {
     return Utils::split(res->body, '\n');
 }
 
+string MorkClient::clear(const string& pattern) {
+    auto path = "/clear/" + url_encode(pattern);
+    LOG_DEBUG("CLEAR request sent to MORK: "
+              << " url=" << path);
+    auto res = send_request("GET", path);
+    return res->body;
+}
+
 httplib::Result MorkClient::send_request(const string& method, const string& path, const string& data) {
     httplib::Result res;
 
@@ -230,8 +238,7 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
     uint count = 0;
     for (const auto& link : links) {
         auto link_handle = link->handle();
-
-        string metta_expression = link->metta_expression;
+        string metta_expression = link->custom_attributes.get_or<string>("metta_expression", "");
         if (metta_expression.empty()) metta_expression = link->metta_representation(*this);
         metta_expressions += metta_expression + "\n";
 
@@ -276,6 +283,51 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
 bool MorkDB::delete_link(const string& handle, bool delete_targets) {
     Utils::error("MORKDB does not support deleting links.", false);
     return false;
+}
+
+string MorkDB::flush_pattern(const string& pattern) { return this->mork_client->clear(pattern); }
+
+void MorkDB::re_index_patterns(bool flush_patterns) {
+    vector<Link*> links;
+    uint max_arity = 0;
+
+    bsoncxx::builder::stream::document filter_builder;
+    auto atom_documents =
+        this->get_filtered_documents(MONGODB_LINKS_COLLECTION_NAME, filter_builder, {});
+
+    for (const auto& atom_document : atom_documents) {
+        auto link_document = dynamic_pointer_cast<atomdb_api_types::MongodbDocument>(atom_document);
+        vector<string> targets;
+        size_t size = link_document->get_size("targets");
+        for (size_t i = 0; i < size; i++) {
+            targets.push_back(string(link_document->get("targets", i)));
+        }
+        Properties custom_attributes;
+        if (link_document->contains("custom_attributes")) {
+            custom_attributes =
+                link_document->extract_custom_attributes(link_document->get_object("custom_attributes"));
+        }
+        links.push_back(new Link(string(link_document->get("named_type")), targets, custom_attributes));
+
+        uint link_arity = targets.size();
+        if (link_arity > max_arity) max_arity = link_arity;
+    }
+
+    // Clear MORK for each arity
+    if (max_arity > 0 && flush_patterns) {
+        for (uint i = max_arity; i >= 1; i--) {
+            string pattern = "(";
+            for (uint j = 0; j < i; j++) {
+                pattern += "$v" + to_string(j + 1);
+                if (j < i - 1) pattern += " ";
+            }
+            pattern += ")";
+            LOG_DEBUG("Clearing MORK for arity " << i << " with pattern " << pattern);
+            this->mork_client->clear(pattern);
+        }
+    }
+
+    this->add_links(links, false, true);
 }
 
 // <--

--- a/src/atomdb/morkdb/MorkDB.h
+++ b/src/atomdb/morkdb/MorkDB.h
@@ -28,6 +28,7 @@ class MorkClient {
     ~MorkClient();
     string post(const string& data, const string& pattern = "$x", const string& template_ = "$x");
     vector<string> get(const string& pattern, const string& template_);
+    string clear(const string& pattern);
 
    private:
     string base_url_;
@@ -52,6 +53,10 @@ class MorkDB : public RedisMongoDB {
 
     // TODO: Implement this once MORK supports deleting links (S-Expressions)
     bool delete_link(const string& handle, bool delete_targets) override;
+
+    string flush_pattern(const string& pattern);
+
+    void re_index_patterns(bool flush_patterns = true) override;
 
    private:
     shared_ptr<AtomDBCache> atomdb_cache;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -1276,7 +1276,7 @@ vector<vector<string>> RedisMongoDB::index_entries_combinations(unsigned int ari
     return index_entries;
 }
 
-void RedisMongoDB::re_index_patterns() {
+void RedisMongoDB::re_index_patterns(bool flush_patterns) {
     vector<Link*> links;
     auto conn = this->mongodb_pool->acquire();
     auto mongodb_collection = (*conn)[MONGODB_DB_NAME][MONGODB_LINKS_COLLECTION_NAME];
@@ -1293,7 +1293,7 @@ void RedisMongoDB::re_index_patterns() {
     load_pattern_index_schema();
 
     // Flush Redis patterns indexes
-    flush_redis_by_prefix(REDIS_PATTERNS_PREFIX);
+    if (flush_patterns) flush_redis_by_prefix(REDIS_PATTERNS_PREFIX);
 
     // Reset patterns next score
     this->patterns_next_score.store(1);

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -125,8 +125,9 @@ class RedisMongoDB : public AtomDB {
         const bsoncxx::builder::stream::document& filter_builder,
         const vector<string>& fields);
 
+    void re_index_patterns(bool flush_patterns = true);
+
     void add_pattern_index_schema(const string& tokens, const vector<vector<string>>& index_entries);
-    void re_index_patterns();
     void flush_redis_by_prefix(const string& prefix);
 
     void drop_all();

--- a/src/commons/atoms/Link.cc
+++ b/src/commons/atoms/Link.cc
@@ -14,9 +14,8 @@ using namespace atoms;
 Link::Link(const string& type,
            const vector<string>& targets,
            bool is_toplevel,
-           const Properties& custom_attributes,
-           const string& metta_expression)
-    : Atom(type, is_toplevel, custom_attributes), targets(targets), metta_expression(metta_expression) {
+           const Properties& custom_attributes)
+    : Atom(type, is_toplevel, custom_attributes), targets(targets) {
     this->validate();
 }
 

--- a/src/commons/atoms/Link.h
+++ b/src/commons/atoms/Link.h
@@ -9,8 +9,7 @@ namespace atoms {
 
 class Link : public Atom {
    public:
-    vector<string> targets;   ///< The handles of the target atoms of the link.
-    string metta_expression;  ///< The MeTTa expression of the link.
+    vector<string> targets;  ///< The handles of the target atoms of the link.
 
     // ---------------------------------------------------------------------------------------------
     // Constructors, destructors , basic operators and initializers
@@ -26,8 +25,7 @@ class Link : public Atom {
     Link(const string& type,
          const vector<string>& targets,
          bool is_toplevel = false,
-         const Properties& custom_attributes = {},
-         const string& metta_expression = "");
+         const Properties& custom_attributes = {});
 
     Link(const string& type, const vector<string>& targets, const Properties& custom_attributes);
 

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -723,6 +723,7 @@ cc_test(
     deps = [
         "//atomdb:atomdb_singleton",
         "//tests/cpp/test_commons",
+        "//tests/cpp/test_commons:mock_animals_data_lib",
         "@com_github_google_googletest//:gtest_main",
         "@mbedtls",
     ],

--- a/src/tests/cpp/atom_space_test.cc
+++ b/src/tests/cpp/atom_space_test.cc
@@ -171,6 +171,8 @@ class MockAtomDB : public AtomDB {
     }
 
     shared_ptr<Atom> get_atom(const string& handle) { return shared_ptr<Atom>(this->atoms[handle]); }
+
+    void re_index_patterns(bool flush_patterns = true) override { return; }
 };
 
 class MockAtomSpace : public AtomSpace {

--- a/src/tests/cpp/morkdb_test.cc
+++ b/src/tests/cpp/morkdb_test.cc
@@ -12,6 +12,7 @@
 #include "AtomDBCacheSingleton.h"
 #include "AtomDBSingleton.h"
 #include "LinkSchema.h"
+#include "MockAnimalsData.h"
 #include "TestConfig.h"
 
 using namespace atomdb;
@@ -26,6 +27,7 @@ class MorkDBTestEnvironment : public ::testing::Environment {
         auto atomdb = new MorkDB("morkdb_test_");
         atomdb->drop_all();
         AtomDBSingleton::provide(shared_ptr<AtomDB>(atomdb));
+        load_animals_data();
     }
 };
 
@@ -327,14 +329,18 @@ TEST_F(MorkDBTest, ConcurrentAddLinks) {
                 }
                 metta_expression += ")";
 
-                auto link = new Link("Expression", targets, true, {}, metta_expression);
+                auto link = new Link(
+                    "Expression", targets, true, Properties{{"metta_expression", metta_expression}});
                 links.push_back(link);
 
                 vector<string> nested_targets = {targets[0], targets[1], link->handle()};
                 string nested_metta_expression =
                     "(" + node_names[0] + " " + node_names[1] + " " + metta_expression + ")";
                 auto link_with_nested =
-                    new Link("Expression", nested_targets, true, {}, nested_metta_expression);
+                    new Link("Expression",
+                             nested_targets,
+                             true,
+                             Properties{{"metta_expression", nested_metta_expression}});
                 links.push_back(link_with_nested);
 
                 if (i % chunck_size == 0) {
@@ -375,6 +381,76 @@ TEST_F(MorkDBTest, ConcurrentAddLinks) {
 
     auto result = db->query_for_pattern(link_schema);
     EXPECT_EQ(result->size(), 2);
+}
+
+TEST_F(MorkDBTest, ReIndexPatterns) {
+    auto evaluation_node = new Node("Symbol", "EvaluationReIndex");
+    vector<string> targets1 = {
+        evaluation_node->handle(), exp_hash({"Predicate", "link"}), exp_hash({"Concept", "One"})};
+    vector<string> targets2 = {
+        evaluation_node->handle(), exp_hash({"Predicate", "link"}), exp_hash({"Concept", "Two"})};
+    vector<string> targets3 = {
+        evaluation_node->handle(), exp_hash({"Predicate", "link"}), exp_hash({"Concept", "Three"})};
+
+    auto p1 = Properties();
+    p1["metta_expression"] = "(EvaluationReIndex (Predicate \"link\") (Concept \"One\"))";
+    auto link_1 = new Link("Expression", targets1, true, p1);
+
+    auto p2 = Properties();
+    p2["metta_expression"] = "(EvaluationReIndex (Predicate \"link\") (Concept \"Two\"))";
+    auto link_2 = new Link("Expression", targets2, true, p2);
+
+    auto p3 = Properties();
+    p3["metta_expression"] = "(EvaluationReIndex (Predicate \"link\") (Concept \"Three\"))";
+    auto link_3 = new Link("Expression", targets3, true, p3);
+
+    auto link_1_doc = make_shared<atomdb_api_types::MongodbDocument>(link_1, "", vector<string>{});
+    auto link_2_doc = make_shared<atomdb_api_types::MongodbDocument>(link_2, "", vector<string>{});
+    auto link_3_doc = make_shared<atomdb_api_types::MongodbDocument>(link_3, "", vector<string>{});
+
+    // clang-format off
+    LinkSchema link_schema({
+        "LINK_TEMPLATE", "Expression", "3", 
+        "NODE", "Symbol", "EvaluationReIndex", 
+        "LINK", "Expression", "2", "NODE", "Symbol", "Predicate", "NODE", "Symbol", "\"link\"",
+        "VARIABLE", "C"
+    });
+    // clang-format on
+    auto result = db->query_for_pattern(link_schema);
+    EXPECT_EQ(result->size(), 0);
+
+    // Resetting MongoDB database to animals data
+    load_animals_data();
+
+    // Direct insertion into MongoDB
+    auto inserted_count =
+        db->upsert_documents({link_1_doc->value(), link_2_doc->value(), link_3_doc->value()},
+                             RedisMongoDB::MONGODB_LINKS_COLLECTION_NAME);
+    EXPECT_EQ(inserted_count, 3);
+
+    db->re_index_patterns();
+
+    result = db->query_for_pattern(link_schema);
+    EXPECT_EQ(result->size(), 3);
+
+    string pattern = "(EvaluationReIndex $P $C)";
+    db->flush_pattern(pattern);
+
+    result = db->query_for_pattern(link_schema);
+    EXPECT_EQ(result->size(), 0);
+
+    // Confirm that patterns are re-indexed
+
+    // clang-format off
+    link_schema = LinkSchema({
+        link_template, expression, "3",
+            node, symbol, inheritance,
+            variable, "x",
+            node, symbol, mammal});
+    // clang-format on
+
+    result = db->query_for_pattern(link_schema);
+    EXPECT_EQ(result->size(), 4);
 }
 
 int main(int argc, char** argv) {

--- a/src/tests/cpp/test_commons/MockAnimalsData.cc
+++ b/src/tests/cpp/test_commons/MockAnimalsData.cc
@@ -94,15 +94,21 @@ void load_animals_data() {
     bool is_toplevel = true;
 
     // Types
-    auto similarity_type = new Link("Expression",
-                                    {colon->handle(), similarity->handle(), type->handle()},
-                                    is_toplevel);  // (: Similarity Type)
-    auto concept_type = new Link("Expression",
-                                 {colon->handle(), concept->handle(), type->handle()},
-                                 is_toplevel);  // (: Concept Type)
-    auto inheritance_type = new Link("Expression",
-                                     {colon->handle(), inheritance->handle(), type->handle()},
-                                     is_toplevel);  // (: Inheritance Type)
+    auto similarity_type =
+        new Link("Expression",
+                 {colon->handle(), similarity->handle(), type->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: Similarity Type)"}});  // (: Similarity Type)
+    auto concept_type =
+        new Link("Expression",
+                 {colon->handle(), concept->handle(), type->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: Concept Type)"}});  // (: Concept Type)
+    auto inheritance_type =
+        new Link("Expression",
+                 {colon->handle(), inheritance->handle(), type->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: Inheritance Type)"}});  // (: Inheritance Type)
 
     links.push_back(similarity_type);
     links.push_back(concept_type);
@@ -113,48 +119,76 @@ void load_animals_data() {
     links.clear();
 
     // Concepts
-    auto human_concept = new Link("Expression",
-                                  {colon->handle(), human->handle(), concept->handle()},
-                                  is_toplevel);  // (: "human" Concept)
-    auto monkey_concept = new Link("Expression",
-                                   {colon->handle(), monkey->handle(), concept->handle()},
-                                   is_toplevel);  // (: "monkey" Concept)
-    auto chimp_concept = new Link("Expression",
-                                  {colon->handle(), chimp->handle(), concept->handle()},
-                                  is_toplevel);  // (: "chimp" Concept)
-    auto snake_concept = new Link("Expression",
-                                  {colon->handle(), snake->handle(), concept->handle()},
-                                  is_toplevel);  // (: "snake" Concept)
-    auto earthworm_concept = new Link("Expression",
-                                      {colon->handle(), earthworm->handle(), concept->handle()},
-                                      is_toplevel);  // (: "earthworm" Concept)
-    auto rhino_concept = new Link("Expression",
-                                  {colon->handle(), rhino->handle(), concept->handle()},
-                                  is_toplevel);  // (: "rhino" Concept)
-    auto triceratops_concept = new Link("Expression",
-                                        {colon->handle(), triceratops->handle(), concept->handle()},
-                                        is_toplevel);  // (: "triceratops" Concept)
-    auto vine_concept = new Link("Expression",
-                                 {colon->handle(), vine->handle(), concept->handle()},
-                                 is_toplevel);  // (: "vine" Concept)
-    auto ent_concept = new Link("Expression",
-                                {colon->handle(), ent->handle(), concept->handle()},
-                                is_toplevel);  // (: "ent" Concept)
-    auto mammal_concept = new Link("Expression",
-                                   {colon->handle(), mammal->handle(), concept->handle()},
-                                   is_toplevel);  // (: "mammal" Concept)
-    auto animal_concept = new Link("Expression",
-                                   {colon->handle(), animal->handle(), concept->handle()},
-                                   is_toplevel);  // (: "animal" Concept)
-    auto reptile_concept = new Link("Expression",
-                                    {colon->handle(), reptile->handle(), concept->handle()},
-                                    is_toplevel);  // (: "reptile" Concept)
-    auto dinosaur_concept = new Link("Expression",
-                                     {colon->handle(), dinosaur->handle(), concept->handle()},
-                                     is_toplevel);  // (: "dinosaur" Concept)
-    auto plant_concept = new Link("Expression",
-                                  {colon->handle(), plant->handle(), concept->handle()},
-                                  is_toplevel);  // (: "plant" Concept)
+    auto human_concept =
+        new Link("Expression",
+                 {colon->handle(), human->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"human\" Concept)"}});  // (: "human" Concept)
+    auto monkey_concept =
+        new Link("Expression",
+                 {colon->handle(), monkey->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"monkey\" Concept)"}});  // (: "monkey" Concept)
+    auto chimp_concept =
+        new Link("Expression",
+                 {colon->handle(), chimp->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"chimp\" Concept)"}});  // (: "chimp" Concept)
+    auto snake_concept =
+        new Link("Expression",
+                 {colon->handle(), snake->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"snake\" Concept)"}});  // (: "snake" Concept)
+    auto earthworm_concept = new Link(
+        "Expression",
+        {colon->handle(), earthworm->handle(), concept->handle()},
+        is_toplevel,
+        Properties{{"metta_expression", "(: \"earthworm\" Concept)"}});  // (: "earthworm" Concept)
+    auto rhino_concept =
+        new Link("Expression",
+                 {colon->handle(), rhino->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"rhino\" Concept)"}});  // (: "rhino" Concept)
+    auto triceratops_concept = new Link(
+        "Expression",
+        {colon->handle(), triceratops->handle(), concept->handle()},
+        is_toplevel,
+        Properties{{"metta_expression", "(: \"triceratops\" Concept)"}});  // (: "triceratops" Concept)
+    auto vine_concept =
+        new Link("Expression",
+                 {colon->handle(), vine->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"vine\" Concept)"}});  // (: "vine" Concept)
+    auto ent_concept =
+        new Link("Expression",
+                 {colon->handle(), ent->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"ent\" Concept)"}});  // (: "ent" Concept)
+    auto mammal_concept =
+        new Link("Expression",
+                 {colon->handle(), mammal->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"mammal\" Concept)"}});  // (: "mammal" Concept)
+    auto animal_concept =
+        new Link("Expression",
+                 {colon->handle(), animal->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"animal\" Concept)"}});  // (: "animal" Concept)
+    auto reptile_concept =
+        new Link("Expression",
+                 {colon->handle(), reptile->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"reptile\" Concept)"}});  // (: "reptile" Concept)
+    auto dinosaur_concept = new Link(
+        "Expression",
+        {colon->handle(), dinosaur->handle(), concept->handle()},
+        is_toplevel,
+        Properties{{"metta_expression", "(: \"dinosaur\" Concept)"}});  // (: "dinosaur" Concept)
+    auto plant_concept =
+        new Link("Expression",
+                 {colon->handle(), plant->handle(), concept->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression", "(: \"plant\" Concept)"}});  // (: "plant" Concept)
 
     links.push_back(human_concept);
     links.push_back(monkey_concept);
@@ -176,52 +210,90 @@ void load_animals_data() {
     links.clear();
 
     // Similarity
-    auto similarity_human_monkey = new Link("Expression",
-                                            {similarity->handle(), human->handle(), monkey->handle()},
-                                            is_toplevel);  // (Similarity "human" "monkey")
-    auto similarity_human_chimp = new Link("Expression",
-                                           {similarity->handle(), human->handle(), chimp->handle()},
-                                           is_toplevel);  // (Similarity "human" "chimp")
-    auto similarity_chimp_monkey = new Link("Expression",
-                                            {similarity->handle(), chimp->handle(), monkey->handle()},
-                                            is_toplevel);  // (Similarity "chimp" "monkey")
-    auto similarity_snake_earthworm =
+    auto similarity_human_monkey =
         new Link("Expression",
-                 {similarity->handle(), snake->handle(), earthworm->handle()},
-                 is_toplevel);  // (Similarity "snake" "earthworm")
-    auto similarity_rhino_triceratops =
+                 {similarity->handle(), human->handle(), monkey->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"human\" \"monkey\")"}});  // (Similarity "human" "monkey")
+    auto similarity_human_chimp =
         new Link("Expression",
-                 {similarity->handle(), rhino->handle(), triceratops->handle()},
-                 is_toplevel);  // (Similarity "rhino" "triceratops")
-    auto similarity_snake_vine = new Link("Expression",
-                                          {similarity->handle(), snake->handle(), vine->handle()},
-                                          is_toplevel);  // (Similarity "snake" "vine")
-    auto similarity_human_ent = new Link("Expression",
-                                         {similarity->handle(), human->handle(), ent->handle()},
-                                         is_toplevel);  // (Similarity "human" "ent")
-    auto similarity_monkey_human = new Link("Expression",
-                                            {similarity->handle(), monkey->handle(), human->handle()},
-                                            is_toplevel);  // (Similarity "monkey" "human")
-    auto similarity_chimp_human = new Link("Expression",
-                                           {similarity->handle(), chimp->handle(), human->handle()},
-                                           is_toplevel);  // (Similarity "chimp" "human")
-    auto similarity_monkey_chimp = new Link("Expression",
-                                            {similarity->handle(), monkey->handle(), chimp->handle()},
-                                            is_toplevel);  // (Similarity "monkey" "chimp")
-    auto similarity_earthworm_snake =
+                 {similarity->handle(), human->handle(), chimp->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"human\" \"chimp\")"}});  // (Similarity "human" "chimp")
+    auto similarity_chimp_monkey =
         new Link("Expression",
-                 {similarity->handle(), earthworm->handle(), snake->handle()},
-                 is_toplevel);  // (Similarity "earthworm" "snake")
-    auto similarity_triceratops_rhino =
+                 {similarity->handle(), chimp->handle(), monkey->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"chimp\" \"monkey\")"}});  // (Similarity "chimp" "monkey")
+    auto similarity_snake_earthworm = new Link(
+        "Expression",
+        {similarity->handle(), snake->handle(), earthworm->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Similarity \"snake\" \"earthworm\")"}});  // (Similarity "snake" "earthworm")
+    auto similarity_rhino_triceratops = new Link(
+        "Expression",
+        {similarity->handle(), rhino->handle(), triceratops->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Similarity \"rhino\" \"triceratops\")"}});  // (Similarity "rhino" "triceratops")
+    auto similarity_snake_vine =
         new Link("Expression",
-                 {similarity->handle(), triceratops->handle(), rhino->handle()},
-                 is_toplevel);  // (Similarity "triceratops" "rhino")
-    auto similarity_vine_snake = new Link("Expression",
-                                          {similarity->handle(), vine->handle(), snake->handle()},
-                                          is_toplevel);  // (Similarity "vine" "snake")
-    auto similarity_ent_human = new Link("Expression",
-                                         {similarity->handle(), ent->handle(), human->handle()},
-                                         is_toplevel);  // (Similarity "ent" "human")
+                 {similarity->handle(), snake->handle(), vine->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"snake\" \"vine\")"}});  // (Similarity "snake" "vine")
+    auto similarity_human_ent =
+        new Link("Expression",
+                 {similarity->handle(), human->handle(), ent->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"human\" \"ent\")"}});  // (Similarity "human" "ent")
+    auto similarity_monkey_human =
+        new Link("Expression",
+                 {similarity->handle(), monkey->handle(), human->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"monkey\" \"human\")"}});  // (Similarity "monkey" "human")
+    auto similarity_chimp_human =
+        new Link("Expression",
+                 {similarity->handle(), chimp->handle(), human->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"chimp\" \"human\")"}});  // (Similarity "chimp" "human")
+    auto similarity_monkey_chimp =
+        new Link("Expression",
+                 {similarity->handle(), monkey->handle(), chimp->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"monkey\" \"chimp\")"}});  // (Similarity "monkey" "chimp")
+    auto similarity_earthworm_snake = new Link(
+        "Expression",
+        {similarity->handle(), earthworm->handle(), snake->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Similarity \"earthworm\" \"snake\")"}});  // (Similarity "earthworm" "snake")
+    auto similarity_triceratops_rhino = new Link(
+        "Expression",
+        {similarity->handle(), triceratops->handle(), rhino->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Similarity \"triceratops\" \"rhino\")"}});  // (Similarity "triceratops" "rhino")
+    auto similarity_vine_snake =
+        new Link("Expression",
+                 {similarity->handle(), vine->handle(), snake->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"vine\" \"snake\")"}});  // (Similarity "vine" "snake")
+    auto similarity_ent_human =
+        new Link("Expression",
+                 {similarity->handle(), ent->handle(), human->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Similarity \"ent\" \"human\")"}});  // (Similarity "ent" "human")
 
     links.push_back(similarity_human_monkey);
     links.push_back(similarity_human_chimp);
@@ -243,49 +315,79 @@ void load_animals_data() {
     links.clear();
 
     // Inheritance
-    auto inheritance_human_mammal = new Link("Expression",
-                                             {inheritance->handle(), human->handle(), mammal->handle()},
-                                             is_toplevel);  // (Inheritance "human" "mammal")
-    auto inheritance_monkey_mammal =
+    auto inheritance_human_mammal =
         new Link("Expression",
-                 {inheritance->handle(), monkey->handle(), mammal->handle()},
-                 is_toplevel);  // (Inheritance "monkey" "mammal")
-    auto inheritance_chimp_mammal = new Link("Expression",
-                                             {inheritance->handle(), chimp->handle(), mammal->handle()},
-                                             is_toplevel);  // (Inheritance "chimp" "mammal")
-    auto inheritance_mammal_animal =
+                 {inheritance->handle(), human->handle(), mammal->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Inheritance \"human\" \"mammal\")"}});  // (Inheritance "human" "mammal")
+    auto inheritance_monkey_mammal = new Link(
+        "Expression",
+        {inheritance->handle(), monkey->handle(), mammal->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Inheritance \"monkey\" \"mammal\")"}});  // (Inheritance "monkey" "mammal")
+    auto inheritance_chimp_mammal =
         new Link("Expression",
-                 {inheritance->handle(), mammal->handle(), animal->handle()},
-                 is_toplevel);  // (Inheritance "mammal" "animal")
-    auto inheritance_reptile_animal =
+                 {inheritance->handle(), chimp->handle(), mammal->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Inheritance \"chimp\" \"mammal\")"}});  // (Inheritance "chimp" "mammal")
+    auto inheritance_mammal_animal = new Link(
+        "Expression",
+        {inheritance->handle(), mammal->handle(), animal->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Inheritance \"mammal\" \"animal\")"}});  // (Inheritance "mammal" "animal")
+    auto inheritance_reptile_animal = new Link(
+        "Expression",
+        {inheritance->handle(), reptile->handle(), animal->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Inheritance \"reptile\" \"animal\")"}});  // (Inheritance "reptile" "animal")
+    auto inheritance_snake_reptile = new Link(
+        "Expression",
+        {inheritance->handle(), snake->handle(), reptile->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Inheritance \"snake\" \"reptile\")"}});  // (Inheritance "snake" "reptile")
+    auto inheritance_dinosaur_reptile = new Link(
+        "Expression",
+        {inheritance->handle(), dinosaur->handle(), reptile->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Inheritance \"dinosaur\" \"reptile\")"}});  // (Inheritance "dinosaur" "reptile")
+    auto inheritance_triceratops_dinosaur = new Link(
+        "Expression",
+        {inheritance->handle(), triceratops->handle(), dinosaur->handle()},
+        is_toplevel,
+        Properties{
+            {"metta_expression",
+             "(Inheritance \"triceratops\" \"dinosaur\")"}});  // (Inheritance "triceratops" "dinosaur")
+    auto inheritance_earthworm_animal = new Link(
+        "Expression",
+        {inheritance->handle(), earthworm->handle(), animal->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(Inheritance \"earthworm\" \"animal\")"}});  // (Inheritance "earthworm" "animal")
+    auto inheritance_rhino_mammal =
         new Link("Expression",
-                 {inheritance->handle(), reptile->handle(), animal->handle()},
-                 is_toplevel);  // (Inheritance "reptile" "animal")
-    auto inheritance_snake_reptile =
+                 {inheritance->handle(), rhino->handle(), mammal->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Inheritance \"rhino\" \"mammal\")"}});  // (Inheritance "rhino" "mammal")
+    auto inheritance_vine_plant =
         new Link("Expression",
-                 {inheritance->handle(), snake->handle(), reptile->handle()},
-                 is_toplevel);  // (Inheritance "snake" "reptile")
-    auto inheritance_dinosaur_reptile =
+                 {inheritance->handle(), vine->handle(), plant->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Inheritance \"vine\" \"plant\")"}});  // (Inheritance "vine" "plant")
+    auto inheritance_ent_plant =
         new Link("Expression",
-                 {inheritance->handle(), dinosaur->handle(), reptile->handle()},
-                 is_toplevel);  // (Inheritance "dinosaur" "reptile")
-    auto inheritance_triceratops_dinosaur =
-        new Link("Expression",
-                 {inheritance->handle(), triceratops->handle(), dinosaur->handle()},
-                 is_toplevel);  // (Inheritance "triceratops" "dinosaur")
-    auto inheritance_earthworm_animal =
-        new Link("Expression",
-                 {inheritance->handle(), earthworm->handle(), animal->handle()},
-                 is_toplevel);  // (Inheritance "earthworm" "animal")
-    auto inheritance_rhino_mammal = new Link("Expression",
-                                             {inheritance->handle(), rhino->handle(), mammal->handle()},
-                                             is_toplevel);  // (Inheritance "rhino" "mammal")
-    auto inheritance_vine_plant = new Link("Expression",
-                                           {inheritance->handle(), vine->handle(), plant->handle()},
-                                           is_toplevel);  // (Inheritance "vine" "plant")
-    auto inheritance_ent_plant = new Link("Expression",
-                                          {inheritance->handle(), ent->handle(), plant->handle()},
-                                          is_toplevel);  // (Inheritance "ent" "plant")
+                 {inheritance->handle(), ent->handle(), plant->handle()},
+                 is_toplevel,
+                 Properties{{"metta_expression",
+                             "(Inheritance \"ent\" \"plant\")"}});  // (Inheritance "ent" "plant")
 
     links.push_back(inheritance_human_mammal);
     links.push_back(inheritance_monkey_mammal);
@@ -305,35 +407,69 @@ void load_animals_data() {
     links.clear();
 
     // OddLinks
-    auto oddlink_earthworm_snake = new Link("Expression",
-                                            {oddlink->handle(), similarity_earthworm_snake->handle()},
-                                            is_toplevel);  // (OddLink (Similarity "earthworm" "snake"))
-    auto oddlink_triceratops_rhino =
-        new Link("Expression",
-                 {oddlink->handle(), similarity_triceratops_rhino->handle()},
-                 is_toplevel);  // (OddLink (Similarity "triceratops" "rhino"))
-    auto oddlink_vine_snake = new Link("Expression",
-                                       {oddlink->handle(), similarity_vine_snake->handle()},
-                                       is_toplevel);  // (OddLink (Similarity "vine" "snake"))
-    auto oddlink_ent_human = new Link("Expression",
-                                      {oddlink->handle(), similarity_ent_human->handle()},
-                                      is_toplevel);  // (OddLink (Similarity "ent" "human"))
-    auto oddlink_snake_earthworm = new Link("Expression",
-                                            {oddlink->handle(), similarity_snake_earthworm->handle()},
-                                            is_toplevel);  // (OddLink (Similarity "snake" "earthworm"))
-    auto oddlink_rhino_triceratops =
-        new Link("Expression",
-                 {oddlink->handle(), similarity_rhino_triceratops->handle()},
-                 is_toplevel);  // (OddLink (Similarity "rhino" "triceratops"))
-    auto oddlink_snake_vine = new Link("Expression",
-                                       {oddlink->handle(), similarity_snake_vine->handle()},
-                                       is_toplevel);  // (OddLink (Similarity "snake" "vine"))
-    auto oddlink_human_ent = new Link("Expression",
-                                      {oddlink->handle(), similarity_human_ent->handle()},
-                                      is_toplevel);  // (OddLink (Similarity "human" "ent"))
-    auto oddlink_ent_plant = new Link("Expression",
-                                      {oddlink->handle(), inheritance_ent_plant->handle()},
-                                      is_toplevel);  // (OddLink (Inheritance "ent" "plant"))
+    auto oddlink_earthworm_snake = new Link(
+        "Expression",
+        {oddlink->handle(), similarity_earthworm_snake->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(OddLink (Similarity \"earthworm\" \"snake\"))"}});  // (OddLink (Similarity
+                                                                          // "earthworm" "snake"))
+    auto oddlink_triceratops_rhino = new Link(
+        "Expression",
+        {oddlink->handle(), similarity_triceratops_rhino->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(OddLink (Similarity \"triceratops\" \"rhino\"))"}});  // (OddLink (Similarity
+                                                                            // "triceratops" "rhino"))
+    auto oddlink_vine_snake = new Link(
+        "Expression",
+        {oddlink->handle(), similarity_vine_snake->handle()},
+        is_toplevel,
+        Properties{
+            {"metta_expression",
+             "(OddLink (Similarity \"vine\" \"snake\"))"}});  // (OddLink (Similarity "vine" "snake"))
+    auto oddlink_ent_human = new Link(
+        "Expression",
+        {oddlink->handle(), similarity_ent_human->handle()},
+        is_toplevel,
+        Properties{
+            {"metta_expression",
+             "(OddLink (Similarity \"ent\" \"human\"))"}});  // (OddLink (Similarity "ent" "human"))
+    auto oddlink_snake_earthworm = new Link(
+        "Expression",
+        {oddlink->handle(), similarity_snake_earthworm->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(OddLink (Similarity \"snake\" \"earthworm\"))"}});  // (OddLink (Similarity "snake"
+                                                                          // "earthworm"))
+    auto oddlink_rhino_triceratops = new Link(
+        "Expression",
+        {oddlink->handle(), similarity_rhino_triceratops->handle()},
+        is_toplevel,
+        Properties{{"metta_expression",
+                    "(OddLink (Similarity \"rhino\" \"triceratops\"))"}});  // (OddLink (Similarity
+                                                                            // "rhino" "triceratops"))
+    auto oddlink_snake_vine = new Link(
+        "Expression",
+        {oddlink->handle(), similarity_snake_vine->handle()},
+        is_toplevel,
+        Properties{
+            {"metta_expression",
+             "(OddLink (Similarity \"snake\" \"vine\"))"}});  // (OddLink (Similarity "snake" "vine"))
+    auto oddlink_human_ent = new Link(
+        "Expression",
+        {oddlink->handle(), similarity_human_ent->handle()},
+        is_toplevel,
+        Properties{
+            {"metta_expression",
+             "(OddLink (Similarity \"human\" \"ent\"))"}});  // (OddLink (Similarity "human" "ent"))
+    auto oddlink_ent_plant = new Link(
+        "Expression",
+        {oddlink->handle(), inheritance_ent_plant->handle()},
+        is_toplevel,
+        Properties{
+            {"metta_expression",
+             "(OddLink (Inheritance \"ent\" \"plant\"))"}});  // (OddLink (Inheritance "ent" "plant"))
 
     links.push_back(oddlink_earthworm_snake);
     links.push_back(oddlink_triceratops_rhino);

--- a/src/tests/cpp/test_commons/mocks/MockAtomDB.h
+++ b/src/tests/cpp/test_commons/mocks/MockAtomDB.h
@@ -112,6 +112,8 @@ class AtomDBMock : public AtomDB {
                 (const vector<string>& handles, bool delete_link_targets),
                 (override));
 
+    MOCK_METHOD(void, re_index_patterns, (bool flush_patterns), (override));
+
     AtomDBMock() {
         ON_CALL(*this, get_atom_document(testing::_))
             .WillByDefault(::testing::Return(make_shared<MockAtomDocument>()));

--- a/src/tests/main/tests_db_loader.cc
+++ b/src/tests/main/tests_db_loader.cc
@@ -168,7 +168,12 @@ int main(int argc, char* argv[]) {
                                     continue;
                                 }
                                 handles.insert(pair.second->handle());
-                                batch_atoms.push_back(pair.second.get());
+
+                                auto atom = pair.second.get();
+                                if (atom->arity() > 0)
+                                    atom->custom_attributes["metta_expression"] = metta_expr;
+                                batch_atoms.push_back(atom);
+
                                 thread_atoms_count++;
 
                                 // Add atoms in batches
@@ -256,14 +261,20 @@ int main(int argc, char* argv[]) {
                         }
                         metta_expression += ")";
 
-                        auto link = new Link("Expression", targets, true, {}, metta_expression);
+                        auto link = new Link("Expression",
+                                             targets,
+                                             true,
+                                             Properties{{"metta_expression", metta_expression}});
                         links.push_back(link);
 
                         vector<string> nested_targets = {targets[0], targets[1], link->handle()};
                         string nested_metta_expression =
                             "(" + node_names[0] + " " + node_names[1] + " " + metta_expression + ")";
                         auto link_with_nested =
-                            new Link("Expression", nested_targets, true, {}, nested_metta_expression);
+                            new Link("Expression",
+                                     nested_targets,
+                                     true,
+                                     Properties{{"metta_expression", nested_metta_expression}});
                         links.push_back(link_with_nested);
 
                         if (j % chunck_size == 0) {


### PR DESCRIPTION
This PR:

1 - Moves `Link->metta_expression` field to `Link-> custom_attributes["metta_expression"]`.
2 - Implements `MorkDB::re_index_patterns()` to restore S-Expr from MongoDB to MORK.
3 - Uses `load_animals_data()` at `morkdb_test.cc` so we don't need to manually call `make mork-loader FILE` anymore.