### PR TITLE
[#212] Implemented Chain operator in query engine metta parser

### DIFF
--- a/src/agents/query_engine/MettaParserActions.cc
+++ b/src/agents/query_engine/MettaParserActions.cc
@@ -4,7 +4,6 @@
 
 // clang-format off
 
-#define LOG_LEVEL DEBUG_LEVEL
 #include "Logger.h"
 
 #include "And.h"
@@ -89,7 +88,7 @@ void MettaParserActions::literal(float value) {
     ParserActions::literal(value);
     if ((this->current_expression_type == AND) || (this->current_expression_type == OR) ||
         (this->current_expression_type == CHAIN)) {
-        Utils::error("Invalid query expression: AND/OR can't operate float literals.");
+        Utils::error("Invalid query expression: AND/OR/CHAIN can't operate float literals.");
         return;
     }
     this->current_expression_size++;

--- a/src/agents/query_engine/MettaParserActions.cc
+++ b/src/agents/query_engine/MettaParserActions.cc
@@ -33,7 +33,8 @@ MettaParserActions::~MettaParserActions() {}
 
 void MettaParserActions::symbol(const string& name) {
     ParserActions::symbol(name);
-    if ((name == MettaMapping::AND_QUERY_OPERATOR) || (name == MettaMapping::OR_QUERY_OPERATOR) || (name == MettaMapping::CHAIN_QUERY_OPERATOR)) {
+    if ((name == MettaMapping::AND_QUERY_OPERATOR) || (name == MettaMapping::OR_QUERY_OPERATOR) ||
+        (name == MettaMapping::CHAIN_QUERY_OPERATOR)) {
         if (name == MettaMapping::AND_QUERY_OPERATOR) {
             this->current_expression_type = AND;
         } else if (name == MettaMapping::OR_QUERY_OPERATOR) {
@@ -53,7 +54,8 @@ void MettaParserActions::symbol(const string& name) {
 
 void MettaParserActions::variable(const string& value) {
     ParserActions::variable(value);
-    if ((this->current_expression_type == AND) || (this->current_expression_type == OR) || (this->current_expression_type == CHAIN)) {
+    if ((this->current_expression_type == AND) || (this->current_expression_type == OR) ||
+        (this->current_expression_type == CHAIN)) {
         Utils::error("Invalid query expression: AND/OR/CHAIN can't operate variables.");
         return;
     }
@@ -85,7 +87,8 @@ void MettaParserActions::literal(int value) {
 
 void MettaParserActions::literal(float value) {
     ParserActions::literal(value);
-    if ((this->current_expression_type == AND) || (this->current_expression_type == OR) || (this->current_expression_type == CHAIN)) {
+    if ((this->current_expression_type == AND) || (this->current_expression_type == OR) ||
+        (this->current_expression_type == CHAIN)) {
         Utils::error("Invalid query expression: AND/OR can't operate float literals.");
         return;
     }
@@ -107,7 +110,7 @@ shared_ptr<Terminal> MettaParserActions::unstack_terminal(bool node_flag) {
     if (terminal == nullptr) {
         Utils::error("Expecting Terminal. Got: " + this->element_stack.top()->to_string());
     } else {
-        if (node_flag && (! terminal->is_node)) {
+        if (node_flag && (!terminal->is_node)) {
             Utils::error("Expecting Node. Got: " + this->element_stack.top()->to_string());
         }
     }
@@ -120,7 +123,8 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
     unsigned int arity = this->current_expression_size;
     if (this->element_stack.size() < arity) {
         Utils::error("Invalid query expression: too few arguments for expression. Expected: " +
-                     std::to_string(arity) + " Stack size: " + std::to_string(this->element_stack.size()));
+                     std::to_string(arity) +
+                     " Stack size: " + std::to_string(this->element_stack.size()));
         return;
     }
     LOG_DEBUG("Arity: " + std::to_string(arity));
@@ -157,7 +161,8 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
             array<shared_ptr<QueryElement>, 2> clauses;
             vector<shared_ptr<QueryElement>> link_templates;
             for (int i = 1; i >= 0; i--) {
-                LinkTemplate* link_template = dynamic_cast<LinkTemplate*>(this->element_stack.top().get());
+                LinkTemplate* link_template =
+                    dynamic_cast<LinkTemplate*>(this->element_stack.top().get());
                 if (link_template != NULL) {
                     link_templates.push_back(this->element_stack.top());
                     link_template->build();
@@ -222,7 +227,8 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
             LOG_DEBUG("Source handle: " + source->compute_handle());
             LOG_DEBUG("Target handle: " + target->compute_handle());
 
-            bool incomplete_flag = this->proxy->parameters.get<bool>(BaseQueryProxy::ALLOW_INCOMPLETE_CHAIN_PATH);
+            bool incomplete_flag =
+                this->proxy->parameters.get<bool>(BaseQueryProxy::ALLOW_INCOMPLETE_CHAIN_PATH);
             auto chain_operator = make_shared<Chain>(clauses,
                                                      link_template,
                                                      source->compute_handle(),

--- a/src/agents/query_engine/MettaParserActions.cc
+++ b/src/agents/query_engine/MettaParserActions.cc
@@ -4,7 +4,7 @@
 
 // clang-format off
 
-#define LOG_LEVEL INFO_LEVEL
+#define LOG_LEVEL DEBUG_LEVEL
 #include "Logger.h"
 
 #include "And.h"
@@ -12,6 +12,7 @@
 #include "MettaMapping.h"
 #include "MettaParserActions.h"
 #include "Or.h"
+#include "Chain.h"
 #include "Terminal.h"
 #include "UniqueAssignmentFilter.h"
 
@@ -32,11 +33,13 @@ MettaParserActions::~MettaParserActions() {}
 
 void MettaParserActions::symbol(const string& name) {
     ParserActions::symbol(name);
-    if ((name == MettaMapping::AND_QUERY_OPERATOR) || (name == MettaMapping::OR_QUERY_OPERATOR)) {
+    if ((name == MettaMapping::AND_QUERY_OPERATOR) || (name == MettaMapping::OR_QUERY_OPERATOR) || (name == MettaMapping::CHAIN_QUERY_OPERATOR)) {
         if (name == MettaMapping::AND_QUERY_OPERATOR) {
             this->current_expression_type = AND;
-        } else {
+        } else if (name == MettaMapping::OR_QUERY_OPERATOR) {
             this->current_expression_type = OR;
+        } else {
+            this->current_expression_type = CHAIN;
         }
     } else {
         if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
@@ -50,8 +53,8 @@ void MettaParserActions::symbol(const string& name) {
 
 void MettaParserActions::variable(const string& value) {
     ParserActions::variable(value);
-    if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid query expression: AND/OR can't operate variables.");
+    if ((this->current_expression_type == AND) || (this->current_expression_type == OR) || (this->current_expression_type == CHAIN)) {
+        Utils::error("Invalid query expression: AND/OR/CHAIN can't operate variables.");
         return;
     }
     this->current_expression_size++;
@@ -82,8 +85,8 @@ void MettaParserActions::literal(int value) {
 
 void MettaParserActions::literal(float value) {
     ParserActions::literal(value);
-    if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid query expression: AND/OR can't operate literals.");
+    if ((this->current_expression_type == AND) || (this->current_expression_type == OR) || (this->current_expression_type == CHAIN)) {
+        Utils::error("Invalid query expression: AND/OR can't operate float literals.");
         return;
     }
     this->current_expression_size++;
@@ -99,20 +102,33 @@ void MettaParserActions::expression_begin() {
     this->current_expression_type = LINK;
 }
 
+shared_ptr<Terminal> MettaParserActions::unstack_terminal(bool node_flag) {
+    shared_ptr<Terminal> terminal = dynamic_pointer_cast<Terminal>(this->element_stack.top());
+    if (terminal == nullptr) {
+        Utils::error("Expecting Terminal. Got: " + this->element_stack.top()->to_string());
+    } else {
+        if (node_flag && (! terminal->is_node)) {
+            Utils::error("Expecting Node. Got: " + this->element_stack.top()->to_string());
+        }
+    }
+    this->element_stack.pop();
+    return terminal;
+}
+
 void MettaParserActions::expression_end(bool toplevel, const string& metta_expression) {
     ParserActions::expression_end(toplevel, metta_expression);
     unsigned int arity = this->current_expression_size;
-    if (element_stack.size() < arity) {
+    if (this->element_stack.size() < arity) {
         Utils::error("Invalid query expression: too few arguments for expression. Expected: " +
-                     std::to_string(arity) + " Stack size: " + std::to_string(element_stack.size()));
+                     std::to_string(arity) + " Stack size: " + std::to_string(this->element_stack.size()));
         return;
     }
     LOG_DEBUG("Arity: " + std::to_string(arity));
     if ((this->current_expression_type == LINK) || (this->current_expression_type == LINK_TEMPLATE)) {
         vector<shared_ptr<QueryElement>> targets;
         for (unsigned int i = 0; i < arity; i++) {
-            targets.push_back(element_stack.top());
-            element_stack.pop();
+            targets.push_back(this->element_stack.top());
+            this->element_stack.pop();
         }
         reverse(targets.begin(), targets.end());
         if (this->current_expression_type == LINK) {
@@ -135,26 +151,26 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
             this->element_stack.push(new_link_template);
         }
     } else if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        if (element_stack.size() >= 2) {
+        if (this->element_stack.size() >= 2) {
             shared_ptr<QueryElement> new_operator;
             // When using MeTTa to define a query, AND and OR operations always take 2 arguments.
             array<shared_ptr<QueryElement>, 2> clauses;
             vector<shared_ptr<QueryElement>> link_templates;
             for (int i = 1; i >= 0; i--) {
-                LinkTemplate* link_template = dynamic_cast<LinkTemplate*>(element_stack.top().get());
+                LinkTemplate* link_template = dynamic_cast<LinkTemplate*>(this->element_stack.top().get());
                 if (link_template != NULL) {
-                    link_templates.push_back(element_stack.top());
+                    link_templates.push_back(this->element_stack.top());
                     link_template->build();
                     clauses[i] = link_template->get_source_element();
                 } else {
-                    if (element_stack.top()->is_operator) {
-                        clauses[i] = element_stack.top();
+                    if (this->element_stack.top()->is_operator) {
+                        clauses[i] = this->element_stack.top();
                     } else {
                         Utils::error("All AND clauses are supposed to be LinkTemplate or Operator");
                         return;
                     }
                 }
-                element_stack.pop();
+                this->element_stack.pop();
             }
             if (this->current_expression_type == AND) {
                 LOG_DEBUG("Pushing AND");
@@ -164,12 +180,61 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
                 new_operator = make_shared<Or<2>>(clauses, link_templates);
             }
             if (this->proxy->parameters.get<bool>(BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG)) {
-                element_stack.push(make_shared<UniqueAssignmentFilter>(new_operator));
+                this->element_stack.push(make_shared<UniqueAssignmentFilter>(new_operator));
             } else {
-                element_stack.push(new_operator);
+                this->element_stack.push(new_operator);
             }
         } else {
             Utils::error("Invalid query expression: 'and' and 'or' require exactly two arguments.");
+            return;
+        }
+    } else if (this->current_expression_type == CHAIN) {
+        if (this->element_stack.size() >= 6) {
+            LOG_DEBUG("Building CHAIN operator...");
+            array<shared_ptr<QueryElement>, 1> clauses;
+            clauses[0] = this->element_stack.top();
+            this->element_stack.pop();
+            shared_ptr<LinkTemplate> link_template = dynamic_pointer_cast<LinkTemplate>(clauses[0]);
+            if (link_template != nullptr) {
+                link_template->build();
+                clauses[0] = link_template->get_source_element();
+            }
+            LOG_DEBUG("Input: " + clauses[0]->to_string());
+            shared_ptr<Terminal> target = unstack_terminal();
+            shared_ptr<Terminal> source = unstack_terminal();
+            shared_ptr<Terminal> cursor = unstack_terminal(true);
+            unsigned int head_reference = Utils::string_to_uint(cursor->name);
+            cursor = unstack_terminal(true);
+            unsigned int tail_reference = Utils::string_to_uint(cursor->name);
+            cursor = unstack_terminal(true);
+            QueryAnswerElement link_selector;
+            if (isdigit(static_cast<unsigned char>(cursor->name[0]))) {
+                link_selector.set(Utils::string_to_uint(cursor->name));
+                LOG_DEBUG("Link selector is handle index: " + cursor->name);
+            } else {
+                link_selector.set(cursor->name);
+                LOG_DEBUG("Link selector is variable: " + cursor->name);
+            }
+            LOG_DEBUG("Tail reference: " + std::to_string(tail_reference));
+            LOG_DEBUG("Head reference: " + std::to_string(head_reference));
+            LOG_DEBUG("Source terminal: " + source->to_string());
+            LOG_DEBUG("Target terminal: " + target->to_string());
+            LOG_DEBUG("Source handle: " + source->compute_handle());
+            LOG_DEBUG("Target handle: " + target->compute_handle());
+
+            bool incomplete_flag = this->proxy->parameters.get<bool>(BaseQueryProxy::ALLOW_INCOMPLETE_CHAIN_PATH);
+            auto chain_operator = make_shared<Chain>(clauses,
+                                                     link_template,
+                                                     source->compute_handle(),
+                                                     target->compute_handle(),
+                                                     link_selector,
+                                                     tail_reference,
+                                                     head_reference,
+                                                     incomplete_flag);
+            LOG_DEBUG("Building CHAIN operator... DONE");
+            this->element_stack.push(chain_operator);
+        } else {
+            Utils::error("Invalid query expression: 'chain' requires exactly six arguments.");
             return;
         }
     } else {

--- a/src/agents/query_engine/MettaParserActions.h
+++ b/src/agents/query_engine/MettaParserActions.h
@@ -3,6 +3,7 @@
 #include <stack>
 
 #include "ParserActions.h"
+#include "Terminal.h"
 #include "PatternMatchingQueryProxy.h"
 #include "QueryElement.h"
 
@@ -12,7 +13,7 @@ using namespace query_element;
 
 namespace query_engine {
 
-enum ExpressionType { LINK, LINK_TEMPLATE, AND, OR };
+enum ExpressionType { LINK, LINK_TEMPLATE, AND, OR, CHAIN };
 
 /**
  *
@@ -63,6 +64,9 @@ class MettaParserActions : public ParserActions {
     stack<shared_ptr<QueryElement>> element_stack;
 
    private:
+
+    shared_ptr<Terminal> unstack_terminal(bool node_flag = false);
+
     shared_ptr<PatternMatchingQueryProxy> proxy;
     unsigned int current_expression_size;
     ExpressionType current_expression_type;

--- a/src/agents/query_engine/MettaParserActions.h
+++ b/src/agents/query_engine/MettaParserActions.h
@@ -3,9 +3,9 @@
 #include <stack>
 
 #include "ParserActions.h"
-#include "Terminal.h"
 #include "PatternMatchingQueryProxy.h"
 #include "QueryElement.h"
+#include "Terminal.h"
 
 using namespace std;
 using namespace metta;
@@ -64,7 +64,6 @@ class MettaParserActions : public ParserActions {
     stack<shared_ptr<QueryElement>> element_stack;
 
    private:
-
     shared_ptr<Terminal> unstack_terminal(bool node_flag = false);
 
     shared_ptr<PatternMatchingQueryProxy> proxy;

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -1,9 +1,6 @@
 #include "PatternMatchingQueryProcessor.h"
 // clang-format off
 
-#ifndef LOG_LEVEL
-#define LOG_LEVEL INFO_LEVEL
-#endif
 #include "Logger.h"
 
 #include <map>

--- a/src/agents/query_engine/query_element/Terminal.cc
+++ b/src/agents/query_engine/query_element/Terminal.cc
@@ -1,6 +1,5 @@
 #include "Terminal.h"
 
-#define LOG_LEVEL INFO_LEVEL
 #include "Hasher.h"
 #include "Link.h"
 #include "Logger.h"

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -178,11 +178,11 @@ int Utils::string_to_int(const string& s) {
 
 unsigned int Utils::string_to_uint(const string& s) {
     if (!is_number(s)) {
-        throw invalid_argument("Can not convert string to unsigned int: Invalid arguments (" + s + ")");
+        Utils::error("Can not convert string to unsigned int: Invalid arguments (" + s + ")");
     }
     int n = stoi(s);
     if (n < 0) {
-        throw invalid_argument("Can not convert string to unsigned int: Invalid negative number (" + s +
+        Utils::error("Can not convert string to unsigned int: Invalid negative number (" + s +
                                ")");
     }
     return (unsigned int) n;

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -182,8 +182,7 @@ unsigned int Utils::string_to_uint(const string& s) {
     }
     int n = stoi(s);
     if (n < 0) {
-        Utils::error("Can not convert string to unsigned int: Invalid negative number (" + s +
-                               ")");
+        Utils::error("Can not convert string to unsigned int: Invalid negative number (" + s + ")");
     }
     return (unsigned int) n;
 }

--- a/src/metta/MettaMapping.cc
+++ b/src/metta/MettaMapping.cc
@@ -6,3 +6,4 @@ string MettaMapping::EXPRESSION_LINK_TYPE = "Expression";
 string MettaMapping::SYMBOL_NODE_TYPE = "Symbol";
 string MettaMapping::AND_QUERY_OPERATOR = "and";
 string MettaMapping::OR_QUERY_OPERATOR = "or";
+string MettaMapping::CHAIN_QUERY_OPERATOR = "chain";

--- a/src/metta/MettaMapping.h
+++ b/src/metta/MettaMapping.h
@@ -19,6 +19,7 @@ class MettaMapping {
     static string SYMBOL_NODE_TYPE;
     static string AND_QUERY_OPERATOR;
     static string OR_QUERY_OPERATOR;
+    static string CHAIN_QUERY_OPERATOR;
 };
 
 }  // namespace commons

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -149,6 +149,7 @@ void check_query(const string& query_tag,
 
 void check_query_chain(const string& query_tag,
                        const vector<string>& query,
+                       const string& metta_expression,
                        const string& source,
                        const string& target,
                        unsigned int expected_count,
@@ -168,6 +169,16 @@ void check_query_chain(const string& query_tag,
     proxy1->parameters[PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG] = positive_importance;
     proxy1->parameters[PatternMatchingQueryProxy::UNIQUE_VALUE_FLAG] = unique_value_flag;
     LOG_INFO("proxy1: " + proxy1->to_string());
+
+    vector<string> metta_query = {metta_expression};
+    shared_ptr<PatternMatchingQueryProxy> proxy2(new PatternMatchingQueryProxy(metta_query, context));
+    proxy2->parameters[BaseQueryProxy::USE_METTA_AS_QUERY_TOKENS] = true;
+    proxy2->parameters[BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG] = unique_assignment;
+    proxy2->parameters[BaseQueryProxy::ATTENTION_UPDATE_FLAG] = update_attention_broker;
+    proxy2->parameters[BaseQueryProxy::POPULATE_METTA_MAPPING] = false;
+    proxy2->parameters[PatternMatchingQueryProxy::POSITIVE_IMPORTANCE_FLAG] = positive_importance;
+    proxy2->parameters[PatternMatchingQueryProxy::UNIQUE_VALUE_FLAG] = unique_value_flag;
+    LOG_INFO("proxy2: " + proxy2->to_string());
 
     unsigned int count = 0;
     shared_ptr<QueryAnswer> query_answer;
@@ -203,6 +214,36 @@ void check_query_chain(const string& query_tag,
     // giving time to the server to close the previous connection
     // otherwise the test fails with "Node ID already in the network"
     Utils::sleep();
+
+    if (metta_expression != "") {
+        client_bus->issue_bus_command(proxy2);
+        count = 0;
+        while (!proxy2->finished()) {
+            while (!(query_answer = proxy2->pop())) {
+                if (proxy2->finished()) {
+                    break;
+                } else {
+                    Utils::sleep();
+                }
+            }
+            if (query_answer) {
+                LOG_INFO(">>>>>>>>>> " << query_answer->assignment.to_string());
+                for (auto pair : query_answer->assignment.table) {
+                    LOG_INFO(">>>>>>>>>>>>>> " << pair.first << " " << handle_to_atom(pair.second));
+                }
+                if (((query_answer->get(Chain::ORIGIN_VARIABLE_NAME) == source) &&
+                     (query_answer->get(Chain::DESTINY_VARIABLE_NAME) == target)) ||
+                    ((query_answer->get(Chain::ORIGIN_VARIABLE_NAME) == target) &&
+                     (query_answer->get(Chain::DESTINY_VARIABLE_NAME) == source))) {
+                    count++;
+                }
+                EXPECT_TRUE((query_answer->get(Chain::ORIGIN_VARIABLE_NAME) == source) ||
+                            (query_answer->get(Chain::ORIGIN_VARIABLE_NAME) == target));
+            }
+        }
+        EXPECT_EQ(count, expected_count);
+        EXPECT_EQ(proxy2->error_flag, error_flag);
+    }
 }
 
 TEST(PatternMatchingQuery, queries) {
@@ -326,6 +367,7 @@ TEST(PatternMatchingQuery, queries) {
                 "VARIABLE", "v1",
                 "VARIABLE", "v2",
     };
+    string q8m = "(chain 0 1 2 \"chimp\" \"ent\" (Similarity $v1 $v2))";
     int q8_expected_count = 2;
 
     vector<string> q9 = {
@@ -342,6 +384,7 @@ TEST(PatternMatchingQuery, queries) {
                     "VARIABLE", "v1",
                     "VARIABLE", "v2",
     };
+    string q9m = "(chain 0 1 2 \"ent\" \"animal\" (or (Similarity $v1 $v2) (Inheritance $v1 $v2)))";
     int q9_expected_count = 5;
 
     vector<string> q10 = {
@@ -363,6 +406,7 @@ TEST(PatternMatchingQuery, queries) {
                     "VARIABLE", "v1",
                     "VARIABLE", "v2"
     };
+    string q10m = "(chain 1 1 2 \"chimp\" \"ent\" (and (or (Inheritance $v1 \"mammal\") (Inheritance $v2 \"mammal\")) (Similarity $v1 $v2)))";
     int q10_expected_count = 2;
 
     // Regular queries
@@ -374,9 +418,9 @@ TEST(PatternMatchingQuery, queries) {
     check_query("q5", q5, q5m, q5_expected_count, client_bus, "PatternMatchingQuery.queries", false, false, false, false, false);
     check_query("q6", q6, q6m, q6_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false, false);
     check_query("q7", q7, q7m, q7_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false, false);
-    check_query_chain("q8", q8, Hasher::node_handle("Symbol", "\"chimp\""), Hasher::node_handle("Symbol", "\"ent\""), q8_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false, false);
-    check_query_chain("q9", q9, Hasher::node_handle("Symbol", "\"ent\""), Hasher::node_handle("Symbol", "\"animal\""), q9_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false, false);
-    check_query_chain("q10", q10, Hasher::node_handle("Symbol", "\"chimp\""), Hasher::node_handle("Symbol", "\"ent\""), q10_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false, false);
+    check_query_chain("q8", q8, q8m, Hasher::node_handle("Symbol", "\"chimp\""), Hasher::node_handle("Symbol", "\"ent\""), q8_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false, false);
+    check_query_chain("q9", q9, q9m, Hasher::node_handle("Symbol", "\"ent\""), Hasher::node_handle("Symbol", "\"animal\""), q9_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false, false);
+    check_query_chain("q10", q10, q10m, Hasher::node_handle("Symbol", "\"chimp\""), Hasher::node_handle("Symbol", "\"ent\""), q10_expected_count, client_bus, "PatternMatchingQuery.queries", false, true, false, false, false);
 
     // Importance filtering
     // XXX AttentionBroker is being revised so its dynamics is a bit unpredictable right now


### PR DESCRIPTION
Resolves #212

Final PR in the scope of #212  implementing the changes in the Querey Engine's MeTTa parser. Now Chain operator can be used in any query either as tokens or as metta expressions.

There are examples in `pattern_matching_query_test.cc` but the MeTTa syntax for Chain is like this:

```
tokens_query = {
        "CHAIN", "1", "1", "2",
            "NODE", "Symbol", "\"chimp\"",
            "NODE", "Symbol", "\"ent\"",
            "AND", "2",
                "OR", "2",
                    "LINK_TEMPLATE", "Expression", "3",
                        "NODE", "Symbol", "Inheritance",
                        "VARIABLE", "v1",
                        "NODE", "Symbol", "\"mammal\"",
                    "LINK_TEMPLATE", "Expression", "3",
                        "NODE", "Symbol", "Inheritance",
                        "VARIABLE", "v2",
                        "NODE", "Symbol", "\"mammal\"",
                "LINK_TEMPLATE", "Expression", "3",
                    "NODE", "Symbol", "Similarity",
                    "VARIABLE", "v1",
                    "VARIABLE", "v2"
};
    
metta_query =  "(chain 1 1 2 \"chimp\" \"ent\" (and (or (Inheritance $v1 \"mammal\") (Inheritance $v2 \"mammal\")) (Similarity $v1 $v2)))";
```
