### PR TITLE
[Fix] Remove fully concrete match + `test_db_loader` better split

### DIFF
--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -716,7 +716,8 @@ vector<vector<string>> InMemoryDB::index_entries_combinations(unsigned int arity
     vector<vector<string>> index_entries;
     unsigned int total = 1 << arity;  // 2^arity
 
-    for (unsigned int mask = 0; mask < total; ++mask) {
+    // Skip mask == 0 (all concrete): identical to the link's own handle; no separate pattern index.
+    for (unsigned int mask = 1; mask < total; ++mask) {
         vector<string> index_entry;
         for (unsigned int i = 0; i < arity; ++i) {
             if (mask & (1 << i))

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -1307,7 +1307,8 @@ vector<vector<string>> RedisMongoDB::index_entries_combinations(unsigned int ari
     vector<vector<string>> index_entries;
     unsigned int total = 1 << arity;  // 2^arity
 
-    for (unsigned int mask = 0; mask < total; ++mask) {
+    // Skip mask == 0 (all concrete): identical to the link's own handle; no separate pattern index.
+    for (unsigned int mask = 1; mask < total; ++mask) {
         vector<string> index_entry;
         for (unsigned int i = 0; i < arity; ++i) {
             if (mask & (1 << i))

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -1242,35 +1242,37 @@ void RedisMongoDB::load_pattern_index_schema() {
         LOG_INFO(
             "WARNING: No pattern_index_schema found, all possible patterns will be created during link "
             "insertion!");
-        this->pattern_index_schema_map = default_pattern_index_schema();
     }
-}
-
-map<int, tuple<vector<string>, vector<vector<string>>>> RedisMongoDB::default_pattern_index_schema() {
-    map<int, tuple<vector<string>, vector<vector<string>>>> default_map;
-    for (unsigned int arity = 1; arity <= 4; arity++) {
-        vector<string> tokens = {"LINK_TEMPLATE", "Expression", to_string(arity)};
-        for (unsigned int i = 0; i < arity; i++) {
-            tokens.push_back("VARIABLE");
-            tokens.push_back("v" + to_string(i + 1));
-        }
-        auto index_entries = index_entries_combinations(arity);
-        default_map[arity] = make_tuple(move(tokens), move(index_entries));
-    }
-    return default_map;
 }
 
 vector<string> RedisMongoDB::match_pattern_index_schema(const Link* link) {
     vector<string> pattern_handles;
 
+    const auto& map_ref = this->pattern_index_schema_map;
+
+    const map<int, tuple<vector<string>, vector<vector<string>>>>* iter_map = &map_ref;
+
+    // When map is empty, use a default map
+    map<int, tuple<vector<string>, vector<vector<string>>>> default_map;
+    if (map_ref.empty()) {
+        vector<string> tokens = {"LINK_TEMPLATE", "Expression", to_string(link->arity())};
+        for (unsigned int i = 0; i < link->arity(); i++) {
+            tokens.push_back("VARIABLE");
+            tokens.push_back("v" + to_string(i + 1));
+        }
+        auto index_entries = this->index_entries_combinations(link->arity());
+        default_map = {{1, make_tuple(move(tokens), move(index_entries))}};
+        iter_map = &default_map;
+    }
+
     vector<int> sorted_keys;
-    for (const auto& pair : this->pattern_index_schema_map) {
+    for (const auto& pair : *iter_map) {
         sorted_keys.push_back(pair.first);
     }
     std::sort(sorted_keys.begin(), sorted_keys.end(), std::greater<int>());
 
     for (const auto& priority : sorted_keys) {
-        const auto& value = this->pattern_index_schema_map.at(priority);
+        const auto& value = (*iter_map).at(priority);
         auto link_schema = LinkSchema(get<0>(value));
         auto index_entries = get<1>(value);
         Assignment assignment;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -1242,34 +1242,35 @@ void RedisMongoDB::load_pattern_index_schema() {
         LOG_INFO(
             "WARNING: No pattern_index_schema found, all possible patterns will be created during link "
             "insertion!");
+        this->pattern_index_schema_map = default_pattern_index_schema();
     }
+}
+
+map<int, tuple<vector<string>, vector<vector<string>>>> RedisMongoDB::default_pattern_index_schema() {
+    map<int, tuple<vector<string>, vector<vector<string>>>> default_map;
+    for (unsigned int arity = 1; arity <= 4; arity++) {
+        vector<string> tokens = {"LINK_TEMPLATE", "Expression", to_string(arity)};
+        for (unsigned int i = 0; i < arity; i++) {
+            tokens.push_back("VARIABLE");
+            tokens.push_back("v" + to_string(i + 1));
+        }
+        auto index_entries = index_entries_combinations(arity);
+        default_map[arity] = make_tuple(move(tokens), move(index_entries));
+    }
+    return default_map;
 }
 
 vector<string> RedisMongoDB::match_pattern_index_schema(const Link* link) {
     vector<string> pattern_handles;
-    auto local_map = this->pattern_index_schema_map;
-
-    if (local_map.size() == 0) {
-        vector<string> tokens = {"LINK_TEMPLATE", "Expression", to_string(link->arity())};
-        for (unsigned int i = 0; i < link->arity(); i++) {
-            tokens.push_back("VARIABLE");
-            tokens.push_back("v" + to_string(i + 1));
-        }
-
-        auto link_schema = LinkSchema(tokens);
-        auto index_entries = index_entries_combinations(link->arity());
-
-        local_map[1] = make_tuple(move(tokens), move(index_entries));
-    }
 
     vector<int> sorted_keys;
-    for (const auto& pair : local_map) {
+    for (const auto& pair : this->pattern_index_schema_map) {
         sorted_keys.push_back(pair.first);
     }
     std::sort(sorted_keys.begin(), sorted_keys.end(), std::greater<int>());
 
     for (const auto& priority : sorted_keys) {
-        auto value = local_map[priority];
+        const auto& value = this->pattern_index_schema_map.at(priority);
         auto link_schema = LinkSchema(get<0>(value));
         auto index_entries = get<1>(value);
         Assignment assignment;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -193,6 +193,7 @@ class RedisMongoDB : public AtomDB {
     void update_incoming_set(const string& key, const string& value);
 
     void load_pattern_index_schema();
+    map<int, tuple<vector<string>, vector<vector<string>>>> default_pattern_index_schema();
     vector<string> match_pattern_index_schema(const Link* link);
     vector<vector<string>> index_entries_combinations(unsigned int arity);
 

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -193,7 +193,6 @@ class RedisMongoDB : public AtomDB {
     void update_incoming_set(const string& key, const string& value);
 
     void load_pattern_index_schema();
-    map<int, tuple<vector<string>, vector<vector<string>>>> default_pattern_index_schema();
     vector<string> match_pattern_index_schema(const Link* link);
     vector<vector<string>> index_entries_combinations(unsigned int arity);
 

--- a/src/tests/main/tests_db_loader.cc
+++ b/src/tests/main/tests_db_loader.cc
@@ -124,13 +124,13 @@ int main(int argc, char* argv[]) {
             atomic<size_t> total_atoms_processed(0);
 
             for (int i = 0; i < num_threads; i++) {
-                size_t start_line = i * lines_per_thread;
-                size_t end_line = start_line + lines_per_thread;
-
-                // Remainder must be added to the last thread
-                if (i == num_threads - 1) {
-                    end_line++;
-                }
+                // Even split: thread i gets [start_line, end_line). Using integer division avoids
+                // the bug where "last thread gets +1" was always applied (OOB when remainder==0,
+                // e.g. 5 lines / 1 thread => end_line 6 and lines[5] is undefined).
+                size_t start_line =
+                    (static_cast<size_t>(i) * lines.size()) / static_cast<size_t>(num_threads);
+                size_t end_line =
+                    (static_cast<size_t>(i + 1) * lines.size()) / static_cast<size_t>(num_threads);
 
                 threads.emplace_back([&, start_line, end_line, i]() -> void {
                     auto thread_atomdb = AtomDBSingleton::get_instance();


### PR DESCRIPTION
This PR removes the indexing of fully concrete match from Redis patterns.
It also improves the way we split load in `test_db_loader`.