### PR TITLE
Move `EmptyTrieValue` to `commons::HandleTrie` and `value != NULL`

### DIFF
--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -407,7 +407,7 @@ void RemoteAtomDBPeer::fetch(const LinkSchema& link_schema) {
         auto result = atomdb_->query_for_pattern(link_schema);
         if (result) {
             feed_cache_from_handle_set(result);
-            fetched_link_templates_.insert(link_schema.handle(), NULL);
+            fetched_link_templates_.insert(link_schema.handle(), empty_trie_value_);
         }
     }
 }

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -16,12 +16,6 @@ using namespace atoms;
 
 namespace atomdb {
 
-// Dummy TrieValue for using HandleTrie as a set (presence only)
-class EmptyTrieValue : public HandleTrie::TrieValue {
-   public:
-    void merge(HandleTrie::TrieValue* /*other*/) override {}
-};
-
 /**
  * RemoteAtomDBPeer represents a cached connection to a remote AtomDB.
  * It combines an in-memory cache, a read-only remote AtomDB, and local persistence

--- a/src/commons/HandleTrie.cc
+++ b/src/commons/HandleTrie.cc
@@ -77,6 +77,10 @@ HandleTrie::TrieValue* HandleTrie::insert(const string& key, TrieValue* value) {
         Utils::error("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
     }
 
+    if (value == NULL) {
+        Utils::error("Value cannot be NULL");
+    }
+
     TrieNode* tree_cursor = root;
     TrieNode* parent = root;
     TrieNode* child;

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -133,4 +133,14 @@ class HandleTrie {
     unsigned int key_size;
 };
 
+/**
+ * Dummy TrieValue for using HandleTrie as a set (presence only).
+ * Use this when you only need to track which keys exist, with no payload.
+ * Safe to pass to insert(); merge() is a no-op.
+ */
+class EmptyTrieValue : public HandleTrie::TrieValue {
+   public:
+    void merge(HandleTrie::TrieValue* /*other*/) override {}
+};
+
 }  // namespace commons


### PR DESCRIPTION
This PR moves the `EmptyTrieValue` class to `commons::HandleTrie` so others can use it.
It also ensure that `TrieValue* value` is not `NULL` when it is being inserted to the `HandleTrie`.