### PR TITLE
[#1099] [FIX] Utils::error() don't log actual file/line where error occured

### DIFF
--- a/src/agents/BaseProxy.cc
+++ b/src/agents/BaseProxy.cc
@@ -33,7 +33,7 @@ bool BaseProxy::finished() {
 
 void BaseProxy::abort() {
     lock_guard<mutex> semaphore(this->api_mutex);
-    // Utils::error("Method not implemented");
+    // RAISE_ERROR("Method not implemented");
     if (!this->command_finished_flag) {
         to_remote_peer(ABORT, {});
     }

--- a/src/agents/BaseQueryProxy.cc
+++ b/src/agents/BaseQueryProxy.cc
@@ -159,7 +159,7 @@ void BaseQueryProxy::recursive_metta_mapping(string handle, map<string, string>&
             // is link
             auto link = dynamic_cast<Link*>(atom.get());
             if (link->type != "Expression") {
-                Utils::error("Link type \"" + link->type + "\" can't be mapped to MeTTa");
+                RAISE_ERROR("Link type \"" + link->type + "\" can't be mapped to MeTTa");
                 table[handle] = "";
                 return;
             }
@@ -183,7 +183,7 @@ void BaseQueryProxy::recursive_metta_mapping(string handle, map<string, string>&
             // is node
             auto node = dynamic_cast<Node*>(atom.get());
             if (node->type != "Symbol") {
-                Utils::error("Node type \"" + node->type + "\" can't be mapped to MeTTa");
+                RAISE_ERROR("Node type \"" + node->type + "\" can't be mapped to MeTTa");
                 table[handle] = "";
                 return;
             }
@@ -225,7 +225,7 @@ void BaseQueryProxy::answer_bundle(const vector<string>& args) {
     lock_guard<mutex> semaphore(this->api_mutex);
     if (!this->is_aborting()) {
         if (args.size() == 0) {
-            Utils::error("Invalid empty query answer bundle");
+            RAISE_ERROR("Invalid empty query answer bundle");
         } else {
             for (auto tokens : args) {
                 QueryAnswer* query_answer = new QueryAnswer();

--- a/src/agents/atomdb_broker/AtomDBProcessor.cc
+++ b/src/agents/atomdb_broker/AtomDBProcessor.cc
@@ -29,7 +29,7 @@ void AtomDBProcessor::run_command(shared_ptr<BusCommandProxy> proxy) {
     LOG_DEBUG("Starting new thread: " << thread_id << " to run command: <" << proxy->get_command()
                                       << ">");
     if (this->query_threads.find(thread_id) != this->query_threads.end()) {
-        Utils::error("Invalid thread id: " + thread_id);
+        RAISE_ERROR("Invalid thread id: " + thread_id);
     } else {
         shared_ptr<StoppableThread> stoppable_thread = make_shared<StoppableThread>(thread_id);
         stoppable_thread->attach(new thread(
@@ -48,7 +48,7 @@ void AtomDBProcessor::thread_process_one_query(shared_ptr<StoppableThread> monit
                 Utils::sleep();
             }
         } else {
-            Utils::error("Invalid command " + command + " in AtomDBProcessor");
+            RAISE_ERROR("Invalid command " + command + " in AtomDBProcessor");
         }
     } catch (const std::runtime_error& exception) {
         proxy->raise_error_on_peer(exception.what());

--- a/src/agents/atomdb_broker/AtomDBProxy.cc
+++ b/src/agents/atomdb_broker/AtomDBProxy.cc
@@ -78,7 +78,7 @@ vector<string> AtomDBProxy::add_atoms(const vector<Atom*>& atoms, bool use_strea
         } else if (dynamic_cast<Link*>(atom)) {
             atom_type = LINK;
         } else {
-            Utils::error("Invalid Atom type");
+            RAISE_ERROR("Invalid Atom type");
         }
 
         args.insert(args.begin(), atom_type);
@@ -154,7 +154,7 @@ bool AtomDBProxy::from_remote_peer(const string& command, const vector<string>& 
         this->delete_atoms_callback(args);
         return true;
     } else {
-        Utils::error("Invalid AtomDBProxy command: <" + command + ">");
+        RAISE_ERROR("Invalid AtomDBProxy command: <" + command + ">");
         return false;
     }
 }
@@ -176,7 +176,7 @@ void AtomDBProxy::add_atoms_callback(const vector<string>& tokens) {
 void AtomDBProxy::delete_atoms_callback(const vector<string>& args) {
     try {
         if (args.size() < 1) {
-            Utils::error("No handles provided for deletion");
+            RAISE_ERROR("No handles provided for deletion");
         }
         vector<string> handles(args.begin(), args.end() - 1);
         bool delete_link_targets = args.back() == "1";
@@ -208,7 +208,7 @@ void AtomDBProxy::process_atom_batches() {
                 }
                 auto atom = (Atom*) this->processing_queue->dequeue();
                 if (atom == nullptr) {
-                    Utils::error("Dequeued null atom pointer");
+                    RAISE_ERROR("Dequeued null atom pointer");
                 }
                 atoms.push_back(atom);
             }

--- a/src/agents/context_broker/ContextBrokerProcessor.cc
+++ b/src/agents/context_broker/ContextBrokerProcessor.cc
@@ -44,7 +44,7 @@ void ContextBrokerProcessor::run_command(shared_ptr<BusCommandProxy> proxy) {
     LOG_DEBUG("Starting new thread: " << thread_id << " to run command: <" << proxy->get_command()
                                       << ">");
     if (this->query_threads.find(thread_id) != this->query_threads.end()) {
-        Utils::error("Invalid thread id: " + thread_id);
+        RAISE_ERROR("Invalid thread id: " + thread_id);
     } else {
         shared_ptr<StoppableThread> stoppable_thread = make_shared<StoppableThread>(thread_id);
         stoppable_thread->attach(new thread(&ContextBrokerProcessor::thread_process_one_query,
@@ -62,14 +62,14 @@ void ContextBrokerProcessor::thread_process_one_query(shared_ptr<StoppableThread
                                                       shared_ptr<ContextBrokerProxy> proxy) {
     try {
         if (proxy->args.size() < 2) {
-            Utils::error("Syntax error in query command. Missing implicit parameters.");
+            RAISE_ERROR("Syntax error in query command. Missing implicit parameters.");
         }
 
         proxy->untokenize(proxy->args);
 
         // Do not allow use_cache == false and enforce_cache_recreation == true
         if (!proxy->get_use_cache() && proxy->get_enforce_cache_recreation()) {
-            Utils::error("use_cache == false and enforce_cache_recreation == true is not allowed");
+            RAISE_ERROR("use_cache == false and enforce_cache_recreation == true is not allowed");
         }
 
         string command = proxy->get_command();
@@ -82,7 +82,7 @@ void ContextBrokerProcessor::thread_process_one_query(shared_ptr<StoppableThread
 
             this->create_context(monitor, proxy);
         } else {
-            Utils::error("Invalid command " + command + " in ContextBrokerProcessor");
+            RAISE_ERROR("Invalid command " + command + " in ContextBrokerProcessor");
         }
     } catch (const std::runtime_error& exception) {
         proxy->raise_error_on_peer(exception.what());
@@ -197,7 +197,7 @@ void ContextBrokerProcessor::set_attention_broker_parameters(double rent_rate,
 
 static inline void read_line(ifstream& file, string& line) {
     if (!getline(file, line)) {
-        Utils::error("Error reading a line from cache file");
+        RAISE_ERROR("Error reading a line from cache file");
     }
 }
 

--- a/src/agents/context_broker/ContextBrokerProxy.cc
+++ b/src/agents/context_broker/ContextBrokerProxy.cc
@@ -221,7 +221,7 @@ bool ContextBrokerProxy::from_remote_peer(const string& command, const vector<st
     } else if (command == ATTENTION_BROKER_SET_PARAMETERS_FINISHED) {
         this->ongoing_attention_broker_set_parameters = false;
     } else {
-        Utils::error("Invalid ContextBrokerProxy command: <" + command + ">");
+        RAISE_ERROR("Invalid ContextBrokerProxy command: <" + command + ">");
         return false;
     }
     return true;

--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -213,7 +213,7 @@ void QueryEvolutionProcessor::apply_elitism(
     if (count > 0) {
         if (count > population.size()) {
             RAISE_ERROR("Invalid evolution parameters. Elitism count: " + std::to_string(count) +
-                         " population size: " + std::to_string(population.size()));
+                        " population size: " + std::to_string(population.size()));
         } else {
             LOG_DEBUG("Selecting " << count << " individuals by elitism.");
             selected.insert(selected.begin(), population.begin(), population.begin() + count);
@@ -249,7 +249,7 @@ void QueryEvolutionProcessor::select_best_individuals(
     if (count > 0) {
         if (count > population_size) {
             RAISE_ERROR("Invalid evolution parameters. Selection count: " + std::to_string(count) +
-                         " population size: " + std::to_string(population_size));
+                        " population size: " + std::to_string(population_size));
         } else if (count == population_size) {
             selected.insert(selected.begin(), population.begin(), population.end());
             population.clear();

--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -40,7 +40,7 @@ void QueryEvolutionProcessor::run_command(shared_ptr<BusCommandProxy> proxy) {
     LOG_DEBUG("Starting new thread: " << thread_id << " to run command: <" << proxy->get_command()
                                       << ">");
     if (this->query_threads.find(thread_id) != this->query_threads.end()) {
-        Utils::error("Invalid thread id: " + thread_id);
+        RAISE_ERROR("Invalid thread id: " + thread_id);
     } else {
         shared_ptr<StoppableThread> stoppable_thread = make_shared<StoppableThread>(thread_id);
         stoppable_thread->attach(new thread(
@@ -56,7 +56,7 @@ void QueryEvolutionProcessor::thread_process_one_query(shared_ptr<StoppableThrea
                                                        shared_ptr<QueryEvolutionProxy> proxy) {
     try {
         if (proxy->args.size() < 2) {
-            Utils::error("Syntax error in query command. Missing implicit parameters.");
+            RAISE_ERROR("Syntax error in query command. Missing implicit parameters.");
         }
         proxy->untokenize(proxy->args);
         string command = proxy->get_command();
@@ -64,7 +64,7 @@ void QueryEvolutionProcessor::thread_process_one_query(shared_ptr<StoppableThrea
             LOG_INFO("Proxy: " << proxy->to_string());
             this->evolve_query(monitor, proxy);
         } else {
-            Utils::error("Invalid command " + command + " in QueryEvolutionProcessor");
+            RAISE_ERROR("Invalid command " + command + " in QueryEvolutionProcessor");
         }
     } catch (const std::runtime_error& exception) {
         proxy->raise_error_on_peer(exception.what());
@@ -176,7 +176,7 @@ void QueryEvolutionProcessor::sample_population(
         LOG_INFO("Evaluating fitness remotelly");
         if (answer_bundle_vector.size() >
             proxy->parameters.get<unsigned int>(BaseQueryProxy::MAX_BUNDLE_SIZE)) {
-            Utils::error(
+            RAISE_ERROR(
                 "Expected POPULATION_SIZE <= MAX_BUNDLE_SIZE in order to use remote fitness evaluation");
             return;
         }
@@ -186,7 +186,7 @@ void QueryEvolutionProcessor::sample_population(
         }
         vector<float> fitness_bundle = proxy->get_remotely_evaluated_fitness();
         if (fitness_bundle.size() != population_size) {
-            Utils::error("Invalid fitness bundle of size: " + std::to_string(fitness_bundle.size()));
+            RAISE_ERROR("Invalid fitness bundle of size: " + std::to_string(fitness_bundle.size()));
             return;
         }
         for (unsigned int i = 0; i < population_size; i++) {
@@ -212,7 +212,7 @@ void QueryEvolutionProcessor::apply_elitism(
     unsigned int count = (unsigned int) std::lround(elitism_rate * population.size());
     if (count > 0) {
         if (count > population.size()) {
-            Utils::error("Invalid evolution parameters. Elitism count: " + std::to_string(count) +
+            RAISE_ERROR("Invalid evolution parameters. Elitism count: " + std::to_string(count) +
                          " population size: " + std::to_string(population.size()));
         } else {
             LOG_DEBUG("Selecting " << count << " individuals by elitism.");
@@ -248,7 +248,7 @@ void QueryEvolutionProcessor::select_best_individuals(
 
     if (count > 0) {
         if (count > population_size) {
-            Utils::error("Invalid evolution parameters. Selection count: " + std::to_string(count) +
+            RAISE_ERROR("Invalid evolution parameters. Selection count: " + std::to_string(count) +
                          " population size: " + std::to_string(population_size));
         } else if (count == population_size) {
             selected.insert(selected.begin(), population.begin(), population.end());
@@ -306,10 +306,10 @@ void QueryEvolutionProcessor::correlate_similar(shared_ptr<QueryEvolutionProxy> 
     vector<pair<QueryAnswerElement, QueryAnswerElement>> correlation_mappings =
         proxy->get_correlation_mappings();
     if (correlation_queries.size() != correlation_replacements.size()) {
-        Utils::error("Invalid correlation queries/replacements. Proxy: " + proxy->to_string());
+        RAISE_ERROR("Invalid correlation queries/replacements. Proxy: " + proxy->to_string());
     }
     if (correlation_mappings.size() == 0) {
-        Utils::error("Invalid correlation mappings. Proxy: " + proxy->to_string());
+        RAISE_ERROR("Invalid correlation mappings. Proxy: " + proxy->to_string());
     }
 
     // Rewrite correlation query using handles from original query answer
@@ -317,7 +317,7 @@ void QueryEvolutionProcessor::correlate_similar(shared_ptr<QueryEvolutionProxy> 
         query_tokens.clear();
         if (proxy->parameters.get<bool>(BaseQueryProxy::USE_METTA_AS_QUERY_TOKENS)) {
             if (correlation_queries[i].size() != 1) {
-                Utils::error("Invalid MeTTa expression as correlation query");
+                RAISE_ERROR("Invalid MeTTa expression as correlation query");
                 return;
             }
             string expression = correlation_queries[i][0];
@@ -337,7 +337,7 @@ void QueryEvolutionProcessor::correlate_similar(shared_ptr<QueryEvolutionProxy> 
                 string token = correlation_queries[i][cursor++];
                 if (token == LinkSchema::UNTYPED_VARIABLE) {
                     if (cursor == size) {
-                        Utils::error("Invalid correlation_tokens");
+                        RAISE_ERROR("Invalid correlation_tokens");
                         return;
                     }
                     token = correlation_queries[i][cursor++];
@@ -389,7 +389,7 @@ void QueryEvolutionProcessor::stimulate(shared_ptr<QueryEvolutionProxy> proxy,
     vector<pair<QueryAnswerElement, QueryAnswerElement>> correlation_mappings =
         proxy->get_correlation_mappings();
     if (correlation_mappings.size() == 0) {
-        Utils::error("Invalid correlation mappings. Proxy: " + proxy->to_string());
+        RAISE_ERROR("Invalid correlation mappings. Proxy: " + proxy->to_string());
     }
     unsigned int importance_tokens =
         proxy->parameters.get<unsigned int>(QueryEvolutionProxy::TOTAL_ATTENTION_TOKENS);

--- a/src/agents/evolution/QueryEvolutionProxy.cc
+++ b/src/agents/evolution/QueryEvolutionProxy.cc
@@ -214,13 +214,13 @@ void QueryEvolutionProxy::untokenize(vector<string>& tokens) {
 
 float QueryEvolutionProxy::compute_fitness(shared_ptr<QueryAnswer> answer) {
     if (this->fitness_function_tag == "") {
-        Utils::error("Invalid empty fitness function tag");
+        RAISE_ERROR("Invalid empty fitness function tag");
         return 0;
     } else if (this->fitness_function_object == nullptr) {
         if (this->fitness_function_tag == FitnessFunctionRegistry::REMOTE_FUNCTION) {
-            Utils::error("Invalid call to remote function");
+            RAISE_ERROR("Invalid call to remote function");
         } else {
-            Utils::error("Fitness function is not set up");
+            RAISE_ERROR("Fitness function is not set up");
         }
         return 0;
     } else {
@@ -250,10 +250,10 @@ void QueryEvolutionProxy::new_population_sampled(
 void QueryEvolutionProxy::set_fitness_function_tag(const string& tag) {
     lock_guard<mutex> semaphore(this->api_mutex);
     if ((this->fitness_function_tag != "") && (tag != this->fitness_function_tag)) {
-        Utils::error("Invalid reset of fitness function: " + this->fitness_function_tag + " --> " + tag);
+        RAISE_ERROR("Invalid reset of fitness function: " + this->fitness_function_tag + " --> " + tag);
     } else {
         if (tag == "") {
-            Utils::error("Invalid empty fitness function tag");
+            RAISE_ERROR("Invalid empty fitness function tag");
         }
         this->fitness_function_tag = tag;
         if (tag != FitnessFunctionRegistry::REMOTE_FUNCTION) {
@@ -317,7 +317,7 @@ bool QueryEvolutionProxy::from_remote_peer(const string& command, const vector<s
         eval_fitness_response(args);
         return true;
     } else {
-        Utils::error("Invalid QueryEvolutionProxy command: <" + command + ">");
+        RAISE_ERROR("Invalid QueryEvolutionProxy command: <" + command + ">");
         return false;
     }
 }
@@ -326,7 +326,7 @@ void QueryEvolutionProxy::eval_fitness(const vector<string>& args) {
     lock_guard<mutex> semaphore(this->api_mutex);
     if (!this->is_aborting()) {
         if (args.size() == 0) {
-            Utils::error("Invalid empty query answer bundle");
+            RAISE_ERROR("Invalid empty query answer bundle");
         } else {
             vector<string> fitness_bundle;
             for (auto tokens : args) {
@@ -344,7 +344,7 @@ void QueryEvolutionProxy::eval_fitness_response(const vector<string>& args) {
     lock_guard<mutex> semaphore(this->api_mutex);
     if (!this->is_aborting()) {
         if (args.size() == 0) {
-            Utils::error("Invalid empty fitness value bundle");
+            RAISE_ERROR("Invalid empty fitness value bundle");
         } else {
             for (auto value_str : args) {
                 float fitness = Utils::string_to_float(value_str);

--- a/src/agents/evolution/fitness_functions/CountLetterFunction.cc
+++ b/src/agents/evolution/fitness_functions/CountLetterFunction.cc
@@ -12,7 +12,7 @@ CountLetterFunction::CountLetterFunction() { this->db = AtomDBSingleton::get_ins
 
 float CountLetterFunction::eval(shared_ptr<QueryAnswer> query_answer) {
     if (query_answer->get_handles_size() != 1) {
-        Utils::error("Invalid answer in CountLetterFunction");
+        RAISE_ERROR("Invalid answer in CountLetterFunction");
         return 0;
     } else {
         shared_ptr<Link> sentence_link;

--- a/src/agents/evolution/fitness_functions/FitnessFunctionRegistry.cc
+++ b/src/agents/evolution/fitness_functions/FitnessFunctionRegistry.cc
@@ -19,7 +19,7 @@ map<string, shared_ptr<FitnessFunction>> FitnessFunctionRegistry::FUNCTION;
 
 void FitnessFunctionRegistry::initialize_statics() {
     if (INITIALIZED) {
-        Utils::error(
+        RAISE_ERROR(
             "FitnessFunctionRegistry already initialized. "
             "FitnessFunctionRegistry::init() should be called only once.");
     } else {
@@ -39,15 +39,15 @@ void FitnessFunctionRegistry::initialize_statics() {
 shared_ptr<FitnessFunction> FitnessFunctionRegistry::function(const string& tag) {
     if (INITIALIZED) {
         if (tag == REMOTE_FUNCTION) {
-            Utils::error("Invalid use of reserved fitness function tag: " + tag);
+            RAISE_ERROR("Invalid use of reserved fitness function tag: " + tag);
         }
         if (FUNCTION.find(tag) != FUNCTION.end()) {
             return FUNCTION[tag];
         } else {
-            Utils::error("Unkown fitness function: " + tag);
+            RAISE_ERROR("Unkown fitness function: " + tag);
         }
     } else {
-        Utils::error(
+        RAISE_ERROR(
             "FitnessFunctionRegistry isn't initialized. Call "
             "FitnessFunctionRegistry::initialize_statics() first.");
     }

--- a/src/agents/inference_agent/InferenceAgent.cc
+++ b/src/agents/inference_agent/InferenceAgent.cc
@@ -31,7 +31,7 @@ InferenceAgent::~InferenceAgent() {
 
 shared_ptr<InferenceRequest> InferenceAgent::build_inference_request(const vector<string>& request) {
     if (!inference_request_validator.validate(request)) {
-        Utils::error("Invalid inference request, failed to parse: " + Utils::join(request, ' '));
+        RAISE_ERROR("Invalid inference request, failed to parse: " + Utils::join(request, ' '));
     }
     shared_ptr<InferenceRequest> inference_request;
     string inference_command = request.front();
@@ -39,7 +39,7 @@ shared_ptr<InferenceRequest> InferenceAgent::build_inference_request(const vecto
     string second_handle = request[2];
     int max_proof_length = Utils::string_to_int(request[3]);
     if (max_proof_length > max_proof_length_limit) {
-        Utils::error("Max proof length exceeded");
+        RAISE_ERROR("Max proof length exceeded");
     }
     string context = request[4];
     if (inference_command == PROOF_OF_IMPLICATION) {
@@ -51,7 +51,7 @@ shared_ptr<InferenceRequest> InferenceAgent::build_inference_request(const vecto
         inference_request =
             make_shared<ProofOfEquivalence>(first_handle, second_handle, max_proof_length, context);
     } else {
-        Utils::error("Invalid inference command");
+        RAISE_ERROR("Invalid inference command");
     }
     return inference_request;
 }
@@ -163,7 +163,7 @@ void InferenceAgent::stop() {
 bool InferenceAgent::is_lca_requests_finished(shared_ptr<InferenceRequest> inference_request) {
     auto it = link_creation_proxy_map.find(inference_request->get_id());
     if (it == link_creation_proxy_map.end()) {
-        Utils::error("No link creation requests found for inference request ID: " +
+        RAISE_ERROR("No link creation requests found for inference request ID: " +
                      inference_request->get_id());
     }
     for (const auto& proxy : it->second) {
@@ -343,7 +343,7 @@ void InferenceAgent::send_update_attention_allocation_request(
 
 void InferenceAgent::process_inference_request(const vector<string>& request, const string& request_id) {
     if (request.empty()) {
-        Utils::error("Empty inference request");
+        RAISE_ERROR("Empty inference request");
     }
     LOG_DEBUG("Processing inference request: " << Utils::join(request, ' '));
     auto inference_request = build_inference_request(request);
@@ -353,13 +353,13 @@ void InferenceAgent::process_inference_request(const vector<string>& request, co
 
 void InferenceAgent::process_inference_request(shared_ptr<InferenceProxy> proxy) {
     if (proxy == nullptr) {
-        Utils::error("Invalid inference proxy");
+        RAISE_ERROR("Invalid inference proxy");
     }
     LOG_DEBUG("Processing inference request: " << Utils::join(proxy->get_args(), ' '));
     string request_id = proxy->peer_id() + to_string(proxy->get_serial());
     inference_proxy_map[request_id] = proxy;
     if (proxy->get_args().empty()) {
-        Utils::error("Empty inference request");
+        RAISE_ERROR("Empty inference request");
     }
     LOG_DEBUG("Inference Request:");
     LOG_DEBUG("  Request ID: " << request_id);
@@ -390,7 +390,7 @@ void InferenceAgent::process_inference_request(shared_ptr<InferenceProxy> proxy)
 
 void InferenceAgent::process_inference_abort_request(shared_ptr<InferenceRequest> inference_request) {
     if (inference_request == nullptr) {
-        Utils::error("Invalid inference request");
+        RAISE_ERROR("Invalid inference request");
     }
     auto request_id = inference_request->get_id();
     LOG_DEBUG("Evolution proxy finished for request ID: " << request_id);

--- a/src/agents/inference_agent/InferenceAgent.cc
+++ b/src/agents/inference_agent/InferenceAgent.cc
@@ -164,7 +164,7 @@ bool InferenceAgent::is_lca_requests_finished(shared_ptr<InferenceRequest> infer
     auto it = link_creation_proxy_map.find(inference_request->get_id());
     if (it == link_creation_proxy_map.end()) {
         RAISE_ERROR("No link creation requests found for inference request ID: " +
-                     inference_request->get_id());
+                    inference_request->get_id());
     }
     for (const auto& proxy : it->second) {
         if (!proxy->finished()) {

--- a/src/agents/link_creation_agent/LinkCreateTemplate.cc
+++ b/src/agents/link_creation_agent/LinkCreateTemplate.cc
@@ -16,7 +16,7 @@ using namespace std;
 
 static string get_token(vector<string>& link_template, size_t cursor) {
     if (cursor >= link_template.size()) {
-        Utils::error("Can not get token: Invalid arguments");
+        RAISE_ERROR("Can not get token: Invalid arguments");
     }
     return link_template[cursor];
 }
@@ -29,7 +29,7 @@ LinkCreateTemplate::LinkCreateTemplate(const string& link_type) {
 
 static vector<string> parse_sub_custom_field(vector<string>& link_template, size_t& cursor) {
     if (get_token(link_template, cursor) != "CUSTOM_FIELD" || link_template.size() < cursor + 3)
-        Utils::error("Can not create Custom Field: Invalid arguments");
+        RAISE_ERROR("Can not create Custom Field: Invalid arguments");
     vector<string> custom_field_args;
     int custom_field_size = Utils::string_to_int(get_token(link_template, cursor + 2));
     custom_field_args.push_back(get_token(link_template, cursor));      // CUSTOM_FIELD
@@ -58,7 +58,7 @@ static vector<string> parse_sub_custom_field(vector<string>& link_template, size
 
 static vector<string> parse_sub_link_template(vector<string>& link_template, size_t& cursor) {
     if (get_token(link_template, cursor) != "LINK_CREATE" || link_template.size() < cursor + 4)
-        Utils::error("Can not create Link Template: Invalid arguments");
+        RAISE_ERROR("Can not create Link Template: Invalid arguments");
     int sub_link_template_size = Utils::string_to_int(get_token(link_template, cursor + 2));
     int sub_link_custom_field_size = Utils::string_to_int(get_token(link_template, cursor + 3));
     int custom_field_value_size = 0;
@@ -136,7 +136,7 @@ LinkCreateTemplate::LinkCreateTemplate(vector<string>& link_template) {
         }
     }
     if (this->targets.size() != link_template_size || this->custom_fields.size() != custom_field_size) {
-        Utils::error("Can not create Link Template: Invalid arguments");
+        RAISE_ERROR("Can not create Link Template: Invalid arguments");
     }
 }
 
@@ -184,7 +184,7 @@ CustomField::CustomField(const string& name) { this->name = name; }
 
 CustomField::CustomField(vector<string>& custom_fields) {
     if (get_token(custom_fields, 0) != "CUSTOM_FIELD")
-        Utils::error("Can not create Custom Field: Invalid arguments");
+        RAISE_ERROR("Can not create Custom Field: Invalid arguments");
 
     size_t cursor = 0;
     string custom_field_name = get_token(custom_fields, 1);
@@ -303,7 +303,7 @@ vector<string> CustomField::tokenize() { return Utils::split(this->to_string(), 
 
 LinkCreateTemplateList::LinkCreateTemplateList(vector<string> link_template) {
     if (get_token(link_template, 0) != "LIST")
-        Utils::error("Can not create Link Template List: Invalid arguments");
+        RAISE_ERROR("Can not create Link Template List: Invalid arguments");
 
     size_t cursor = 0;
     size_t link_template_size = Utils::string_to_int(get_token(link_template, 1));
@@ -313,7 +313,7 @@ LinkCreateTemplateList::LinkCreateTemplateList(vector<string> link_template) {
         this->templates.push_back(LinkCreateTemplate(sub_link_template));
     }
     if (this->templates.size() != link_template_size) {
-        Utils::error("Can not create Link Template List: Invalid arguments");
+        RAISE_ERROR("Can not create Link Template List: Invalid arguments");
     }
 }
 

--- a/src/agents/link_creation_agent/LinkCreationAgent.cc
+++ b/src/agents/link_creation_agent/LinkCreationAgent.cc
@@ -242,10 +242,10 @@ shared_ptr<LinkCreationAgentRequest> LinkCreationAgent::create_request(
             LinkCreationRequestProxy::QUERY_INTERVAL, requests_interval_seconds);
         lca_request->current_interval = request_interval;
         if (lca_request->link_template.size() == 0) {
-            Utils::error("Link template cannot be empty");
+            RAISE_ERROR("Link template cannot be empty");
         }
         if (lca_request->id.empty()) {
-            Utils::error("Request ID cannot be empty");
+            RAISE_ERROR("Request ID cannot be empty");
         }
         if (lca_request->repeat == 0) {
             lca_request->infinite = true;
@@ -261,14 +261,14 @@ shared_ptr<LinkCreationAgentRequest> LinkCreationAgent::create_request(
         return lca_request;
     } catch (exception& e) {
         LOG_ERROR("Error parsing request from proxy: " << string(e.what()));
-        Utils::error("Invalid request format from proxy: " + string(e.what()));
+        RAISE_ERROR("Invalid request format from proxy: " + string(e.what()));
     }
     return nullptr;
 }
 
 void LinkCreationAgent::process_request(shared_ptr<LinkCreationRequestProxy> proxy) {
     if (proxy == nullptr) {
-        Utils::error("Invalid link creation request proxy");
+        RAISE_ERROR("Invalid link creation request proxy");
     }
     LOG_DEBUG("Processing link creation request: " << Utils::join(proxy->get_args(), ' '));
     string request_id = proxy->peer_id() + to_string(proxy->get_serial());

--- a/src/agents/link_creation_agent/LinkProcessor.h
+++ b/src/agents/link_creation_agent/LinkProcessor.h
@@ -81,7 +81,7 @@ class LinkProcessor {
             counts = {};
             count_intersection = 0;
             count_union = 0;
-            Utils::error("Invalid number of queries for compute_counts");
+            RAISE_ERROR("Invalid number of queries for compute_counts");
         }
         vector<shared_ptr<PatternMatchingQueryProxy>> query_proxies;
         for (const auto& query : queries) {
@@ -92,7 +92,7 @@ class LinkProcessor {
                 query_count_proxy->parameters[BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG] = true;
                 query_proxies.push_back(query_count_proxy);
             } catch (const exception& e) {
-                Utils::error("Exception: " + string(e.what()));
+                RAISE_ERROR("Exception: " + string(e.what()));
             }
         }
 

--- a/src/agents/link_creation_agent/MettaTemplateProcessor.cc
+++ b/src/agents/link_creation_agent/MettaTemplateProcessor.cc
@@ -22,7 +22,7 @@ static string parse_metta_expression(string metta_expression,
         if (handle_to_metta.find(assignment_pair.first) == handle_to_metta.end()) {
             auto atom = atomdb->get_atom(assignment_pair.second);
             if (atom == nullptr) {
-                Utils::error("Atom with handle " + assignment_pair.second +
+                RAISE_ERROR("Atom with handle " + assignment_pair.second +
                              " not found in AtomDB while creating missing atoms for link creation.");
                 continue;
             }
@@ -59,13 +59,13 @@ static void create_missing_atoms_in_atomdb(shared_ptr<MettaParserActions> parser
             parser_actions->handle_to_metta_expression.end(),
             [&metta_expression_cp](const auto& pair) { return pair.second == metta_expression_cp; });
         if (handle == parser_actions->handle_to_metta_expression.end()) {
-            Utils::error("Could not find handle for metta expression: " + metta_expression_cp);
+            RAISE_ERROR("Could not find handle for metta expression: " + metta_expression_cp);
             continue;
         }
         auto link = parser_actions->handle_to_atom[handle->first];
         try {
             if (dynamic_pointer_cast<Link>(link) == nullptr) {
-                Utils::error("Parsed atom is not a Link for metta expression: " + metta_expression_cp);
+                RAISE_ERROR("Parsed atom is not a Link for metta expression: " + metta_expression_cp);
                 continue;
             }
             atomdb->add_link(dynamic_pointer_cast<Link>(link).get(), false);
@@ -80,7 +80,7 @@ vector<shared_ptr<Link>> MettaTemplateProcessor::process_query(shared_ptr<QueryA
                                                                optional<vector<string>> extra_params) {
     vector<shared_ptr<Link>> links;
     if (extra_params == nullopt) {
-        Utils::error("Invalid link template");
+        RAISE_ERROR("Invalid link template");
     }
     auto atomdb = AtomDBSingleton::get_instance();
     for (const auto& param : extra_params.value()) {
@@ -94,12 +94,12 @@ vector<shared_ptr<Link>> MettaTemplateProcessor::process_query(shared_ptr<QueryA
         parser.parse(true);
         create_missing_atoms_in_atomdb(parser_actions);
         if (parser_actions->element_stack.size() == 0) {
-            Utils::error("Invalid MeTTa link template. Parser returned an empty stack.");
+            RAISE_ERROR("Invalid MeTTa link template. Parser returned an empty stack.");
             continue;
         } else {
             auto link = parser_actions->element_stack.top();
             if (dynamic_pointer_cast<Link>(link) == nullptr) {
-                Utils::error("Parsed atom is not a Link for metta expression: " + metta_expression);
+                RAISE_ERROR("Parsed atom is not a Link for metta expression: " + metta_expression);
                 continue;
             }
             LOG_DEBUG("Parsed MeTTa link template: " << metta_expression

--- a/src/agents/link_creation_agent/MettaTemplateProcessor.cc
+++ b/src/agents/link_creation_agent/MettaTemplateProcessor.cc
@@ -23,7 +23,7 @@ static string parse_metta_expression(string metta_expression,
             auto atom = atomdb->get_atom(assignment_pair.second);
             if (atom == nullptr) {
                 RAISE_ERROR("Atom with handle " + assignment_pair.second +
-                             " not found in AtomDB while creating missing atoms for link creation.");
+                            " not found in AtomDB while creating missing atoms for link creation.");
                 continue;
             }
             handle_to_metta[assignment_pair.second] = atom->metta_representation(*atomdb.get());

--- a/src/agents/link_creation_agent/TemplateProcessor.cc
+++ b/src/agents/link_creation_agent/TemplateProcessor.cc
@@ -13,7 +13,7 @@ vector<shared_ptr<Link>> LinkTemplateProcessor::process_query(shared_ptr<QueryAn
                                                               optional<vector<string>> extra_params) {
     vector<shared_ptr<Link>> links;
     if (extra_params == nullopt) {
-        Utils::error("Invalid link template");
+        RAISE_ERROR("Invalid link template");
     }
     if (extra_params.value().front() == "LIST") {
         LinkCreateTemplateList link_create_template_list(extra_params.value());

--- a/src/agents/query_engine/MettaParserActions.cc
+++ b/src/agents/query_engine/MettaParserActions.cc
@@ -124,8 +124,8 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
     unsigned int arity = this->current_expression_size;
     if (this->element_stack.size() < arity) {
         RAISE_ERROR("Invalid query expression: too few arguments for expression. Expected: " +
-                     std::to_string(arity) +
-                     " Stack size: " + std::to_string(this->element_stack.size()));
+                    std::to_string(arity) +
+                    " Stack size: " + std::to_string(this->element_stack.size()));
         return;
     }
     LOG_DEBUG("Arity: " + std::to_string(arity));

--- a/src/agents/query_engine/MettaParserActions.cc
+++ b/src/agents/query_engine/MettaParserActions.cc
@@ -44,7 +44,7 @@ void MettaParserActions::symbol(const string& name) {
     } else {
         if ((this->current_expression_type == AND) || (this->current_expression_type == OR) ||
             (this->current_expression_type == CHAIN)) {
-            Utils::error("Invalid query expression: AND/OR/CHAIN can't operate symbols.");
+            RAISE_ERROR("Invalid query expression: AND/OR/CHAIN can't operate symbols.");
             return;
         }
         this->current_expression_size++;
@@ -55,7 +55,7 @@ void MettaParserActions::symbol(const string& name) {
 void MettaParserActions::variable(const string& value) {
     ParserActions::variable(value);
     if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid query expression: AND/OR can't operate variables.");
+        RAISE_ERROR("Invalid query expression: AND/OR can't operate variables.");
         return;
     }
     if (this->current_expression_type == LINK) {
@@ -68,7 +68,7 @@ void MettaParserActions::variable(const string& value) {
 void MettaParserActions::literal(const string& value) {
     ParserActions::literal(value);
     if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid query expression: AND/OR can't operate literals.");
+        RAISE_ERROR("Invalid query expression: AND/OR can't operate literals.");
         return;
     }
     this->current_expression_size++;
@@ -78,7 +78,7 @@ void MettaParserActions::literal(const string& value) {
 void MettaParserActions::literal(int value) {
     ParserActions::literal(value);
     if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid query expression: AND/OR can't operate literals.");
+        RAISE_ERROR("Invalid query expression: AND/OR can't operate literals.");
         return;
     }
     this->current_expression_size++;
@@ -90,7 +90,7 @@ void MettaParserActions::literal(float value) {
     ParserActions::literal(value);
     if ((this->current_expression_type == AND) || (this->current_expression_type == OR) ||
         (this->current_expression_type == CHAIN)) {
-        Utils::error("Invalid query expression: AND/OR/CHAIN can't operate float literals.");
+        RAISE_ERROR("Invalid query expression: AND/OR/CHAIN can't operate float literals.");
         return;
     }
     this->current_expression_size++;
@@ -109,10 +109,10 @@ void MettaParserActions::expression_begin() {
 shared_ptr<Terminal> MettaParserActions::unstack_terminal(bool node_flag) {
     shared_ptr<Terminal> terminal = dynamic_pointer_cast<Terminal>(this->element_stack.top());
     if (terminal == nullptr) {
-        Utils::error("Expecting Terminal. Got: " + this->element_stack.top()->to_string());
+        RAISE_ERROR("Expecting Terminal. Got: " + this->element_stack.top()->to_string());
     } else {
         if (node_flag && (!terminal->is_node)) {
-            Utils::error("Expecting Node. Got: " + this->element_stack.top()->to_string());
+            RAISE_ERROR("Expecting Node. Got: " + this->element_stack.top()->to_string());
         }
     }
     this->element_stack.pop();
@@ -123,7 +123,7 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
     ParserActions::expression_end(toplevel, metta_expression);
     unsigned int arity = this->current_expression_size;
     if (this->element_stack.size() < arity) {
-        Utils::error("Invalid query expression: too few arguments for expression. Expected: " +
+        RAISE_ERROR("Invalid query expression: too few arguments for expression. Expected: " +
                      std::to_string(arity) +
                      " Stack size: " + std::to_string(this->element_stack.size()));
         return;
@@ -138,7 +138,7 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
         reverse(targets.begin(), targets.end());
         if (this->current_expression_type == LINK) {
             if (toplevel) {
-                Utils::error("Invalid query expression: a link is not a valid pattern matching query");
+                RAISE_ERROR("Invalid query expression: a link is not a valid pattern matching query");
                 return;
             }
             LOG_DEBUG("Pushing LINK");
@@ -172,7 +172,7 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
                     if (this->element_stack.top()->is_operator) {
                         clauses[i] = this->element_stack.top();
                     } else {
-                        Utils::error("All AND clauses are supposed to be LinkTemplate or Operator");
+                        RAISE_ERROR("All AND clauses are supposed to be LinkTemplate or Operator");
                         return;
                     }
                 }
@@ -191,7 +191,7 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
                 this->element_stack.push(new_operator);
             }
         } else {
-            Utils::error("Invalid query expression: 'and' and 'or' require exactly two arguments.");
+            RAISE_ERROR("Invalid query expression: 'and' and 'or' require exactly two arguments.");
             return;
         }
     } else if (this->current_expression_type == CHAIN) {
@@ -235,7 +235,7 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
             Chain::SearchDirection search_direction;
             if (target->is_variable) {
                 if (source->is_variable) {
-                    Utils::error("Invalid CHAIN arguments. source and target are variables.");
+                    RAISE_ERROR("Invalid CHAIN arguments. source and target are variables.");
                 } else {
                     search_direction = Chain::FORWARD;
                     incomplete_flag = true;
@@ -266,11 +266,11 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_expre
             LOG_DEBUG("Building CHAIN operator... DONE");
             this->element_stack.push(chain_operator);
         } else {
-            Utils::error("Invalid query expression: 'chain' requires exactly six arguments.");
+            RAISE_ERROR("Invalid query expression: 'chain' requires exactly six arguments.");
             return;
         }
     } else {
-        Utils::error("Invalid query expression: unknown expression type");
+        RAISE_ERROR("Invalid query expression: unknown expression type");
         return;
     }
 

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -395,7 +395,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link_template(
                 if (element_stack.top()->is_operator) {                                           \
                     clauses[i] = element_stack.top();                                             \
                 } else {                                                                          \
-                    RAISE_ERROR("All AND clauses are supposed to be LinkTemplate or Operator");  \
+                    RAISE_ERROR("All AND clauses are supposed to be LinkTemplate or Operator");   \
                 }                                                                                 \
             }                                                                                     \
             element_stack.pop();                                                                  \
@@ -410,8 +410,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_and(
     const vector<string> query_tokens = proxy->get_query_tokens();
     unsigned int num_clauses = std::stoi(query_tokens[cursor + 1]);
     if (element_stack.size() < num_clauses) {
-        RAISE_ERROR(
-            "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for AND");
+        RAISE_ERROR("PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for AND");
     }
     // clang-format off
     switch (num_clauses) {
@@ -449,7 +448,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_and(
                     clauses[i] = element_stack.top();                                             \
                     LOG_DEBUG("OR input[" << i << "]: " << element_stack.top()->to_string());     \
                 } else {                                                                          \
-                    RAISE_ERROR("All OR clauses are supposed to be LinkTemplate or Operator");   \
+                    RAISE_ERROR("All OR clauses are supposed to be LinkTemplate or Operator");    \
                 }                                                                                 \
             }                                                                                     \
             element_stack.pop();                                                                  \

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -61,7 +61,7 @@ void PatternMatchingQueryProcessor::run_command(shared_ptr<BusCommandProxy> prox
     LOG_DEBUG("Starting new thread: " << thread_id << " to run command: <" << proxy->get_command()
                                       << ">");
     if (this->query_threads.find(thread_id) != this->query_threads.end()) {
-        Utils::error("Invalid thread id: " + thread_id);
+        RAISE_ERROR("Invalid thread id: " + thread_id);
     } else {
         shared_ptr<StoppableThread> stoppable_thread = make_shared<StoppableThread>(thread_id);
         stoppable_thread->attach(new thread(&PatternMatchingQueryProcessor::thread_process_one_query,
@@ -197,7 +197,7 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
         set<string> joint_answer;  // used to stimulate attention broker
         string command = proxy->get_command();
         if (root_query_element == NULL) {
-            Utils::error("Invalid empty query tree.");
+            RAISE_ERROR("Invalid empty query tree.");
         } else {
             if (command == ServiceBus::PATTERN_MATCHING_QUERY) {
                 LinkTemplate* root_link_template = dynamic_cast<LinkTemplate*>(root_query_element.get());
@@ -240,7 +240,7 @@ void PatternMatchingQueryProcessor::thread_process_one_query(
                 LOG_INFO("Total processed answers: " << answer_count);
                 query_sink->graceful_shutdown();
             } else {
-                Utils::error("Invalid command " + command + " in PatternMatchingQueryProcessor");
+                RAISE_ERROR("Invalid command " + command + " in PatternMatchingQueryProcessor");
             }
         }
     } catch (const std::runtime_error& exception) {
@@ -263,7 +263,7 @@ void PatternMatchingQueryProcessor::remove_query_thread(const string& stoppable_
 shared_ptr<QueryElement> PatternMatchingQueryProcessor::parse_metta_query(
     shared_ptr<PatternMatchingQueryProxy> proxy) {
     if (proxy->get_query_tokens().size() > 1) {
-        Utils::error(
+        RAISE_ERROR(
             "Only one string with the whole MeTTa expression is expected when issuing MeTTa queries");
         return nullptr;
     }
@@ -271,10 +271,10 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::parse_metta_query(
     MettaParser parser(proxy->get_query_tokens()[0], parser_actions);
     parser.parse(true);
     if (parser_actions->element_stack.size() == 0) {
-        Utils::error("Invalid MeTTa query. Parser returned an empty stack.");
+        RAISE_ERROR("Invalid MeTTa query. Parser returned an empty stack.");
         return nullptr;
     } else if (parser_actions->element_stack.size() > 1) {
-        Utils::error("Invalid MeTTa query with more than 1 toplevel expressions");
+        RAISE_ERROR("Invalid MeTTa query with more than 1 toplevel expressions");
         return nullptr;
     } else {
         return parser_actions->element_stack.top();
@@ -302,12 +302,12 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
         } else if (query_tokens[cursor] == CHAIN) {
             cursor += 4;
         } else {
-            Utils::error("Invalid token in query: " + query_tokens[cursor]);
+            RAISE_ERROR("Invalid token in query: " + query_tokens[cursor]);
         }
     }
 
     if (cursor != tokens_count) {
-        Utils::error("Parse error in query tokens");
+        RAISE_ERROR("Parse error in query tokens");
         return shared_ptr<QueryElement>(NULL);
     }
 
@@ -339,13 +339,13 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::setup_query_tree(
         } else if (query_tokens[cursor] == CHAIN) {
             element_stack.push(build_chain(proxy, cursor, element_stack));
         } else {
-            Utils::error("Invalid token " + query_tokens[cursor] + " in PATTERN_MATCHING_QUERY message");
+            RAISE_ERROR("Invalid token " + query_tokens[cursor] + " in PATTERN_MATCHING_QUERY message");
         }
         execution_stack.pop();
     }
 
     if (element_stack.size() != 1) {
-        Utils::error("Parse error in query tokens (trailing elements)");
+        RAISE_ERROR("Parse error in query tokens (trailing elements)");
         return shared_ptr<QueryElement>(NULL);
     }
     return element_stack.top();
@@ -359,7 +359,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link_template(
     const vector<string> query_tokens = proxy->get_query_tokens();
     unsigned int arity = std::stoi(query_tokens[cursor + 2]);
     if (element_stack.size() < arity) {
-        Utils::error(
+        RAISE_ERROR(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for "
             "LINK_TEMPLATE");
     }
@@ -395,7 +395,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link_template(
                 if (element_stack.top()->is_operator) {                                           \
                     clauses[i] = element_stack.top();                                             \
                 } else {                                                                          \
-                    Utils::error("All AND clauses are supposed to be LinkTemplate or Operator");  \
+                    RAISE_ERROR("All AND clauses are supposed to be LinkTemplate or Operator");  \
                 }                                                                                 \
             }                                                                                     \
             element_stack.pop();                                                                  \
@@ -410,7 +410,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_and(
     const vector<string> query_tokens = proxy->get_query_tokens();
     unsigned int num_clauses = std::stoi(query_tokens[cursor + 1]);
     if (element_stack.size() < num_clauses) {
-        Utils::error(
+        RAISE_ERROR(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for AND");
     }
     // clang-format off
@@ -427,7 +427,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_and(
         case 10: BUILD_AND(10)
         // clang-format on
         default: {
-            Utils::error("PATTERN_MATCHING_QUERY message: max supported num_clauses for AND: 10");
+            RAISE_ERROR("PATTERN_MATCHING_QUERY message: max supported num_clauses for AND: 10");
         }
     }
     return NULL;  // Just to avoid warnings. This is not actually reachable.
@@ -449,7 +449,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_and(
                     clauses[i] = element_stack.top();                                             \
                     LOG_DEBUG("OR input[" << i << "]: " << element_stack.top()->to_string());     \
                 } else {                                                                          \
-                    Utils::error("All OR clauses are supposed to be LinkTemplate or Operator");   \
+                    RAISE_ERROR("All OR clauses are supposed to be LinkTemplate or Operator");   \
                 }                                                                                 \
             }                                                                                     \
             element_stack.pop();                                                                  \
@@ -465,7 +465,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_or(
     const vector<string> query_tokens = proxy->get_query_tokens();
     unsigned int num_clauses = std::stoi(query_tokens[cursor + 1]);
     if (element_stack.size() < num_clauses) {
-        Utils::error("PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for OR");
+        RAISE_ERROR("PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for OR");
     }
     // clang-format off
     switch (num_clauses) {
@@ -481,7 +481,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_or(
         case 10: BUILD_OR(10)
         // clang-format on
         default: {
-            Utils::error("PATTERN_MATCHING_QUERY message: max supported num_clauses for OR: 10");
+            RAISE_ERROR("PATTERN_MATCHING_QUERY message: max supported num_clauses for OR: 10");
         }
     }
     return NULL;  // Just to avoid warnings. This is not actually reachable.
@@ -507,7 +507,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_chain(
     LOG_DEBUG("Head reference: " + std::to_string(head_reference));
 
     if (element_stack.size() < 3) {
-        Utils::error(
+        RAISE_ERROR(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for "
             "CHAIN");
     }
@@ -525,7 +525,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_chain(
     Chain::SearchDirection search_direction;
     if (target->is_variable) {
         if (source->is_variable) {
-            Utils::error("Invalid CHAIN arguments. source and target are variables.");
+            RAISE_ERROR("Invalid CHAIN arguments. source and target are variables.");
         } else {
             search_direction = Chain::FORWARD;
             incomplete_flag = true;
@@ -575,7 +575,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_link(
     const vector<string> query_tokens = proxy->get_query_tokens();
     unsigned int arity = std::stoi(query_tokens[cursor + 2]);
     if (element_stack.size() < arity) {
-        Utils::error(
+        RAISE_ERROR(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for LINK");
     }
     vector<shared_ptr<QueryElement>> targets;
@@ -591,7 +591,7 @@ shared_ptr<QueryElement> PatternMatchingQueryProcessor::build_unique_assignment_
     unsigned int cursor,
     stack<shared_ptr<QueryElement>>& element_stack) {
     if (element_stack.size() < 1) {
-        Utils::error(
+        RAISE_ERROR(
             "PATTERN_MATCHING_QUERY message: parse error in tokens - too few arguments for "
             "UniqueAssignmentFilter");
     }

--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -46,7 +46,7 @@ PatternMatchingQueryProxy::~PatternMatchingQueryProxy() {}
 shared_ptr<QueryAnswer> PatternMatchingQueryProxy::pop() {
     lock_guard<mutex> semaphore(this->api_mutex);
     if (this->parameters.get<bool>(COUNT_FLAG)) {
-        Utils::error("Can't pop QueryAnswers from count_only queries.");
+        RAISE_ERROR("Can't pop QueryAnswers from count_only queries.");
         return shared_ptr<QueryAnswer>(NULL);
     } else {
         return BaseQueryProxy::pop();
@@ -72,7 +72,7 @@ bool PatternMatchingQueryProxy::from_remote_peer(const string& command, const ve
             count_answer(args);
             return true;
         } else {
-            Utils::error("Invalid proxy command: <" + command + ">");
+            RAISE_ERROR("Invalid proxy command: <" + command + ">");
             return false;
         }
     }
@@ -82,10 +82,10 @@ void PatternMatchingQueryProxy::count_answer(const vector<string>& args) {
     lock_guard<mutex> semaphore(this->api_mutex);
     if (!this->is_aborting()) {
         if (args.size() != 1) {
-            Utils::error("Invalid args for count command");
+            RAISE_ERROR("Invalid args for count command");
         }
         if (!this->parameters.get<bool>(COUNT_FLAG)) {
-            Utils::error("Invalid count command. Query is not count_only.");
+            RAISE_ERROR("Invalid count command. Query is not count_only.");
         } else {
             this->set_count(stoi(args[0]));
         }

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -252,7 +252,7 @@ void QueryAnswer::untokenize(const string& tokens) {
 
     if (handles_size >= MAX_NUMBER_OF_OPERATION_CLAUSES) {
         RAISE_ERROR("Invalid handles_size: " + std::to_string(handles_size) +
-                     " untokenizing QueryAnswer");
+                    " untokenizing QueryAnswer");
     } else {
         for (unsigned int i = 0; i < handles_size; i++) {
             read_token(token_string, cursor, number, 4);
@@ -279,7 +279,7 @@ void QueryAnswer::untokenize(const string& tokens) {
 
     if (assignment_size > MAX_NUMBER_OF_VARIABLES_IN_QUERY) {
         RAISE_ERROR("Invalid number of assignments: " + std::to_string(assignment_size) +
-                     " untokenizing QueryAnswer");
+                    " untokenizing QueryAnswer");
     }
 
     for (unsigned int i = 0; i < assignment_size; i++) {
@@ -386,7 +386,7 @@ void QueryAnswer::add_path_element(unsigned int path_index, const string& handle
     } else {
         if (path_index >= (this->handles.size() - 1)) {
             RAISE_ERROR("Invalid path index: " + std::to_string(path_index) +
-                         " QueryAnswer: " + to_string());
+                        " QueryAnswer: " + to_string());
         } else {
             this->handles[path_index + 1].push_back(handle);
         }
@@ -409,7 +409,7 @@ vector<string>& QueryAnswer::get_handles_vector() { return this->handles[0]; }
 vector<string>& QueryAnswer::get_path_vector(unsigned int path_index) {
     if ((this->handles.size() == 0) || (path_index >= (this->handles.size() - 1))) {
         RAISE_ERROR("Invalid path index: " + std::to_string(path_index) +
-                     " QueryAnswer: " + to_string());
+                    " QueryAnswer: " + to_string());
     }
     return this->handles[path_index + 1];
 }

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -190,7 +190,7 @@ static inline void read_token(const char* token_string,
     unsigned int cursor_token = 0;
     while (token_string[cursor] != ' ') {
         if ((cursor_token == token_size) || (token_string[cursor] == '\0')) {
-            Utils::error("Invalid token string");
+            RAISE_ERROR("Invalid token string");
         }
         token[cursor_token++] = token_string[cursor++];
     }
@@ -216,7 +216,7 @@ static inline string read_metta_expression(const char* token_string, unsigned in
     do {
         cursor++;
         if (token_string[cursor] == '\0') {
-            Utils::error("Invalid metta expression string");
+            RAISE_ERROR("Invalid metta expression string");
         } else if ((token_string[cursor] == close_char) && (token_string[cursor - 1] != '\\')) {
             unmatched--;
         } else if ((token_string[cursor] == open_char) && (token_string[cursor - 1] != '\\')) {
@@ -251,7 +251,7 @@ void QueryAnswer::untokenize(const string& tokens) {
     unsigned int handles_size = (unsigned int) std::stoi(number);
 
     if (handles_size >= MAX_NUMBER_OF_OPERATION_CLAUSES) {
-        Utils::error("Invalid handles_size: " + std::to_string(handles_size) +
+        RAISE_ERROR("Invalid handles_size: " + std::to_string(handles_size) +
                      " untokenizing QueryAnswer");
     } else {
         for (unsigned int i = 0; i < handles_size; i++) {
@@ -278,7 +278,7 @@ void QueryAnswer::untokenize(const string& tokens) {
     unsigned int assignment_size = (unsigned int) std::stoi(number);
 
     if (assignment_size > MAX_NUMBER_OF_VARIABLES_IN_QUERY) {
-        Utils::error("Invalid number of assignments: " + std::to_string(assignment_size) +
+        RAISE_ERROR("Invalid number of assignments: " + std::to_string(assignment_size) +
                      " untokenizing QueryAnswer");
     }
 
@@ -300,7 +300,7 @@ void QueryAnswer::untokenize(const string& tokens) {
     }
 
     if (token_string[cursor] != '\0') {
-        Utils::error("Invalid token string - invalid text after QueryAnswer definition");
+        RAISE_ERROR("Invalid token string - invalid text after QueryAnswer definition");
     }
 }
 
@@ -312,7 +312,7 @@ string QueryAnswer::get(const QueryAnswerElement& key, bool return_empty_when_no
         case QueryAnswerElement::VARIABLE:
             return get(key.name, return_empty_when_not_found);
         default:
-            Utils::error("Invalid QueryAnswerElemente: " + std::to_string(key.type));
+            RAISE_ERROR("Invalid QueryAnswerElemente: " + std::to_string(key.type));
     }
     return answer;
 }
@@ -320,7 +320,7 @@ string QueryAnswer::get(const QueryAnswerElement& key, bool return_empty_when_no
 string QueryAnswer::get(const string& key, bool return_empty_when_not_found) {
     string answer = this->assignment.get(key);
     if ((answer == "") && (!return_empty_when_not_found)) {
-        Utils::error("Invalid variable name: " + key);
+        RAISE_ERROR("Invalid variable name: " + key);
     }
     return answer;
 }
@@ -331,7 +331,7 @@ string QueryAnswer::get(unsigned int key, bool return_empty_when_not_found) {
         answer = this->handles[0][key];
     } else {
         if (!return_empty_when_not_found) {
-            Utils::error("Invalid handle index: " + std::to_string(key));
+            RAISE_ERROR("Invalid handle index: " + std::to_string(key));
         }
     }
     return answer;
@@ -347,7 +347,7 @@ void QueryAnswer::rewrite_query(const vector<string>& original_query,
         string token = original_query[cursor++];
         if (token == LinkSchema::UNTYPED_VARIABLE) {
             if (cursor == size) {
-                Utils::error("Invalid query");
+                RAISE_ERROR("Invalid query");
                 return;
             }
             token = original_query[cursor++];
@@ -370,7 +370,7 @@ void QueryAnswer::add_handle(const string& handle) { this->handles[0].push_back(
 
 unsigned int QueryAnswer::add_path() {
     if (this->handles.size() == 0) {
-        Utils::error("Invalid QueryAnswer setup. Trying to add a path to an uninitialized  QueryAnswer");
+        RAISE_ERROR("Invalid QueryAnswer setup. Trying to add a path to an uninitialized  QueryAnswer");
         return 0;
     } else {
         unsigned int new_index = this->handles.size() - 1;
@@ -381,11 +381,11 @@ unsigned int QueryAnswer::add_path() {
 
 void QueryAnswer::add_path_element(unsigned int path_index, const string& handle) {
     if (this->handles.size() == 0) {
-        Utils::error(
+        RAISE_ERROR(
             "Invalid QueryAnswer setup. Trying to add a path element to an uninitialized  QueryAnswer");
     } else {
         if (path_index >= (this->handles.size() - 1)) {
-            Utils::error("Invalid path index: " + std::to_string(path_index) +
+            RAISE_ERROR("Invalid path index: " + std::to_string(path_index) +
                          " QueryAnswer: " + to_string());
         } else {
             this->handles[path_index + 1].push_back(handle);
@@ -408,7 +408,7 @@ vector<string>& QueryAnswer::get_handles_vector() { return this->handles[0]; }
 
 vector<string>& QueryAnswer::get_path_vector(unsigned int path_index) {
     if ((this->handles.size() == 0) || (path_index >= (this->handles.size() - 1))) {
-        Utils::error("Invalid path index: " + std::to_string(path_index) +
+        RAISE_ERROR("Invalid path index: " + std::to_string(path_index) +
                      " QueryAnswer: " + to_string());
     }
     return this->handles[path_index + 1];

--- a/src/agents/query_engine/QueryAnswer.h
+++ b/src/agents/query_engine/QueryAnswer.h
@@ -40,7 +40,7 @@ class QueryAnswerElement {
             this->type = VARIABLE;
             this->name = key;
         } else {
-            Utils::error("Invalid attempt to reset a QueryAnswerElement");
+            RAISE_ERROR("Invalid attempt to reset a QueryAnswerElement");
         }
     }
     void set(unsigned int key) {
@@ -48,7 +48,7 @@ class QueryAnswerElement {
             this->type = HANDLE;
             this->index = key;
         } else {
-            Utils::error("Invalid attempt to reset a QueryAnswerElement");
+            RAISE_ERROR("Invalid attempt to reset a QueryAnswerElement");
         }
     }
     string to_string() {

--- a/src/agents/query_engine/QueryNode.cc
+++ b/src/agents/query_engine/QueryNode.cc
@@ -96,7 +96,7 @@ shared_ptr<Message> QueryNode::message_factory(string& command, vector<string>& 
 
 void QueryNode::add_query_answer(QueryAnswer* query_answer) {
     if (is_query_answers_finished()) {
-        Utils::error("Invalid addition of new query answer.");
+        RAISE_ERROR("Invalid addition of new query answer.");
     } else {
         this->query_answer_queue.enqueue((void*) query_answer);
     }

--- a/src/agents/query_engine/query_element/Chain.cc
+++ b/src/agents/query_engine/query_element/Chain.cc
@@ -334,7 +334,7 @@ bool Chain::thread_one_step() {
                 shared_ptr<Link> link =
                     dynamic_pointer_cast<Link>(AtomDBSingleton::get_instance()->get_atom(handle));
                 if (link == nullptr) {
-                    Utils::error("Invalid query answer in Chain operator.");
+                    RAISE_ERROR("Invalid query answer in Chain operator.");
                 } else {
                     LOG_DEBUG("[CHAIN OPERATOR] "
                               << "Valid link");
@@ -365,7 +365,7 @@ bool Chain::thread_one_step() {
                             Path(tail, head, QueryAnswer::copy(answer), false), answer->importance);
                     }
                 } else {
-                    Utils::error("Invalid Link " + link->to_string() + " with arity " +
+                    RAISE_ERROR("Invalid Link " + link->to_string() + " with arity " +
                                  std::to_string(link->arity()) + " in CHAIN operator. Tail reference: " +
                                  std::to_string(this->tail_reference) +
                                  ". Head reference: " + std::to_string(this->head_reference));
@@ -463,10 +463,10 @@ bool Chain::all_paths_explored() {
 
 void Chain::initialize(const array<shared_ptr<QueryElement>, 1>& clauses) {
     if (clauses.size() != 1) {
-        Utils::error("Invalid Chain operator with " + std::to_string(clauses.size()) + " clauses.");
+        RAISE_ERROR("Invalid Chain operator with " + std::to_string(clauses.size()) + " clauses.");
     }
     if (!(allow_incomplete_chain_path || (forward_active() && backward_active()))) {
-        Utils::error(
+        RAISE_ERROR(
             "Invalid parameters. If CHAIN source or target is a variable, incomplete paths must be "
             "allowed");
     }

--- a/src/agents/query_engine/query_element/Chain.cc
+++ b/src/agents/query_engine/query_element/Chain.cc
@@ -366,9 +366,9 @@ bool Chain::thread_one_step() {
                     }
                 } else {
                     RAISE_ERROR("Invalid Link " + link->to_string() + " with arity " +
-                                 std::to_string(link->arity()) + " in CHAIN operator. Tail reference: " +
-                                 std::to_string(this->tail_reference) +
-                                 ". Head reference: " + std::to_string(this->head_reference));
+                                std::to_string(link->arity()) + " in CHAIN operator. Tail reference: " +
+                                std::to_string(this->tail_reference) +
+                                ". Head reference: " + std::to_string(this->head_reference));
                 }
             } else {
                 LOG_DEBUG("[CHAIN OPERATOR] "

--- a/src/agents/query_engine/query_element/Chain.h
+++ b/src/agents/query_engine/query_element/Chain.h
@@ -89,7 +89,7 @@ class Chain : public Operator<1>, public ThreadMethod {
         bool forward_flag;
         Path(const string& tail, const string& head, QueryAnswer* answer, bool forward_flag) {
             if (tail == head) {
-                Utils::error("Invalid cyclic edge: " + tail + " -> " + head);
+                RAISE_ERROR("Invalid cyclic edge: " + tail + " -> " + head);
             }
             this->edges.push_back({{tail, head}, shared_ptr<QueryAnswer>(answer)});
             this->path_sti = answer->importance;
@@ -122,7 +122,7 @@ class Chain : public Operator<1>, public ThreadMethod {
         }
         inline void concatenate(const Path& other) {
             if (this->forward_flag != other.forward_flag) {
-                Utils::error("Invalid attempt to merge incompatible HeapElements");
+                RAISE_ERROR("Invalid attempt to merge incompatible HeapElements");
             }
             this->edges.insert(this->edges.end(), other.edges.begin(), other.edges.end());
             this->path_sti = max(this->path_sti, other.path_sti);

--- a/src/agents/query_engine/query_element/LinkTemplate.cc
+++ b/src/agents/query_engine/query_element/LinkTemplate.cc
@@ -28,7 +28,7 @@ LinkTemplate::LinkTemplate(const string& type,
     this->targets = targets;
     this->context = context;
     if (positive_importance_flag && disregard_importance_flag) {
-        Utils::error("Conficting settings for positive_importance_flag and disregard_importance_flag");
+        RAISE_ERROR("Conficting settings for positive_importance_flag and disregard_importance_flag");
     }
     this->positive_importance_flag = positive_importance_flag;
     this->disregard_importance_flag = disregard_importance_flag;
@@ -73,13 +73,13 @@ void LinkTemplate::recursive_build(shared_ptr<QueryElement> element, LinkSchema&
             }
             link_schema.stack_link(terminal->type, terminal->targets.size());
         } else {
-            Utils::error("Invalid terminal");
+            RAISE_ERROR("Invalid terminal");
         }
     } else {
         // is an inner LinkTemplate
         LinkTemplate* link_template = dynamic_cast<LinkTemplate*>(element.get());
         if (link_template == NULL) {
-            Utils::error("Invalid NULL element");
+            RAISE_ERROR("Invalid NULL element");
         } else {
             for (auto target : link_template->targets) {
                 recursive_build(target, link_schema);
@@ -103,7 +103,7 @@ void LinkTemplate::build() {
         LOG_INFO("LinkTemplate: " + to_string());
         start_thread();
     } else {
-        Utils::error("LinkTemplate already built");
+        RAISE_ERROR("LinkTemplate already built");
     }
 }
 
@@ -214,7 +214,7 @@ void LinkTemplate::processor_method(shared_ptr<StoppableThread> monitor) {
 
 void LinkTemplate::start_thread() {
     if (this->inner_flag) {
-        Utils::error("Can't start thread in inner LinkTemplates");
+        RAISE_ERROR("Can't start thread in inner LinkTemplates");
     } else {
         this->processor = make_shared<StoppableThread>("processor_thread(" + this->id + ")");
         this->processor->attach(new thread(&LinkTemplate::processor_method, this, this->processor));
@@ -223,7 +223,7 @@ void LinkTemplate::start_thread() {
 
 shared_ptr<Source> LinkTemplate::get_source_element() {
     if (this->inner_flag) {
-        Utils::error("Inner LinkTemplates doesn't have source_element");
+        RAISE_ERROR("Inner LinkTemplates doesn't have source_element");
         return nullptr;
     } else {
         return source_element;
@@ -232,7 +232,7 @@ shared_ptr<Source> LinkTemplate::get_source_element() {
 
 string LinkTemplate::get_handle() {
     if (this->inner_flag) {
-        Utils::error("Inner LinkTemplates doesn't have handle");
+        RAISE_ERROR("Inner LinkTemplates doesn't have handle");
         return "";
     } else {
         return this->link_schema.handle();

--- a/src/agents/query_engine/query_element/Operator.h
+++ b/src/agents/query_engine/query_element/Operator.h
@@ -66,10 +66,10 @@ class Operator : public QueryElement {
     virtual void setup_buffers() {
         LOG_LOCAL_DEBUG("Setting up buffers for Operator: " + std::to_string((unsigned long) this));
         if (this->subsequent_id == "") {
-            Utils::error("Invalid empty parent id");
+            RAISE_ERROR("Invalid empty parent id");
         }
         if (this->id == "") {
-            Utils::error("Invalid empty id");
+            RAISE_ERROR("Invalid empty id");
         }
 
         this->output_buffer = make_shared<QueryNodeClient>(this->id, this->subsequent_id);
@@ -133,7 +133,7 @@ class Operator : public QueryElement {
    private:
     void initialize(const array<shared_ptr<QueryElement>, N>& clauses) {
         if (N > MAX_NUMBER_OF_OPERATION_CLAUSES) {
-            Utils::error("Operation exceeds max number of clauses: " + std::to_string(N));
+            RAISE_ERROR("Operation exceeds max number of clauses: " + std::to_string(N));
         }
         for (unsigned int i = 0; i < N; i++) {
             precedent[i] = clauses[i];

--- a/src/agents/query_engine/query_element/Or.h
+++ b/src/agents/query_engine/query_element/Or.h
@@ -153,7 +153,7 @@ class Or : public Operator<N> {
             }
         }
         if (best_importance < 0) {
-            Utils::error("Invalid state in OR operation");
+            RAISE_ERROR("Invalid state in OR operation");
         }
         return best_index;
     }

--- a/src/agents/query_engine/query_element/Sink.cc
+++ b/src/agents/query_engine/query_element/Sink.cc
@@ -33,10 +33,10 @@ Sink::~Sink() {
 void Sink::setup_buffers() {
     LOG_LOCAL_DEBUG("Setting up buffers for Sink: " + std::to_string((unsigned long) this));
     if (this->subsequent_id != "") {
-        Utils::error("Invalid non-empty subsequent id: " + this->subsequent_id);
+        RAISE_ERROR("Invalid non-empty subsequent id: " + this->subsequent_id);
     }
     if (this->id == "") {
-        Utils::error("Invalid empty id");
+        RAISE_ERROR("Invalid empty id");
     }
     this->input_buffer = make_shared<QueryNodeServer>(this->id);
     this->precedent->subsequent_id = this->id;

--- a/src/agents/query_engine/query_element/Source.cc
+++ b/src/agents/query_engine/query_element/Source.cc
@@ -24,10 +24,10 @@ Source::~Source() {
 void Source::setup_buffers() {
     LOG_LOCAL_DEBUG("Setting up buffers for Source: " + std::to_string((unsigned long) this) + "...");
     if (this->subsequent_id == "") {
-        Utils::error("Invalid empty parent id");
+        RAISE_ERROR("Invalid empty parent id");
     }
     if (this->id == "") {
-        Utils::error("Invalid empty id");
+        RAISE_ERROR("Invalid empty id");
     }
     this->output_buffer = make_shared<QueryNodeClient>(this->id, this->subsequent_id);
     LOG_LOCAL_DEBUG("Setting up buffers for Source: " + std::to_string((unsigned long) this) +

--- a/src/agents/query_engine/query_element/Terminal.cc
+++ b/src/agents/query_engine/query_element/Terminal.cc
@@ -56,7 +56,7 @@ string Terminal::compute_handle() {
         for (auto element : this->targets) {
             shared_ptr<Terminal> terminal = dynamic_pointer_cast<Terminal>(element);
             if (terminal == nullptr) {
-                Utils::error("Invalid non-terminal target in Terminal");
+                RAISE_ERROR("Invalid non-terminal target in Terminal");
             }
             target_handles.push_back(terminal->compute_handle());
         }
@@ -64,7 +64,7 @@ string Terminal::compute_handle() {
     } else if (this->is_atom) {
         return handle;
     } else {
-        Utils::error("Invalid attempt to generate the handle of a variable terminal");
+        RAISE_ERROR("Invalid attempt to generate the handle of a variable terminal");
         return "";
     }
 }
@@ -90,7 +90,7 @@ string Terminal::to_string() {
         }
         return answer;
     } else {
-        Utils::error("Invalid terminal");
+        RAISE_ERROR("Invalid terminal");
         return "";
     }
 }

--- a/src/atomdb/AtomDBSingleton.cc
+++ b/src/atomdb/AtomDBSingleton.cc
@@ -13,7 +13,7 @@ shared_ptr<AtomDB> AtomDBSingleton::atom_db = shared_ptr<AtomDB>{};
 
 void AtomDBSingleton::init(const JsonConfig& atomdb_config) {
     if (AtomDBSingleton::initialized) {
-        Utils::error(
+        RAISE_ERROR(
             "AtomDBSingleton already initialized. AtomDBSingleton::init() should be called only once.");
     } else {
         auto atomdb_type = atomdb_config.at_path("type").get_or<string>("");
@@ -24,7 +24,7 @@ void AtomDBSingleton::init(const JsonConfig& atomdb_config) {
         } else if (atomdb_type == "remotedb") {
             AtomDBSingleton::atom_db = shared_ptr<AtomDB>(new RemoteAtomDB(atomdb_config));
         } else {
-            Utils::error("Invalid AtomDB type: " + atomdb_type);
+            RAISE_ERROR("Invalid AtomDB type: " + atomdb_type);
         }
 
         AtomDBSingleton::initialized = true;
@@ -33,7 +33,7 @@ void AtomDBSingleton::init(const JsonConfig& atomdb_config) {
 
 shared_ptr<AtomDB> AtomDBSingleton::get_instance() {
     if (!AtomDBSingleton::initialized) {
-        Utils::error(
+        RAISE_ERROR(
             "Uninitialized AtomDBSingleton. AtomDBSingleton::init() must be called before "
             "AtomDBSingleton::get_instance()");
         return shared_ptr<AtomDB>{};  // To avoid warnings

--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -301,7 +301,7 @@ string InMemoryDB::add_node(const atoms::Node* node, bool throw_if_exists) {
     string handle = node->handle();
 
     if (throw_if_exists && this->node_exists(handle)) {
-        Utils::error("Node already exists: " + handle);
+        RAISE_ERROR("Node already exists: " + handle);
         return "";
     }
 
@@ -365,7 +365,7 @@ vector<string> InMemoryDB::add_nodes(const vector<atoms::Node*>& nodes,
         auto existing_handles = this->nodes_exist(handles);
         if (!existing_handles.empty()) {
             vector<string> existing_handles_vector(existing_handles.begin(), existing_handles.end());
-            Utils::error("Failed to insert nodes, some nodes already exist: " +
+            RAISE_ERROR("Failed to insert nodes, some nodes already exist: " +
                          Utils::join(existing_handles_vector, ','));
             return {};
         }
@@ -393,7 +393,7 @@ vector<string> InMemoryDB::add_links(const vector<atoms::Link*>& links,
         auto existing_handles = this->links_exist(handles);
         if (!existing_handles.empty()) {
             vector<string> existing_handles_vector(existing_handles.begin(), existing_handles.end());
-            Utils::error("Failed to insert links, some links already exist: " +
+            RAISE_ERROR("Failed to insert links, some links already exist: " +
                          Utils::join(existing_handles_vector, ','));
             return {};
         }
@@ -561,9 +561,9 @@ uint InMemoryDB::delete_links(const vector<string>& handles, bool delete_link_ta
     return deleted_count;
 }
 
-size_t InMemoryDB::node_count() const { Utils::error("node_count() is not implemented yet"); }
+size_t InMemoryDB::node_count() const { RAISE_ERROR("node_count() is not implemented yet"); }
 
-size_t InMemoryDB::link_count() const { Utils::error("link_count() is not implemented yet"); }
+size_t InMemoryDB::link_count() const { RAISE_ERROR("link_count() is not implemented yet"); }
 
 size_t InMemoryDB::atom_count() const {
     auto size = this->atoms_trie_->size;
@@ -704,7 +704,7 @@ vector<string> InMemoryDB::match_pattern_index_schema(const Link* link) {
                     } else {
                         string assignment_value = assignment.get(token);
                         if (assignment_value == "") {
-                            Utils::error("LinkSchema assignments don't have variable: " + token);
+                            RAISE_ERROR("LinkSchema assignments don't have variable: " + token);
                         }
                         hash_entries.push_back(assignment_value);
                     }

--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -366,7 +366,7 @@ vector<string> InMemoryDB::add_nodes(const vector<atoms::Node*>& nodes,
         if (!existing_handles.empty()) {
             vector<string> existing_handles_vector(existing_handles.begin(), existing_handles.end());
             RAISE_ERROR("Failed to insert nodes, some nodes already exist: " +
-                         Utils::join(existing_handles_vector, ','));
+                        Utils::join(existing_handles_vector, ','));
             return {};
         }
     }
@@ -394,7 +394,7 @@ vector<string> InMemoryDB::add_links(const vector<atoms::Link*>& links,
         if (!existing_handles.empty()) {
             vector<string> existing_handles_vector(existing_handles.begin(), existing_handles.end());
             RAISE_ERROR("Failed to insert links, some links already exist: " +
-                         Utils::join(existing_handles_vector, ','));
+                        Utils::join(existing_handles_vector, ','));
             return {};
         }
     }

--- a/src/atomdb/inmemorydb/InMemoryDBAPITypes.cc
+++ b/src/atomdb/inmemorydb/InMemoryDBAPITypes.cc
@@ -96,7 +96,7 @@ HandleListInMemory::~HandleListInMemory() {
 
 const char* HandleListInMemory::get_handle(unsigned int index) {
     if (index >= handles.size()) {
-        Utils::error("Handle index out of bounds: " + to_string(index) +
+        RAISE_ERROR("Handle index out of bounds: " + to_string(index) +
                      " Answer handles size: " + to_string(handles.size()));
     }
     return allocated_strings[index];

--- a/src/atomdb/inmemorydb/InMemoryDBAPITypes.cc
+++ b/src/atomdb/inmemorydb/InMemoryDBAPITypes.cc
@@ -97,7 +97,7 @@ HandleListInMemory::~HandleListInMemory() {
 const char* HandleListInMemory::get_handle(unsigned int index) {
     if (index >= handles.size()) {
         RAISE_ERROR("Handle index out of bounds: " + to_string(index) +
-                     " Answer handles size: " + to_string(handles.size()));
+                    " Answer handles size: " + to_string(handles.size()));
     }
     return allocated_strings[index];
 }

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -198,7 +198,7 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
         if (!existing_handles.empty()) {
             vector<string> existing_handles_vector(existing_handles.begin(), existing_handles.end());
             RAISE_ERROR("Failed to insert links, some links already exist: " +
-                         Utils::join(existing_handles_vector, ','));
+                        Utils::join(existing_handles_vector, ','));
             return {};
         }
     }

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -64,16 +64,16 @@ httplib::Result MorkClient::send_request(const string& method, const string& pat
         res = this->cli.Get(url);
     } else if (method == "POST") {
         if (data.empty()) {
-            Utils::error("POST request data is empty. Cannot send an empty payload to MORK server.");
+            RAISE_ERROR("POST request data is empty. Cannot send an empty payload to MORK server.");
         }
         res = this->cli.Post(url, data, "text/plain");
     }
 
     if (!res) {
-        Utils::error("Connection error at " + url);
+        RAISE_ERROR("Connection error at " + url);
     } else if (res->status != httplib::StatusCode::OK_200) {
         auto err = res.error();
-        Utils::error("Http error: " + httplib::to_string(err));
+        RAISE_ERROR("Http error: " + httplib::to_string(err));
     }
     return res;
 }
@@ -111,7 +111,7 @@ void MorkDB::mork_setup(const JsonConfig& config) {
         this->mork_client = make_shared<MorkClient>(address);
         LOG_INFO("Connected to MORK at " << address);
     } catch (const exception& e) {
-        Utils::error(e.what());
+        RAISE_ERROR(e.what());
     }
 }
 
@@ -197,7 +197,7 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
         auto existing_handles = this->links_exist(handles);
         if (!existing_handles.empty()) {
             vector<string> existing_handles_vector(existing_handles.begin(), existing_handles.end());
-            Utils::error("Failed to insert links, some links already exist: " +
+            RAISE_ERROR("Failed to insert links, some links already exist: " +
                          Utils::join(existing_handles_vector, ','));
             return {};
         }

--- a/src/atomdb/morkdb/MorkDBAPITypes.cc
+++ b/src/atomdb/morkdb/MorkDBAPITypes.cc
@@ -92,7 +92,7 @@ HandleListMork::~HandleListMork() {
 
 const char* HandleListMork::get_handle(unsigned int index) {
     if (index > this->handles_size) {
-        Utils::error("Handle index out of bounds: " + to_string(index) +
+        RAISE_ERROR("Handle index out of bounds: " + to_string(index) +
                      " Answer handles size: " + to_string(this->handles_size));
     }
     return handles[index];

--- a/src/atomdb/morkdb/MorkDBAPITypes.cc
+++ b/src/atomdb/morkdb/MorkDBAPITypes.cc
@@ -93,7 +93,7 @@ HandleListMork::~HandleListMork() {
 const char* HandleListMork::get_handle(unsigned int index) {
     if (index > this->handles_size) {
         RAISE_ERROR("Handle index out of bounds: " + to_string(index) +
-                     " Answer handles size: " + to_string(this->handles_size));
+                    " Answer handles size: " + to_string(this->handles_size));
     }
     return handles[index];
 }

--- a/src/atomdb/redis_mongodb/RedisContext.cc
+++ b/src/atomdb/redis_mongodb/RedisContext.cc
@@ -51,13 +51,13 @@ void RedisContext::append_command(const char* command) {
         if (redisClusterAppendCommand(cluster_ctx, command) == REDIS_OK) {
             pending_commands_count++;
         } else {
-            Utils::error("Failed to append command to Redis cluster context.");
+            RAISE_ERROR("Failed to append command to Redis cluster context.");
         }
     } else {
         if (redisAppendCommand(single_ctx, command) == REDIS_OK) {
             pending_commands_count++;
         } else {
-            Utils::error("Failed to append command to Redis context.");
+            RAISE_ERROR("Failed to append command to Redis context.");
         }
     }
 }

--- a/src/atomdb/redis_mongodb/RedisContextPool.cc
+++ b/src/atomdb/redis_mongodb/RedisContextPool.cc
@@ -77,7 +77,7 @@ shared_ptr<RedisContext> RedisContextPool::acquire() {
     }
 
     if (retries > MAX_RETRY_COUNT) {
-        Utils::error("Redis connection error: Failed to connect to Redis after " +
+        RAISE_ERROR("Redis connection error: Failed to connect to Redis after " +
                      to_string(MAX_RETRY_COUNT) + " retries");
     }
 

--- a/src/atomdb/redis_mongodb/RedisContextPool.cc
+++ b/src/atomdb/redis_mongodb/RedisContextPool.cc
@@ -78,7 +78,7 @@ shared_ptr<RedisContext> RedisContextPool::acquire() {
 
     if (retries > MAX_RETRY_COUNT) {
         RAISE_ERROR("Redis connection error: Failed to connect to Redis after " +
-                     to_string(MAX_RETRY_COUNT) + " retries");
+                    to_string(MAX_RETRY_COUNT) + " retries");
     }
 
     total_contexts++;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -213,7 +213,7 @@ shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(const s
 
         if (reply->type != REDIS_REPLY_STRING) {
             RAISE_ERROR("Invalid Redis response at query_for_targets: " + std::to_string(reply->type) +
-                         " != " + std::to_string(REDIS_REPLY_STRING));
+                        " != " + std::to_string(REDIS_REPLY_STRING));
         }
 
     } catch (const std::exception& e) {
@@ -906,7 +906,7 @@ vector<string> RedisMongoDB::add_links(const vector<atoms::Link*>& links,
         if (!existing_handles.empty()) {
             vector<string> existing_handles_vector(existing_handles.begin(), existing_handles.end());
             RAISE_ERROR("Failed to insert links, some links already exist: " +
-                         Utils::join(existing_handles_vector, ','));
+                        Utils::join(existing_handles_vector, ','));
             return {};
         }
     }

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -346,7 +346,9 @@ uint RedisMongoDB::get_next_score(const string& key) {
     auto ctx = this->redis_pool->acquire();
     string command = "GET " + key;
     redisReply* reply = ctx->execute(command.c_str());
-    if (reply == NULL) RAISE_ERROR("Redis error at get_next_score");
+    if (reply == NULL) {
+        RAISE_ERROR("Redis error at get_next_score");
+    }
 
     if (reply->type == REDIS_REPLY_NIL) return 0;
 

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -55,7 +55,7 @@ void RedisMongoDB::redis_setup(const JsonConfig& config) {
     string address = config.at_path("redis.endpoint").get<string>();
     auto tokens = Utils::split(address, ':');
     if (tokens.size() != 2) {
-        Utils::error("Invalid Redis configuration: endpoint must be in the format <hostname>:<port>");
+        RAISE_ERROR("Invalid Redis configuration: endpoint must be in the format <hostname>:<port>");
     }
     string host = tokens[0];
     string port = tokens[1];
@@ -63,7 +63,7 @@ void RedisMongoDB::redis_setup(const JsonConfig& config) {
     this->cluster_flag = config.at_path("redis.cluster").get_or<bool>(false);
 
     if (address.empty() || address == ":") {
-        Utils::error(
+        RAISE_ERROR(
             "Invalid Redis configuration: resolved address is empty. Check atomdb.redis in "
             "JsonConfig (endpoint or hostname/port).");
     }
@@ -81,7 +81,7 @@ void RedisMongoDB::mongodb_setup(const JsonConfig& config) {
         MONGODB_CHUNK_SIZE = chunk_size;
     }
     if (address.empty() || address == ":" || user.empty() || password.empty()) {
-        Utils::error(
+        RAISE_ERROR(
             "Invalid MongoDB configuration: need non-empty address, username, and password. "
             "Set atomdb.mongodb in JsonConfig (endpoint or hostname/port, username, password).");
     }
@@ -98,7 +98,7 @@ void RedisMongoDB::mongodb_setup(const JsonConfig& config) {
         mongodb.run_command(ping_cmd.view());
         LOG_INFO("Connected to MongoDB at " << address);
     } catch (const std::exception& e) {
-        Utils::error(e.what());
+        RAISE_ERROR(e.what());
     }
 }
 
@@ -175,12 +175,12 @@ shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(const Li
 
         reply = ctx->execute(command.c_str());
 
-        if (reply == NULL) Utils::error("Redis error at query_for_pattern");
+        if (reply == NULL) RAISE_ERROR("Redis error at query_for_pattern");
 
         if (reply->type != REDIS_REPLY_SET && reply->type != REDIS_REPLY_ARRAY) {
             auto error_type = std::to_string(reply->type);
             freeReplyObject(reply);
-            Utils::error("Invalid Redis response at query_for_pattern: " + error_type);
+            RAISE_ERROR("Invalid Redis response at query_for_pattern: " + error_type);
         }
 
         redis_cursor += REDIS_CHUNK_SIZE;
@@ -205,19 +205,19 @@ shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(const s
         auto command = "GET " + REDIS_OUTGOING_PREFIX + ":" + handle;
         reply = ctx->execute(command.c_str());
 
-        if (reply == NULL) Utils::error("Redis error at query_for_targets");
+        if (reply == NULL) RAISE_ERROR("Redis error at query_for_targets");
 
         if ((reply == NULL) || (reply->type == REDIS_REPLY_NIL)) {
             return nullptr;
         }
 
         if (reply->type != REDIS_REPLY_STRING) {
-            Utils::error("Invalid Redis response at query_for_targets: " + std::to_string(reply->type) +
+            RAISE_ERROR("Invalid Redis response at query_for_targets: " + std::to_string(reply->type) +
                          " != " + std::to_string(REDIS_REPLY_STRING));
         }
 
     } catch (const std::exception& e) {
-        Utils::error(e.what());
+        RAISE_ERROR(e.what());
     }
 
     // NOTE: Intentionally, we aren't destroying 'reply' objects.'reply' objects are destroyed in
@@ -245,12 +245,12 @@ shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_incoming_set(con
 
         reply = ctx->execute(command.c_str());
 
-        if (reply == NULL) Utils::error("Redis error at query_for_incoming_set");
+        if (reply == NULL) RAISE_ERROR("Redis error at query_for_incoming_set");
 
         if (reply->type != REDIS_REPLY_SET && reply->type != REDIS_REPLY_ARRAY) {
             auto error_type = std::to_string(reply->type);
             freeReplyObject(reply);
-            Utils::error("Invalid Redis response at query_for_incoming_set: " + error_type);
+            RAISE_ERROR("Invalid Redis response at query_for_incoming_set: " + error_type);
         }
 
         redis_cursor += REDIS_CHUNK_SIZE;
@@ -273,10 +273,10 @@ void RedisMongoDB::add_pattern(const string& pattern_handle, const string& handl
     string command = "ZADD " + REDIS_PATTERNS_PREFIX + ":" + pattern_handle + " " +
                      to_string(this->patterns_next_score.load()) + " " + handle;
     redisReply* reply = ctx->execute(command.c_str());
-    if (reply == NULL) Utils::error("Redis error at add_pattern: <" + command + ">");
+    if (reply == NULL) RAISE_ERROR("Redis error at add_pattern: <" + command + ">");
 
     if (reply->type != REDIS_REPLY_INTEGER) {
-        Utils::error("Invalid Redis response at add_pattern: " + std::to_string(reply->type));
+        RAISE_ERROR("Invalid Redis response at add_pattern: " + std::to_string(reply->type));
     }
 
     set_next_score(REDIS_PATTERNS_PREFIX + ":next_score", this->patterns_next_score.fetch_add(1));
@@ -308,10 +308,10 @@ void RedisMongoDB::add_patterns(const vector<pair<string, string>>& pattern_hand
         }
 
         redisReply* reply = ctx->execute(command.c_str());
-        if (reply == NULL) Utils::error("Redis error at add_patterns");
+        if (reply == NULL) RAISE_ERROR("Redis error at add_patterns");
 
         if (reply->type != REDIS_REPLY_INTEGER) {
-            Utils::error("Invalid Redis response at add_patterns: " + std::to_string(reply->type));
+            RAISE_ERROR("Invalid Redis response at add_patterns: " + std::to_string(reply->type));
         }
     }
     set_next_score(REDIS_PATTERNS_PREFIX + ":next_score", this->patterns_next_score.load());
@@ -325,9 +325,9 @@ void RedisMongoDB::delete_pattern(const string& handle) {
     string command = "DEL " + REDIS_PATTERNS_PREFIX + ":" + handle;
     redisReply* reply = ctx->execute(command.c_str());
 
-    if (reply == NULL) Utils::error("Redis error at delete_pattern");
+    if (reply == NULL) RAISE_ERROR("Redis error at delete_pattern");
     if (reply->type != REDIS_REPLY_INTEGER) {
-        Utils::error("Invalid Redis response at delete_pattern: " + std::to_string(reply->type));
+        RAISE_ERROR("Invalid Redis response at delete_pattern: " + std::to_string(reply->type));
     }
 }
 
@@ -337,7 +337,7 @@ void RedisMongoDB::update_pattern(const string& key, const string& value) {
     auto ctx = this->redis_pool->acquire();
     string command = "ZREM " + REDIS_PATTERNS_PREFIX + ":" + key + " " + value;
     redisReply* reply = ctx->execute(command.c_str());
-    if (reply == NULL) Utils::error("Redis error at update_pattern");
+    if (reply == NULL) RAISE_ERROR("Redis error at update_pattern");
 }
 
 uint RedisMongoDB::get_next_score(const string& key) {
@@ -346,12 +346,12 @@ uint RedisMongoDB::get_next_score(const string& key) {
     auto ctx = this->redis_pool->acquire();
     string command = "GET " + key;
     redisReply* reply = ctx->execute(command.c_str());
-    if (reply == NULL) Utils::error("Redis error at get_next_score");
+    if (reply == NULL) RAISE_ERROR("Redis error at get_next_score");
 
     if (reply->type == REDIS_REPLY_NIL) return 0;
 
     if (reply->type != REDIS_REPLY_STRING) {
-        Utils::error("Invalid Redis response at get_next_score: " + std::to_string(reply->type));
+        RAISE_ERROR("Invalid Redis response at get_next_score: " + std::to_string(reply->type));
     }
 
     return std::stoi(reply->str);
@@ -370,10 +370,10 @@ void RedisMongoDB::set_next_score_with_context(shared_ptr<RedisContext> ctx,
 
     string command = "SET " + key + " " + to_string(score);
     redisReply* reply = ctx->execute(command.c_str());
-    if (reply == NULL) Utils::error("Redis error at set_next_score: <" + command + ">");
+    if (reply == NULL) RAISE_ERROR("Redis error at set_next_score: <" + command + ">");
 
     if (reply->type != REDIS_REPLY_STATUS) {
-        Utils::error("Invalid Redis response at set_next_score: " + std::to_string(reply->type));
+        RAISE_ERROR("Invalid Redis response at set_next_score: " + std::to_string(reply->type));
     }
 }
 
@@ -391,10 +391,10 @@ void RedisMongoDB::add_outgoing_set(const string& handle, const vector<string>& 
         command += outgoing_handle;
     }
     redisReply* reply = ctx->execute(command.c_str());
-    if (reply == NULL) Utils::error("Redis error at add_outgoing_set");
+    if (reply == NULL) RAISE_ERROR("Redis error at add_outgoing_set");
 
     if (reply->type != REDIS_REPLY_STATUS) {
-        Utils::error("Invalid Redis response at add_outgoing_set: " + std::to_string(reply->type));
+        RAISE_ERROR("Invalid Redis response at add_outgoing_set: " + std::to_string(reply->type));
     }
 }
 
@@ -404,7 +404,7 @@ void RedisMongoDB::delete_outgoing_set(const string& handle) {
     auto ctx = this->redis_pool->acquire();
     string command = "DEL " + REDIS_OUTGOING_PREFIX + ":" + handle;
     redisReply* reply = ctx->execute(command.c_str());
-    if (reply == NULL) Utils::error("Redis error at delete_outgoing_set");
+    if (reply == NULL) RAISE_ERROR("Redis error at delete_outgoing_set");
 }
 
 void RedisMongoDB::add_incoming_set(const string& handle, const string& incoming_handle) {
@@ -414,10 +414,10 @@ void RedisMongoDB::add_incoming_set(const string& handle, const string& incoming
     string command = "ZADD " + REDIS_INCOMING_PREFIX + ":" + handle + " " +
                      to_string(this->incoming_set_next_score.load()) + " " + incoming_handle;
     redisReply* reply = ctx->execute(command.c_str());
-    if (reply == NULL) Utils::error("Redis error at add_incoming_set");
+    if (reply == NULL) RAISE_ERROR("Redis error at add_incoming_set");
 
     if (reply->type != REDIS_REPLY_INTEGER) {
-        Utils::error("Invalid Redis response at add_incoming_set: " + std::to_string(reply->type));
+        RAISE_ERROR("Invalid Redis response at add_incoming_set: " + std::to_string(reply->type));
     }
 
     set_next_score(REDIS_INCOMING_PREFIX + ":next_score", this->incoming_set_next_score.fetch_add(1));
@@ -431,9 +431,9 @@ void RedisMongoDB::delete_incoming_set(const string& handle) {
     string command = "DEL " + REDIS_INCOMING_PREFIX + ":" + handle;
     redisReply* reply = ctx->execute(command.c_str());
 
-    if (reply == NULL) Utils::error("Redis error at delete_incoming_set");
+    if (reply == NULL) RAISE_ERROR("Redis error at delete_incoming_set");
     if (reply->type != REDIS_REPLY_INTEGER) {
-        Utils::error("Invalid Redis response at delete_incoming_set: " + std::to_string(reply->type));
+        RAISE_ERROR("Invalid Redis response at delete_incoming_set: " + std::to_string(reply->type));
     }
 }
 
@@ -445,9 +445,9 @@ void RedisMongoDB::update_incoming_set(const string& key, const string& value) {
     string command = "ZREM " + REDIS_INCOMING_PREFIX + ":" + key + " " + value;
     redisReply* reply = ctx->execute(command.c_str());
 
-    if (reply == NULL) Utils::error("Redis error at update_incoming_set");
+    if (reply == NULL) RAISE_ERROR("Redis error at update_incoming_set");
     if (reply->type != REDIS_REPLY_INTEGER) {
-        Utils::error("Invalid Redis response at update_incoming_set: " + std::to_string(reply->type));
+        RAISE_ERROR("Invalid Redis response at update_incoming_set: " + std::to_string(reply->type));
     }
 }
 
@@ -525,7 +525,7 @@ vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_filtered_do
             skip += MONGODB_CHUNK_SIZE;
         }
     } catch (const exception& e) {
-        Utils::error("MongoDB error at get_filtered_documents(): " + string(e.what()));
+        RAISE_ERROR("MongoDB error at get_filtered_documents(): " + string(e.what()));
     }
 
     return atom_documents;
@@ -575,7 +575,7 @@ vector<shared_ptr<atomdb_api_types::AtomDocument>> RedisMongoDB::get_documents(
             }
         }
     } catch (const exception& e) {
-        Utils::error("MongoDB error: " + string(e.what()));
+        RAISE_ERROR("MongoDB error: " + string(e.what()));
     }
 
     return atom_documents;
@@ -697,7 +697,7 @@ set<string> RedisMongoDB::documents_exist(const vector<string>& handles, const s
             }
         }
     } catch (const exception& e) {
-        Utils::error("MongoDB error: " + string(e.what()));
+        RAISE_ERROR("MongoDB error: " + string(e.what()));
     }
 
     return existing_handles;
@@ -744,7 +744,7 @@ bool RedisMongoDB::upsert_document(const bsoncxx::v_noabi::document::value& docu
     auto reply = mongodb_collection.replace_one(filter_builder.view(), document.view(), opts);
 
     if (!reply) {
-        Utils::error("Failed to upsert document into MongoDB");
+        RAISE_ERROR("Failed to upsert document into MongoDB");
     }
 
     return reply->matched_count() > 0 || reply->modified_count() > 0 ||
@@ -796,7 +796,7 @@ uint RedisMongoDB::upsert_documents(const std::vector<bsoncxx::document::value>&
             opts.ordered(false);
             auto reply = mongodb_collection.bulk_write(operations, opts);
             if (!reply) {
-                Utils::error("Failed to upsert documents into MongoDB");
+                RAISE_ERROR("Failed to upsert documents into MongoDB");
             } else {
                 total_modified += reply->modified_count() + reply->upserted_count();
             }
@@ -808,13 +808,13 @@ uint RedisMongoDB::upsert_documents(const std::vector<bsoncxx::document::value>&
 
 string RedisMongoDB::add_node(const atoms::Node* node, bool throw_if_exists) {
     if (throw_if_exists && node_exists(node->handle())) {
-        Utils::error("Node already exists: " + node->handle());
+        RAISE_ERROR("Node already exists: " + node->handle());
         return "";
     }
 
     auto mongodb_doc = atomdb_api_types::MongodbDocument(node);
     if (!this->upsert_document(mongodb_doc.value(), MONGODB_NODES_COLLECTION_NAME)) {
-        Utils::error("Failed to insert node into MongoDB");
+        RAISE_ERROR("Failed to insert node into MongoDB");
         return "";
     }
     return node->handle();
@@ -872,7 +872,7 @@ vector<string> RedisMongoDB::add_nodes(const vector<atoms::Node*>& nodes,
     if (throw_if_exists) {
         auto existing_handles = this->nodes_exist(handles);
         if (existing_handles.size() > 0) {
-            Utils::error("Failed to insert nodes, some nodes already exist.");
+            RAISE_ERROR("Failed to insert nodes, some nodes already exist.");
             return {};
         }
     }
@@ -903,7 +903,7 @@ vector<string> RedisMongoDB::add_links(const vector<atoms::Link*>& links,
         auto existing_handles = this->links_exist(handles);
         if (!existing_handles.empty()) {
             vector<string> existing_handles_vector(existing_handles.begin(), existing_handles.end());
-            Utils::error("Failed to insert links, some links already exist: " +
+            RAISE_ERROR("Failed to insert links, some links already exist: " +
                          Utils::join(existing_handles_vector, ','));
             return {};
         }
@@ -1213,7 +1213,7 @@ vector<string> RedisMongoDB::match_pattern_index_schema(const Link* link) {
                     } else {
                         string assignment_value = assignment.get(token);
                         if (assignment_value == "") {
-                            Utils::error("LinkSchema assignments don't have variable: " + token);
+                            RAISE_ERROR("LinkSchema assignments don't have variable: " + token);
                         }
                         hash_entries.push_back(assignment_value);
                     }
@@ -1306,7 +1306,7 @@ void RedisMongoDB::flush_redis_by_prefix(const string& prefix) {
             "SCAN " + cursor + " MATCH " + prefix + ":* COUNT " + to_string(REDIS_CHUNK_SIZE);
         redisReply* reply = ctx->execute(scan_cmd.c_str());
         if (reply == NULL || reply->type != REDIS_REPLY_ARRAY || reply->elements < 2) {
-            Utils::error("Redis error at flush_redis_by_prefix");
+            RAISE_ERROR("Redis error at flush_redis_by_prefix");
         }
         cursor = reply->element[0]->str;
         redisReply* keys = reply->element[1];
@@ -1318,7 +1318,7 @@ void RedisMongoDB::flush_redis_by_prefix(const string& prefix) {
             }
             redisReply* del_reply = ctx->execute(del_cmd.c_str());
             if (del_reply == NULL) {
-                Utils::error("Redis error at flush_redis_by_prefix");
+                RAISE_ERROR("Redis error at flush_redis_by_prefix");
             }
             freeReplyObject(del_reply);
         }
@@ -1387,7 +1387,7 @@ void RedisMongoDB::check_existing_targets(const vector<atoms::Link*>& links) {
                                  {MONGODB_FIELD_NAME[MONGODB_FIELD::ID]});
     LOG_DEBUG("Existing targets size: " + to_string(existing_targets.size()));
     if (existing_targets.size() != unique_targets.size()) {
-        Utils::error("Failed to insert links: some targets are missing");
+        RAISE_ERROR("Failed to insert links: some targets are missing");
     }
 }
 // end of composite_type and composite_type_hash helper functions

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
@@ -45,12 +45,12 @@ shared_ptr<HandleSetIterator> HandleSetRedis::get_iterator() {
 }
 
 map<string, string> HandleSetRedis::get_metta_expressions_by_handle(const string& handle) {
-    Utils::error("HandleSetRedis does not support get_metta_expressions_by_handle");
+    RAISE_ERROR("HandleSetRedis does not support get_metta_expressions_by_handle");
     return {};
 }
 
 Assignment HandleSetRedis::get_assignments_by_handle(const string& handle) {
-    Utils::error("HandleSetRedis does not support get_assignments_by_handle");
+    RAISE_ERROR("HandleSetRedis does not support get_assignments_by_handle");
     return {};
 }
 
@@ -111,7 +111,7 @@ RedisStringBundle::~RedisStringBundle() {
 
 const char* RedisStringBundle::get_handle(unsigned int index) {
     if (index > this->handles_size) {
-        Utils::error("Handle index out of bounds: " + to_string(index) +
+        RAISE_ERROR("Handle index out of bounds: " + to_string(index) +
                      " Answer handles size: " + to_string(this->handles_size));
     }
     //
@@ -172,7 +172,7 @@ void add_custom_attributes(bsoncxx::builder::basic::document& doc, const Propert
                         custom_attributes_doc.append(bsoncxx::builder::basic::kvp(key, arg));
                     } else {
                         // MongoDB does not support unsigned int.
-                        Utils::error("MongoDB does not support custom attribute '" + key +
+                        RAISE_ERROR("MongoDB does not support custom attribute '" + key +
                                      "' with type: " + typeid(T).name());
                     }
                 },
@@ -201,7 +201,7 @@ Properties MongodbDocument::extract_custom_attributes(const bsoncxx::v_noabi::do
                 custom_attributes[key] = value.get_bool().value;
                 break;
             default:
-                Utils::error("Unknown custom attribute type: " + key +
+                RAISE_ERROR("Unknown custom attribute type: " + key +
                              " type: " + to_string(value.type()));
         }
     }

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
@@ -112,7 +112,7 @@ RedisStringBundle::~RedisStringBundle() {
 const char* RedisStringBundle::get_handle(unsigned int index) {
     if (index > this->handles_size) {
         RAISE_ERROR("Handle index out of bounds: " + to_string(index) +
-                     " Answer handles size: " + to_string(this->handles_size));
+                    " Answer handles size: " + to_string(this->handles_size));
     }
     //
     return handles[index];
@@ -173,7 +173,7 @@ void add_custom_attributes(bsoncxx::builder::basic::document& doc, const Propert
                     } else {
                         // MongoDB does not support unsigned int.
                         RAISE_ERROR("MongoDB does not support custom attribute '" + key +
-                                     "' with type: " + typeid(T).name());
+                                    "' with type: " + typeid(T).name());
                     }
                 },
                 value);
@@ -202,7 +202,7 @@ Properties MongodbDocument::extract_custom_attributes(const bsoncxx::v_noabi::do
                 break;
             default:
                 RAISE_ERROR("Unknown custom attribute type: " + key +
-                             " type: " + to_string(value.type()));
+                            " type: " + to_string(value.type()));
         }
     }
     return Properties(custom_attributes.begin(), custom_attributes.end());

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -42,7 +42,7 @@ shared_ptr<AtomDB> create_atomdb_from_config(const JsonConfig& config) {
         return atomdb;
     }
 
-    Utils::error("Unknown AtomDB type for peer " + uid + ": " + type);
+    RAISE_ERROR("Unknown AtomDB type for peer " + uid + ": " + type);
     return nullptr;
 }
 

--- a/src/attention_broker/AttentionBrokerClient.cc
+++ b/src/attention_broker/AttentionBrokerClient.cc
@@ -34,7 +34,7 @@ void AttentionBrokerClient::correlate(const set<string>& handles, const string& 
         LOG_INFO("Calling AttentionBroker GRPC. Correlating " << handle_list.list_size() << " handles");
         stub->correlate(new grpc::ClientContext(), handle_list, &ack);
         if (ack.msg() != "CORRELATE") {
-            Utils::error("Failed GRPC command: AttentionBroker::correlate()");
+            RAISE_ERROR("Failed GRPC command: AttentionBroker::correlate()");
         }
     } else {
         LOG_INFO("No handles to correlate");
@@ -56,7 +56,7 @@ void AttentionBrokerClient::asymmetric_correlate(const vector<string>& handles, 
                                                                            << " handles");
         stub->asymmetric_correlate(new grpc::ClientContext(), handle_list, &ack);
         if (ack.msg() != "ASYMMETRIC_CORRELATE") {
-            Utils::error("Failed GRPC command: AttentionBroker::asymmetric_correlate()");
+            RAISE_ERROR("Failed GRPC command: AttentionBroker::asymmetric_correlate()");
         }
     } else {
         LOG_INFO("No handles to correlate (asymmetric)");
@@ -81,7 +81,7 @@ void AttentionBrokerClient::stimulate(const map<string, unsigned int>& handle_ma
                                                           << " handles");
     stub->stimulate(new grpc::ClientContext(), handle_count, &ack);
     if (ack.msg() != "STIMULATE") {
-        Utils::error("Failed GRPC command: AttentionBroker::stimulate()");
+        RAISE_ERROR("Failed GRPC command: AttentionBroker::stimulate()");
     }
 }
 
@@ -113,7 +113,7 @@ void AttentionBrokerClient::set_determiners(const vector<vector<string>>& handle
                                                                           << " handles");
         stub->set_determiners(new grpc::ClientContext(), request, &ack);
         if (ack.msg() != "SET_DETERMINERS") {
-            Utils::error("Failed GRPC command: AttentionBroker::set_determiners()");
+            RAISE_ERROR("Failed GRPC command: AttentionBroker::set_determiners()");
         }
         request.clear_list();
         handle_count = 0;
@@ -167,7 +167,7 @@ void AttentionBrokerClient::set_parameters(float rent_rate,
              << " SPREADING_RATE_UPPERBOUND: " << request.spreading_rate_upperbound());
     stub->set_parameters(new grpc::ClientContext(), request, &ack);
     if (ack.msg() != "SET_PARAMETERS") {
-        Utils::error("Failed GRPC command: AttentionBroker::set_parameters()");
+        RAISE_ERROR("Failed GRPC command: AttentionBroker::set_parameters()");
     }
 }
 
@@ -189,7 +189,7 @@ bool AttentionBrokerClient::health_check(bool throw_on_error) {
 }
 
 void AttentionBrokerClient::save_context(const string& context, const string& file_name) {
-    Utils::error("AttentionBrokerClient::save_context() is not implemented.");
+    RAISE_ERROR("AttentionBrokerClient::save_context() is not implemented.");
 }
 
 void AttentionBrokerClient::drop_and_load_context(const string& context, const string& file_name) {
@@ -207,6 +207,6 @@ void AttentionBrokerClient::drop_and_load_context(const string& context, const s
         context + " File name: " + file_name);
     stub->drop_and_load_context(new grpc::ClientContext(), request, &ack);
     if (ack.msg() != "DROP_AND_LOAD_CONTEXT") {
-        Utils::error("Failed GRPC command: AttentionBroker::drop_and_load_context()");
+        RAISE_ERROR("Failed GRPC command: AttentionBroker::drop_and_load_context()");
     }
 }

--- a/src/attention_broker/AttentionBrokerServer.cc
+++ b/src/attention_broker/AttentionBrokerServer.cc
@@ -308,7 +308,7 @@ Status AttentionBrokerServer::drop_and_load_context(ServerContext* grpc_context,
             line_count++;
             if (line.size() < 2) {
                 RAISE_ERROR("Invalid context command with no arguments in line " +
-                             std::to_string(line_count) + " of file " + file_name);
+                            std::to_string(line_count) + " of file " + file_name);
             }
             if (line[0] == "DET") {
                 for (unsigned int i = 1; i < line.size(); i++) {

--- a/src/attention_broker/AttentionBrokerServer.cc
+++ b/src/attention_broker/AttentionBrokerServer.cc
@@ -272,7 +272,7 @@ Status AttentionBrokerServer::drop_and_load_context(ServerContext* grpc_context,
 Status AttentionBrokerServer::save_context(ServerContext* grpc_context,
                                            const dasproto::ContextPersistence* request,
                                            dasproto::Ack* reply) {
-    Utils::error("AttentionBrokerServer::save_context() is not implemented");
+    RAISE_ERROR("AttentionBrokerServer::save_context() is not implemented");
     return Status::CANCELLED;
 }
 
@@ -307,7 +307,7 @@ Status AttentionBrokerServer::drop_and_load_context(ServerContext* grpc_context,
         while (Utils::read_and_split(line, file)) {
             line_count++;
             if (line.size() < 2) {
-                Utils::error("Invalid context command with no arguments in line " +
+                RAISE_ERROR("Invalid context command with no arguments in line " +
                              std::to_string(line_count) + " of file " + file_name);
             }
             if (line[0] == "DET") {
@@ -335,7 +335,7 @@ Status AttentionBrokerServer::drop_and_load_context(ServerContext* grpc_context,
                     sum_activation++;
                 }
             } else {
-                Utils::error("Invalid context mnemonic: " + line[0] + " in context file: " + file_name);
+                RAISE_ERROR("Invalid context mnemonic: " + line[0] + " in context file: " + file_name);
             }
             line.clear();
         }

--- a/src/attention_broker/HebbianNetwork.cc
+++ b/src/attention_broker/HebbianNetwork.cc
@@ -173,7 +173,7 @@ static bool visit_serialize_determiners(HandleTrie::TrieNode* trie_node, void* d
         visit_data->network->visit_nodes(false, &visit_find_handle, (void*) visit_data);
         trie_node->trie_node_mutex.lock();
         if (visit_data->handle == "") {
-            Utils::error("Invalid determiner");
+            RAISE_ERROR("Invalid determiner");
         }
         visit_data->stream->write(visit_data->handle.c_str(), HANDLE_HASH_SIZE - 1);
     }
@@ -187,7 +187,7 @@ static bool visit_serialize_edge(HandleTrie::TrieNode* trie_node, void* data) {
     visit_data->node = edge->node1;
     visit_data->network->visit_nodes(false, &visit_find_handle, (void*) visit_data);
     if (visit_data->handle == "") {
-        Utils::error("Invalid neighbor");
+        RAISE_ERROR("Invalid neighbor");
     }
     visit_data->stream->write(visit_data->handle.c_str(), HANDLE_HASH_SIZE - 1);
     visit_data->stream->write(trie_node->suffix.c_str(), HANDLE_HASH_SIZE - 1);

--- a/src/attention_broker/HebbianNetworkUpdater.cc
+++ b/src/attention_broker/HebbianNetworkUpdater.cc
@@ -21,7 +21,7 @@ HebbianNetworkUpdater* HebbianNetworkUpdater::factory(HebbianNetworkUpdaterType 
             return new ExactCountHebbianUpdater();
         }
         default: {
-            Utils::error("Invalid HebbianNetworkUpdaterType: " + to_string((int) instance_type));
+            RAISE_ERROR("Invalid HebbianNetworkUpdaterType: " + to_string((int) instance_type));
             return NULL;  // to avoid warnings
         }
     }

--- a/src/attention_broker/RequestSelector.cc
+++ b/src/attention_broker/RequestSelector.cc
@@ -35,7 +35,7 @@ RequestSelector* RequestSelector::factory(SelectorType instance_type,
             return new EvenThreadCount(thread_id, stimulus, correlation);
         }
         default: {
-            Utils::error("Invalid selector type: " + to_string((int) instance_type));
+            RAISE_ERROR("Invalid selector type: " + to_string((int) instance_type));
             return NULL;  // to avoid warnings
         }
     }

--- a/src/attention_broker/StimulusSpreader.cc
+++ b/src/attention_broker/StimulusSpreader.cc
@@ -24,7 +24,7 @@ StimulusSpreader* StimulusSpreader::factory(StimulusSpreaderType instance_type) 
             return new TokenSpreader();
         }
         default: {
-            Utils::error("Invalid StimulusSpreaderType: " + to_string((int) instance_type));
+            RAISE_ERROR("Invalid StimulusSpreaderType: " + to_string((int) instance_type));
             return NULL;  // to avoid warnings
         }
     }
@@ -138,7 +138,7 @@ void TokenSpreader::distribute_wages(const dasproto::HandleCount* handle_count,
                                      DATA* data) {
     auto iterator = handle_count->map().find("SUM");
     if (iterator == handle_count->map().end()) {
-        Utils::error("Missing 'SUM' key in HandleCount request");
+        RAISE_ERROR("Missing 'SUM' key in HandleCount request");
     }
     unsigned int total_wages = iterator->second;
     LOG_DEBUG("Total wages: " + std::to_string(total_wages));

--- a/src/attention_broker/WorkerThreads.cc
+++ b/src/attention_broker/WorkerThreads.cc
@@ -64,7 +64,7 @@ void WorkerThreads::worker_thread(unsigned int thread_id,
                     break;
                 }
                 default: {
-                    Utils::error("Invalid request type: " + to_string((int) request.first));
+                    RAISE_ERROR("Invalid request type: " + to_string((int) request.first));
                 }
             }
         } else {

--- a/src/commons/Assignment.cc
+++ b/src/commons/Assignment.cc
@@ -20,12 +20,12 @@ bool Assignment::assign(const string& label, const string& value) {
     if (iterator == this->table.end()) {
         // label is not present, so makes the assignment and return true
         if (label.size() > MAX_VARIABLE_NAME_SIZE) {
-            Utils::error("Invalid assignment. Label size (" + std::to_string(label.size()) +
+            RAISE_ERROR("Invalid assignment. Label size (" + std::to_string(label.size()) +
                          ") is too large (> " + std::to_string(MAX_VARIABLE_NAME_SIZE) + ").");
         }
         this->table[label] = value;
         if (this->table.size() > MAX_NUMBER_OF_VARIABLES_IN_QUERY) {
-            Utils::error("Assignment size exceeds the maximal number of allowed variables in a query: " +
+            RAISE_ERROR("Assignment size exceeds the maximal number of allowed variables in a query: " +
                          std::to_string(MAX_NUMBER_OF_VARIABLES_IN_QUERY));
         }
         return true;

--- a/src/commons/Assignment.cc
+++ b/src/commons/Assignment.cc
@@ -21,12 +21,12 @@ bool Assignment::assign(const string& label, const string& value) {
         // label is not present, so makes the assignment and return true
         if (label.size() > MAX_VARIABLE_NAME_SIZE) {
             RAISE_ERROR("Invalid assignment. Label size (" + std::to_string(label.size()) +
-                         ") is too large (> " + std::to_string(MAX_VARIABLE_NAME_SIZE) + ").");
+                        ") is too large (> " + std::to_string(MAX_VARIABLE_NAME_SIZE) + ").");
         }
         this->table[label] = value;
         if (this->table.size() > MAX_NUMBER_OF_VARIABLES_IN_QUERY) {
             RAISE_ERROR("Assignment size exceeds the maximal number of allowed variables in a query: " +
-                         std::to_string(MAX_NUMBER_OF_VARIABLES_IN_QUERY));
+                        std::to_string(MAX_NUMBER_OF_VARIABLES_IN_QUERY));
         }
         return true;
     } else {

--- a/src/commons/HandleTrie.cc
+++ b/src/commons/HandleTrie.cc
@@ -64,7 +64,7 @@ string HandleTrie::TrieNode::to_string() {
 
 HandleTrie::HandleTrie(unsigned int key_size) {
     if (key_size == 0 || key_size > 255) {
-        Utils::error("Invalid key size: " + to_string(key_size));
+        RAISE_ERROR("Invalid key size: " + to_string(key_size));
     }
     this->key_size = key_size;
     if (!HandleTrie::TLB_INITIALIZED) {
@@ -78,11 +78,11 @@ HandleTrie::~HandleTrie() { delete root; }
 
 HandleTrie::TrieValue* HandleTrie::insert(const string& key, TrieValue* value) {
     if (key.size() != key_size) {
-        Utils::error("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
+        RAISE_ERROR("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
     }
 
     if (value == NULL) {
-        Utils::error("Value cannot be NULL");
+        RAISE_ERROR("Value cannot be NULL");
     }
 
     TrieNode* tree_cursor = root;
@@ -185,7 +185,7 @@ HandleTrie::TrieValue* HandleTrie::lookup(const string& key) {
 
 HandleTrie::TrieNode* HandleTrie::lookup_node(const string& key) {
     if (key.size() != key_size) {
-        Utils::error("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
+        RAISE_ERROR("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
     }
 
     TrieNode* tree_cursor = root;

--- a/src/commons/JsonConfig.cc
+++ b/src/commons/JsonConfig.cc
@@ -70,7 +70,7 @@ JsonConfig::JsonConfig(nlohmann::json root) : nlohmann::json(std::move(root)) {}
 string JsonConfig::get_schema_version() const {
     string version = value("schema_version", string(""));
     if (version.empty()) {
-        Utils::error("schema_version is missing", true);
+        RAISE_ERROR("schema_version is missing");
     }
     return version;
 }

--- a/src/commons/JsonConfigParser.cc
+++ b/src/commons/JsonConfigParser.cc
@@ -53,7 +53,7 @@ void validate_schema_version(const JsonConfig& config, vector<string>& required)
     }
     if (!missing.empty()) {
         string version = config.get_schema_version();
-        Utils::error(required_fields_error(version, missing), true);
+        RAISE_ERROR(required_fields_error(version, missing));
     }
 }
 
@@ -62,7 +62,7 @@ JsonConfig parse_and_validate(const string& json_str, bool is_node) {
     try {
         config = JsonConfig(json::parse(json_str));
     } catch (const exception& e) {
-        Utils::error("Invalid JSON in config: " + string(e.what()), true);
+        RAISE_ERROR("Invalid JSON in config: " + string(e.what()));
     }
     string version = config.get_schema_version();
     try {
@@ -70,7 +70,7 @@ JsonConfig parse_and_validate(const string& json_str, bool is_node) {
                                           : required_client_fields_by_version().at(version);
         validate_schema_version(config, required);
     } catch (const exception& e) {
-        Utils::error("Invalid schema version: " + version + " " + string(e.what()), true);
+        RAISE_ERROR("Invalid schema version: " + version + " " + string(e.what()));
     }
     return config;
 }

--- a/src/commons/Properties.h
+++ b/src/commons/Properties.h
@@ -79,7 +79,7 @@ class Properties : public unordered_map<string, PropertyValue> {
                 return *attr;
             }
         }
-        Utils::error("Unkown property key: " + key);
+        RAISE_ERROR("Unkown property key: " + key);
         return T();
     }
 
@@ -234,14 +234,14 @@ class Properties : public unordered_map<string, PropertyValue> {
                     } else if (value == "false") {
                         (*this)[key] = false;
                     } else {
-                        Utils::error("Invalid 'bool' string value: " + value);
+                        RAISE_ERROR("Invalid 'bool' string value: " + value);
                     }
                 } else {
-                    Utils::error("Invalid token type: " + type);
+                    RAISE_ERROR("Invalid token type: " + type);
                 }
             }
         } else {
-            Utils::error("Invalid tokens vector size: " + std::to_string(tokens.size()));
+            RAISE_ERROR("Invalid tokens vector size: " + std::to_string(tokens.size()));
         }
     }
 };

--- a/src/commons/StoppableThread.cc
+++ b/src/commons/StoppableThread.cc
@@ -28,7 +28,7 @@ void StoppableThread::stop() { this->stop(true); }
 
 void StoppableThread::stop(bool join_thread) {
     if (this->thread_object == NULL) {
-        Utils::error("No thread attached to StoppableThread: " + this->id);
+        RAISE_ERROR("No thread attached to StoppableThread: " + this->id);
     } else if (!this->stop_flag) {
         LOG_DEBUG("Stopping thread: " << this->id);
         this->stop_flag_mutex.lock();

--- a/src/commons/ThreadSafeHashmap.h
+++ b/src/commons/ThreadSafeHashmap.h
@@ -27,7 +27,7 @@ class ThreadSafeHashmap {
         lock_guard<mutex> semaphore(this->api_mutex);
         auto iterator = this->table.find(key);
         if (iterator == this->table.end()) {
-            Utils::error("Lookup for non-existent key in ThreadSafeHashmap");
+            RAISE_ERROR("Lookup for non-existent key in ThreadSafeHashmap");
         }
         return iterator->second;
     }

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -38,7 +38,7 @@ bool Utils::flip_coin(double true_probability) {
 
 unsigned int Utils::uint_rand(unsigned int closed_lower_bound, unsigned int open_upper_bound) {
     if (open_upper_bound <= closed_lower_bound) {
-        Utils::error("Invalid bounds");
+        RAISE_ERROR("Invalid bounds");
     }
     return (rand() % (open_upper_bound - closed_lower_bound)) + closed_lower_bound;
 }
@@ -159,7 +159,7 @@ bool Utils::is_number(const string& s) {
 
 float Utils::string_to_float(const string& s) {
     if (s.empty()) {
-        Utils::error("Can't convert empty string to float");
+        RAISE_ERROR("Can't convert empty string to float");
         return 0;
     } else {
         char* end_ptr;
@@ -167,7 +167,7 @@ float Utils::string_to_float(const string& s) {
         if ((*end_ptr == '\0') && (end_ptr != s.c_str())) {
             return value;
         } else {
-            Utils::error("Can't convert string \"" + s + "\" to float");
+            RAISE_ERROR("Can't convert string \"" + s + "\" to float");
             return 0;
         }
     }
@@ -182,11 +182,11 @@ int Utils::string_to_int(const string& s) {
 
 unsigned int Utils::string_to_uint(const string& s) {
     if (!is_number(s)) {
-        Utils::error("Can not convert string to unsigned int: Invalid arguments (" + s + ")");
+        RAISE_ERROR("Can not convert string to unsigned int: Invalid arguments (" + s + ")");
     }
     int n = stoi(s);
     if (n < 0) {
-        Utils::error("Can not convert string to unsigned int: Invalid negative number (" + s + ")");
+        RAISE_ERROR("Can not convert string to unsigned int: Invalid negative number (" + s + ")");
     }
     return (unsigned int) n;
 }
@@ -211,7 +211,7 @@ string Utils::linux_command_line(const char* cmd) {
     std::string answer;
     FILE* pipe = popen(cmd, "r");
     if (!pipe) {
-        Utils::error("Command line failed");
+        RAISE_ERROR("Command line failed");
         return "";
     }
     try {
@@ -424,7 +424,7 @@ void MemoryFootprint::check(const string& tag) {
         delta_ram.push_back(make_pair(snapshot - this->last_snapshot, tag));
         this->last_snapshot = snapshot;
     } else {
-        Utils::error("MemoryFootprint is not running");
+        RAISE_ERROR("MemoryFootprint is not running");
     }
 }
 
@@ -436,7 +436,7 @@ void MemoryFootprint::stop(const string& tag) {
         this->final_snapshot = Utils::get_current_ram_usage();
         this->running = false;
     } else {
-        Utils::error("MemoryFootprint is not running");
+        RAISE_ERROR("MemoryFootprint is not running");
     }
 }
 

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <vector>
+
 #include "Logger.h"
 
 using namespace std;
@@ -85,9 +86,10 @@ class Utils {
 
 }  // namespace commons
 
-#define RAISE_ERROR(msg) {    \
-    LOG_ERROR(msg);           \
-    Utils::error(msg, true);  \
-}                             \
+#define RAISE_ERROR(msg)         \
+    {                            \
+        LOG_ERROR(msg);          \
+        Utils::error(msg, true); \
+    }
 
 #endif  // _COMMONS_UTILS_H

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -85,8 +85,9 @@ class Utils {
 
 }  // namespace commons
 
-#define RAISE_ERROR(msg) \
-    LOG_ERROR(msg);      \
-    Utils::error(msg, true);   \
+#define RAISE_ERROR(msg) {    \
+    LOG_ERROR(msg);           \
+    Utils::error(msg, true);  \
+}                             \
 
 #endif  // _COMMONS_UTILS_H

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include "Logger.h"
 
 using namespace std;
 
@@ -50,7 +51,7 @@ class Utils {
     Utils() {}
     ~Utils() {}
 
-    static void error(string msg, bool throw_flag = true);
+    static void error(string msg, bool throw_flag);
     static bool flip_coin(double true_probability = 0.5);
     static unsigned int uint_rand(unsigned int open_upper_bound);
     static unsigned int uint_rand(unsigned int closed_lower_bound, unsigned int open_upper_bound);
@@ -83,5 +84,9 @@ class Utils {
 };
 
 }  // namespace commons
+
+#define RAISE_ERROR(msg) \
+    LOG_ERROR(msg);      \
+    Utils::error(msg, true);   \
 
 #endif  // _COMMONS_UTILS_H

--- a/src/commons/atoms/Atom.cc
+++ b/src/commons/atoms/Atom.cc
@@ -41,7 +41,7 @@ bool Atom::operator!=(const Atom& other) { return !(*this == other); }
 
 void Atom::validate() const {
     if (this->type.empty()) {
-        Utils::error("Atom type must not be empty");
+        RAISE_ERROR("Atom type must not be empty");
     }
 }
 

--- a/src/commons/atoms/Link.cc
+++ b/src/commons/atoms/Link.cc
@@ -42,10 +42,10 @@ bool Link::operator!=(const Link& other) { return !(*this == other); }
 
 void Link::validate() const {
     if (this->type == Atom::UNDEFINED_TYPE) {
-        Utils::error("Link type can't be '" + Atom::UNDEFINED_TYPE + "'");
+        RAISE_ERROR("Link type can't be '" + Atom::UNDEFINED_TYPE + "'");
     }
     if (this->targets.size() == 0) {
-        Utils::error("Link must have at least 1 target");
+        RAISE_ERROR("Link must have at least 1 target");
     }
 }
 
@@ -91,7 +91,7 @@ vector<string> Link::composite_type(HandleDecoder& decoder) const {
     for (string handle : this->targets) {
         shared_ptr<Atom> atom = decoder.get_atom(handle);
         if (atom == nullptr) {
-            Utils::error("Unkown atom with handle: " + handle);
+            RAISE_ERROR("Unkown atom with handle: " + handle);
             return {};
         } else {
             composite_type.push_back(atom->composite_type_hash(decoder));
@@ -102,7 +102,7 @@ vector<string> Link::composite_type(HandleDecoder& decoder) const {
 
 string Link::metta_representation(HandleDecoder& decoder) const {
     if (this->type != MettaMapping::EXPRESSION_LINK_TYPE) {
-        Utils::error("Can't compute metta expression of link whose type (" + this->type + ") is not " +
+        RAISE_ERROR("Can't compute metta expression of link whose type (" + this->type + ") is not " +
                      MettaMapping::EXPRESSION_LINK_TYPE);
     }
     string metta_string = "(";
@@ -110,7 +110,7 @@ string Link::metta_representation(HandleDecoder& decoder) const {
     for (unsigned int i = 0; i < size; i++) {
         shared_ptr<Atom> atom = decoder.get_atom(this->targets[i]);
         if (atom == nullptr) {
-            Utils::error("Couldn't decode handle: " + this->targets[i]);
+            RAISE_ERROR("Couldn't decode handle: " + this->targets[i]);
             return "";
         }
         metta_string += atom->metta_representation(decoder);

--- a/src/commons/atoms/Link.cc
+++ b/src/commons/atoms/Link.cc
@@ -103,7 +103,7 @@ vector<string> Link::composite_type(HandleDecoder& decoder) const {
 string Link::metta_representation(HandleDecoder& decoder) const {
     if (this->type != MettaMapping::EXPRESSION_LINK_TYPE) {
         RAISE_ERROR("Can't compute metta expression of link whose type (" + this->type + ") is not " +
-                     MettaMapping::EXPRESSION_LINK_TYPE);
+                    MettaMapping::EXPRESSION_LINK_TYPE);
     }
     string metta_string = "(";
     unsigned int size = this->targets.size();

--- a/src/commons/atoms/LinkSchema.cc
+++ b/src/commons/atoms/LinkSchema.cc
@@ -224,7 +224,7 @@ void LinkSchema::add_target(const string& schema_handle,
         }
     } else {
         RAISE_ERROR("Attempt to add a new target beyond LinkSchema's arity. LinkSchema: " +
-                     this->to_string());
+                    this->to_string());
     }
 }
 
@@ -323,7 +323,7 @@ void LinkSchema::_stack_link_schema(const string& type, unsigned int link_arity,
         this->_schema_element_stack.push(new_schema_element);
     } else {
         RAISE_ERROR("Couldn't stack link. Link arity: " + std::to_string(link_arity) +
-                     " stack size: " + std::to_string(this->_atom_stack.size()));
+                    " stack size: " + std::to_string(this->_atom_stack.size()));
     }
 }
 
@@ -346,7 +346,7 @@ void LinkSchema::build() {
             this->_atom_stack.clear();
         } else {
             RAISE_ERROR("Can't build LinkTemplate of arity " + std::to_string(this->_arity) +
-                         " out of a stack with " + std::to_string(this->_atom_stack.size()) + " atoms.");
+                        " out of a stack with " + std::to_string(this->_atom_stack.size()) + " atoms.");
         }
         for (unsigned int i = 0; i < this->_build_tokens.size(); i++) {
             this->_tokens.insert(
@@ -384,7 +384,7 @@ void LinkSchema::_syntax_assert(bool flag, string token, unsigned int cursor) {
             cursor = 1;
         }
         RAISE_ERROR("Syntax error in LinkSchema untokenization near symbol `" + token +
-                     "` near position " + std::to_string(cursor - 1));
+                    "` near position " + std::to_string(cursor - 1));
     }
 }
 

--- a/src/commons/atoms/LinkSchema.cc
+++ b/src/commons/atoms/LinkSchema.cc
@@ -56,7 +56,7 @@ void LinkSchema::_init(unsigned int arity) {
 
 bool LinkSchema::_check_not_frozen() const {
     if (this->_frozen) {
-        Utils::error("Can't change a LinkTemplate after calling build()");
+        RAISE_ERROR("Can't change a LinkTemplate after calling build()");
         return true;
     } else {
         return false;
@@ -65,7 +65,7 @@ bool LinkSchema::_check_not_frozen() const {
 
 bool LinkSchema::_check_frozen() const {
     if (!this->_frozen) {
-        Utils::error("Can't access LinkTemplate state before calling build()");
+        RAISE_ERROR("Can't access LinkTemplate state before calling build()");
         return true;
     } else {
         return false;
@@ -76,7 +76,7 @@ LinkSchema::LinkSchema(const LinkSchema& other) : Wildcard(other) { *this = othe
 
 LinkSchema& LinkSchema::operator=(const LinkSchema& other) {
     if (!other._frozen) {
-        Utils::error("Can't clone an under-construction LinkTemplate");
+        RAISE_ERROR("Can't clone an under-construction LinkTemplate");
     }
     Wildcard::operator=(other);
     this->_arity = other._arity;
@@ -100,10 +100,10 @@ bool LinkSchema::operator!=(const LinkSchema& other) { return !(*this == other);
 
 void LinkSchema::validate() const {
     if (this->type == Atom::UNDEFINED_TYPE) {
-        Utils::error("LinkSchema type can't be '" + Atom::UNDEFINED_TYPE + "'");
+        RAISE_ERROR("LinkSchema type can't be '" + Atom::UNDEFINED_TYPE + "'");
     }
     if (this->_schema.size() == 0) {
-        Utils::error("LinkSchema must have at least 1 target");
+        RAISE_ERROR("LinkSchema must have at least 1 target");
     }
     bool flag = true;
     for (string schema_handle : this->_schema) {
@@ -113,7 +113,7 @@ void LinkSchema::validate() const {
         }
     }
     if (flag) {
-        Utils::error("Invalid LinkSchema with no variables and no nested link schemas");
+        RAISE_ERROR("Invalid LinkSchema with no variables and no nested link schemas");
     }
 }
 
@@ -223,7 +223,7 @@ void LinkSchema::add_target(const string& schema_handle,
             this->_metta_representation += " ";
         }
     } else {
-        Utils::error("Attempt to add a new target beyond LinkSchema's arity. LinkSchema: " +
+        RAISE_ERROR("Attempt to add a new target beyond LinkSchema's arity. LinkSchema: " +
                      this->to_string());
     }
 }
@@ -286,7 +286,7 @@ void LinkSchema::_stack_link_schema(const string& type, unsigned int link_arity,
             tuple<string, string, string> triplet = this->_atom_stack.back();
             SchemaElement popped_schema_element = this->_schema_element_stack.top();
             if (is_link && (get<0>(triplet) == Atom::WILDCARD_STRING)) {
-                Utils::error("Invalid wildcard in Link");
+                RAISE_ERROR("Invalid wildcard in Link");
             }
             target_handles.insert(target_handles.begin(), get<0>(triplet));
             composite_type.insert(composite_type.begin(), get<1>(triplet));
@@ -322,7 +322,7 @@ void LinkSchema::_stack_link_schema(const string& type, unsigned int link_arity,
         new_schema_element.type = type;
         this->_schema_element_stack.push(new_schema_element);
     } else {
-        Utils::error("Couldn't stack link. Link arity: " + std::to_string(link_arity) +
+        RAISE_ERROR("Couldn't stack link. Link arity: " + std::to_string(link_arity) +
                      " stack size: " + std::to_string(this->_atom_stack.size()));
     }
 }
@@ -345,7 +345,7 @@ void LinkSchema::build() {
             }
             this->_atom_stack.clear();
         } else {
-            Utils::error("Can't build LinkTemplate of arity " + std::to_string(this->_arity) +
+            RAISE_ERROR("Can't build LinkTemplate of arity " + std::to_string(this->_arity) +
                          " out of a stack with " + std::to_string(this->_atom_stack.size()) + " atoms.");
         }
         for (unsigned int i = 0; i < this->_build_tokens.size(); i++) {
@@ -383,7 +383,7 @@ void LinkSchema::_syntax_assert(bool flag, string token, unsigned int cursor) {
         if (cursor == 0) {
             cursor = 1;
         }
-        Utils::error("Syntax error in LinkSchema untokenization near symbol `" + token +
+        RAISE_ERROR("Syntax error in LinkSchema untokenization near symbol `" + token +
                      "` near position " + std::to_string(cursor - 1));
     }
 }

--- a/src/commons/atoms/MettaParserActions.cc
+++ b/src/commons/atoms/MettaParserActions.cc
@@ -38,7 +38,7 @@ void MettaParserActions::symbol(const string& name) {
         }
     } else {
         if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-            Utils::error("Invalid metta expression: AND/OR can't operate symbols.");
+            RAISE_ERROR("Invalid metta expression: AND/OR can't operate symbols.");
             return;
         }
         this->current_expression_size++;
@@ -61,7 +61,7 @@ void MettaParserActions::variable(const string& value) {
 void MettaParserActions::literal(const string& value) {
     ParserActions::literal(value);
     if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid metta expression: AND/OR can't operate literals.");
+        RAISE_ERROR("Invalid metta expression: AND/OR can't operate literals.");
         return;
     }
     this->current_expression_size++;
@@ -74,7 +74,7 @@ void MettaParserActions::literal(const string& value) {
 void MettaParserActions::literal(int value) {
     ParserActions::literal(value);
     if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid metta expression: AND/OR can't operate literals.");
+        RAISE_ERROR("Invalid metta expression: AND/OR can't operate literals.");
         return;
     }
     this->current_expression_size++;
@@ -87,7 +87,7 @@ void MettaParserActions::literal(int value) {
 void MettaParserActions::literal(float value) {
     ParserActions::literal(value);
     if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid metta expression: AND/OR can't operate literals.");
+        RAISE_ERROR("Invalid metta expression: AND/OR can't operate literals.");
         return;
     }
     this->current_expression_size++;
@@ -110,7 +110,7 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_strin
     this->metta_expressions.push_back(metta_string);
     unsigned int arity = this->current_expression_size;
     if (element_stack.size() < arity) {
-        Utils::error("Invalid metta expression: too few arguments for expression. Expected: " +
+        RAISE_ERROR("Invalid metta expression: too few arguments for expression. Expected: " +
                      std::to_string(arity) + " Stack size: " + std::to_string(element_stack.size()));
         return;
     }
@@ -135,10 +135,10 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_strin
         this->element_stack.push(link);
         if (toplevel) this->metta_expression_handle = link->handle();
     } else if ((this->current_expression_type == AND) || (this->current_expression_type == OR)) {
-        Utils::error("Invalid metta expression: AND/OR are not supported.");
+        RAISE_ERROR("Invalid metta expression: AND/OR are not supported.");
         return;
     } else {
-        Utils::error("Invalid metta expression: unknown expression type");
+        RAISE_ERROR("Invalid metta expression: unknown expression type");
         return;
     }
 

--- a/src/commons/atoms/MettaParserActions.cc
+++ b/src/commons/atoms/MettaParserActions.cc
@@ -111,7 +111,7 @@ void MettaParserActions::expression_end(bool toplevel, const string& metta_strin
     unsigned int arity = this->current_expression_size;
     if (element_stack.size() < arity) {
         RAISE_ERROR("Invalid metta expression: too few arguments for expression. Expected: " +
-                     std::to_string(arity) + " Stack size: " + std::to_string(element_stack.size()));
+                    std::to_string(arity) + " Stack size: " + std::to_string(element_stack.size()));
         return;
     }
     LOG_DEBUG("Arity: " + std::to_string(arity));

--- a/src/commons/atoms/Node.cc
+++ b/src/commons/atoms/Node.cc
@@ -56,7 +56,7 @@ string Node::handle() const { return Hasher::node_handle(this->type, this->name)
 string Node::metta_representation(HandleDecoder& decoder) const {
     if (this->type != MettaMapping::SYMBOL_NODE_TYPE) {
         RAISE_ERROR("Can't compute metta expression of node whose type (" + this->type + ") is not " +
-                     MettaMapping::SYMBOL_NODE_TYPE);
+                    MettaMapping::SYMBOL_NODE_TYPE);
     }
     return this->name;
 }

--- a/src/commons/atoms/Node.cc
+++ b/src/commons/atoms/Node.cc
@@ -36,10 +36,10 @@ bool Node::operator!=(const Node& other) { return !(*this == other); }
 
 void Node::validate() const {
     if (this->type == Atom::UNDEFINED_TYPE) {
-        Utils::error("Node type can't be '" + Atom::UNDEFINED_TYPE + "'");
+        RAISE_ERROR("Node type can't be '" + Atom::UNDEFINED_TYPE + "'");
     }
     if (this->name.empty()) {
-        Utils::error("Node name must not be empty");
+        RAISE_ERROR("Node name must not be empty");
     }
 }
 
@@ -55,7 +55,7 @@ string Node::handle() const { return Hasher::node_handle(this->type, this->name)
 
 string Node::metta_representation(HandleDecoder& decoder) const {
     if (this->type != MettaMapping::SYMBOL_NODE_TYPE) {
-        Utils::error("Can't compute metta expression of node whose type (" + this->type + ") is not " +
+        RAISE_ERROR("Can't compute metta expression of node whose type (" + this->type + ") is not " +
                      MettaMapping::SYMBOL_NODE_TYPE);
     }
     return this->name;

--- a/src/commons/atoms/UntypedVariable.cc
+++ b/src/commons/atoms/UntypedVariable.cc
@@ -28,7 +28,7 @@ bool UntypedVariable::operator!=(const UntypedVariable& other) { return !(*this 
 void UntypedVariable::validate() const {
     if (this->type != Atom::UNDEFINED_TYPE) {
         RAISE_ERROR("Invalid type for UntypedVariable: " + this->type + " (expected " +
-                     Atom::UNDEFINED_TYPE + ")");
+                    Atom::UNDEFINED_TYPE + ")");
     }
     if (this->name.empty()) {
         RAISE_ERROR("Invalid empty name for UntypedVariable");

--- a/src/commons/atoms/UntypedVariable.cc
+++ b/src/commons/atoms/UntypedVariable.cc
@@ -27,11 +27,11 @@ bool UntypedVariable::operator!=(const UntypedVariable& other) { return !(*this 
 
 void UntypedVariable::validate() const {
     if (this->type != Atom::UNDEFINED_TYPE) {
-        Utils::error("Invalid type for UntypedVariable: " + this->type + " (expected " +
+        RAISE_ERROR("Invalid type for UntypedVariable: " + this->type + " (expected " +
                      Atom::UNDEFINED_TYPE + ")");
     }
     if (this->name.empty()) {
-        Utils::error("Invalid empty name for UntypedVariable");
+        RAISE_ERROR("Invalid empty name for UntypedVariable");
     }
 }
 

--- a/src/commons/processor/Processor.cc
+++ b/src/commons/processor/Processor.cc
@@ -31,8 +31,8 @@ void Processor::bind_subprocessor(shared_ptr<Processor> root, shared_ptr<Process
     }
     if (child->parent_processor != nullptr) {
         RAISE_ERROR("Invalid attempt to bind processor " + child->to_string() + " to " +
-                     root->to_string() + ". It's already bound to " +
-                     child->parent_processor->to_string());
+                    root->to_string() + ". It's already bound to " +
+                    child->parent_processor->to_string());
     }
     root->subprocessors.push_back(child);
     child->parent_processor = root;

--- a/src/commons/processor/Processor.cc
+++ b/src/commons/processor/Processor.cc
@@ -10,7 +10,7 @@ using namespace processor;
 
 Processor::Processor(const string& id) {
     if (id == "") {
-        Utils::error("Invalid empty id for processor");
+        RAISE_ERROR("Invalid empty id for processor");
     }
     this->current_state = WAITING_SETUP;
     this->id = id;
@@ -27,10 +27,10 @@ Processor::~Processor() {
 void Processor::bind_subprocessor(shared_ptr<Processor> root, shared_ptr<Processor> child) {
     // static method
     if (root->is_setup() || child->is_setup()) {
-        Utils::error("Can't bind processors after setup() has been called");
+        RAISE_ERROR("Can't bind processors after setup() has been called");
     }
     if (child->parent_processor != nullptr) {
-        Utils::error("Invalid attempt to bind processor " + child->to_string() + " to " +
+        RAISE_ERROR("Invalid attempt to bind processor " + child->to_string() + " to " +
                      root->to_string() + ". It's already bound to " +
                      child->parent_processor->to_string());
     }
@@ -127,6 +127,6 @@ void Processor::check_state(const string& action, State state) {
             error_message += "Processor is in unexpected state: " + this->current_state;
         }
         this->api_mutex.unlock();
-        Utils::error(error_message);
+        RAISE_ERROR(error_message);
     }
 }

--- a/src/commons/processor/ThreadPool.cc
+++ b/src/commons/processor/ThreadPool.cc
@@ -64,7 +64,7 @@ void ThreadPool::enqueue(function<void()> task) {
         }
         condition.notify_one();
     } else {
-        Utils::error("Attempt to add a job to ThreadPool " + this->to_string() +
+        RAISE_ERROR("Attempt to add a job to ThreadPool " + this->to_string() +
                      " which has not being started");
     }
 }

--- a/src/commons/processor/ThreadPool.cc
+++ b/src/commons/processor/ThreadPool.cc
@@ -65,7 +65,7 @@ void ThreadPool::enqueue(function<void()> task) {
         condition.notify_one();
     } else {
         RAISE_ERROR("Attempt to add a job to ThreadPool " + this->to_string() +
-                     " which has not being started");
+                    " which has not being started");
     }
 }
 

--- a/src/db_adapter/ContextLoader.cc
+++ b/src/db_adapter/ContextLoader.cc
@@ -17,7 +17,7 @@ namespace fs = std::filesystem;
 
 vector<TableMapping> ContextLoader::load_table_file(const string& file_path) {
     if (!fs::exists(file_path)) {
-        Utils::error("Context file " + file_path + " does not exist");
+        RAISE_ERROR("Context file " + file_path + " does not exist");
     }
 
     ifstream f(file_path);
@@ -124,7 +124,7 @@ vector<TableMapping> ContextLoader::load_table_file(const string& file_path) {
 
 vector<string> ContextLoader::load_query_file(const string& file_path) {
     if (!fs::exists(file_path)) {
-        Utils::error("Query file " + file_path + " does not exist");
+        RAISE_ERROR("Query file " + file_path + " does not exist");
     }
 
     ifstream f(file_path);

--- a/src/db_adapter/DatabaseLoader.cc
+++ b/src/db_adapter/DatabaseLoader.cc
@@ -98,7 +98,7 @@ void DatabaseMappingOrchestrator::task_setup(const JsonConfig& config) {
     string query_file_path = config.at_path("adapter.context_mapping.queries_sql").get_or<string>("");
 
     if (tables_file_path.empty() && query_file_path.empty()) {
-        Utils::error(
+        RAISE_ERROR(
             "No mapping tasks found in the context file. Provide at least one of the following:\n"
             " - adapter.context_mapping.tables (path to tables mapping JSON file)\n"
             " - adapter.context_mapping.queries_sql (path to SQL queries file)");
@@ -323,7 +323,7 @@ void MultiThreadAtomPersister::send_batch(vector<Atom*> atoms,
                             << " | error: " << e.what() << " | batches_failed: "
                             << this->batches_failed.load() << " | thread: " << this_thread::get_id());
 
-        Utils::error("Error in batch #" + to_string(batch_id) + ": " + string(e.what()));
+        RAISE_ERROR("Error in batch #" + to_string(batch_id) + ": " + string(e.what()));
     }
 
     for (auto& atom : atoms) {

--- a/src/db_adapter/DatabaseMapper.cc
+++ b/src/db_adapter/DatabaseMapper.cc
@@ -48,7 +48,7 @@ const vector<Atom*> SQL2AtomsMapper::map(const DbInput& data) {
             size_t separator_pos = column_name.find('|');
 
             if (separator_pos == string::npos) {
-                Utils::error("Invalid foreign key format: " + column_name);
+                RAISE_ERROR("Invalid foreign key format: " + column_name);
             }
 
             string fk_column = column_name.substr(0, separator_pos);
@@ -127,7 +127,7 @@ string SQL2AtomsMapper::add_atom_if_new(SQL2AtomsMapper::ATOM_TYPE atom_type,
         vector<string> targets = get<vector<string>>(value);
         atom = new Link(SQL2AtomsMapper::EXPRESSION, targets, is_toplevel);
     } else {
-        Utils::error("Either name or targets must be provided to create an Atom.");
+        RAISE_ERROR("Either name or targets must be provided to create an Atom.");
     }
 
     if (!metta_expression.empty()) {

--- a/src/db_adapter/MettaFileWriter.cc
+++ b/src/db_adapter/MettaFileWriter.cc
@@ -45,7 +45,7 @@ void MettaFileWriter::write(const string& expression) {
 
     this->state->stream.write(line.data(), static_cast<streamsize>(line_size));
     if (!this->state->stream) {
-        Utils::error("MettaFileWriter: write failed");
+        RAISE_ERROR("MettaFileWriter: write failed");
     }
 
     this->state->current_size += line_size;
@@ -102,7 +102,7 @@ void MettaFileWriter::open_file(int idx) {
     stream.open(filepath, ios::app | ios::binary);
 
     if (!stream.is_open()) {
-        Utils::error("MettaFileWriter: cannot open " + filepath.string());
+        RAISE_ERROR("MettaFileWriter: cannot open " + filepath.string());
     }
 
     this->state->stream = move(stream);
@@ -131,7 +131,7 @@ void MettaFileWriter::remove_duplicate_lines(const filesystem::path& filepath) {
     ofstream out(tmp_path, ios::trunc | ios::binary);
 
     if (!in.is_open() || !out.is_open()) {
-        Utils::error("MettaFileWriter: cannot open files for dedup: " + filepath.string());
+        RAISE_ERROR("MettaFileWriter: cannot open files for dedup: " + filepath.string());
         return;
     }
 

--- a/src/db_adapter/postgres/PostgresWrapper.cc
+++ b/src/db_adapter/postgres/PostgresWrapper.cc
@@ -411,8 +411,8 @@ void PostgresWrapper::map_sql_query(const string& virtual_name, const string& ra
                 string schema = parts[0];
                 string table = parts[1];
                 RAISE_ERROR("Primary key '" + pk + "' of table '" + table_name +
-                             "' must be included in SELECT aliases. Add: " + table + "." + pk + " AS " +
-                             schema + "_" + table + "__" + pk);
+                            "' must be included in SELECT aliases. Add: " + table + "." + pk + " AS " +
+                            schema + "_" + table + "__" + pk);
             }
         } catch (const exception& e) {
             RAISE_ERROR("Error retrieving metadata for table '" + table_name + "': " + e.what());

--- a/src/db_adapter/postgres/PostgresWrapper.cc
+++ b/src/db_adapter/postgres/PostgresWrapper.cc
@@ -62,7 +62,7 @@ void PostgresDatabaseConnection::disconnect() {
 
 pqxx::result PostgresDatabaseConnection::execute_query(const string& query) {
     if (!this->conn || !this->conn->is_open()) {
-        Utils::error("Postgres connection is not open.");
+        RAISE_ERROR("Postgres connection is not open.");
     }
 
     try {
@@ -71,17 +71,17 @@ pqxx::result PostgresDatabaseConnection::execute_query(const string& query) {
         transaction.commit();
         return result;
     } catch (const exception& e) {
-        Utils::error("Error during query execution: " + string(e.what()));
+        RAISE_ERROR("Error during query execution: " + string(e.what()));
     }
     return pqxx::result{};
 }
 
 void PostgresDatabaseConnection::begin_cursor(const string& cursor_name, const string& query) {
     if (!this->conn || !this->conn->is_open()) {
-        Utils::error("Postgres connection is not open.");
+        RAISE_ERROR("Postgres connection is not open.");
     }
     if (this->transaction) {
-        Utils::error("A transaction is already active. Close the current cursor first.");
+        RAISE_ERROR("A transaction is already active. Close the current cursor first.");
     }
     this->transaction = make_unique<pqxx::work>(*this->conn);
 
@@ -89,13 +89,13 @@ void PostgresDatabaseConnection::begin_cursor(const string& cursor_name, const s
         this->transaction->exec("DECLARE " + cursor_name + " CURSOR FOR " + query);
     } catch (const exception& e) {
         this->transaction.reset();
-        Utils::error("Error executing cursor query: " + string(e.what()));
+        RAISE_ERROR("Error executing cursor query: " + string(e.what()));
     }
 }
 
 pqxx::result PostgresDatabaseConnection::fetch_cursor(const string& cursor_name, size_t limit) {
     if (!this->transaction) {
-        Utils::error("No active transaction. Call begin_cursor first.");
+        RAISE_ERROR("No active transaction. Call begin_cursor first.");
     }
     return this->transaction->exec("FETCH " + std::to_string(limit) + " FROM " + cursor_name);
 }
@@ -216,7 +216,7 @@ Table PostgresWrapper::get_table(const string& schema_name, const string& table_
     auto result = db_conn.execute_query(query);
 
     if (result.empty()) {
-        Utils::error("Table '" + schema_name + "." + table_name + "' not found.");
+        RAISE_ERROR("Table '" + schema_name + "." + table_name + "' not found.");
     }
 
     const auto& row = result[0];
@@ -361,7 +361,7 @@ void PostgresWrapper::map_table(const Table& table,
             auto parts = Utils::split(fk, '|');
 
             if (parts.size() != 2) {
-                Utils::error("Invalid foreign key format: " + fk);
+                RAISE_ERROR("Invalid foreign key format: " + fk);
             }
 
             string column = parts[0];
@@ -392,7 +392,7 @@ void PostgresWrapper::map_sql_query(const string& virtual_name, const string& ra
     map<string, vector<string>> table_columns_map = this->extract_aliases_from_query(raw_query);
 
     if (table_columns_map.empty()) {
-        Utils::error("No valid aliases found in query for " + virtual_name);
+        RAISE_ERROR("No valid aliases found in query for " + virtual_name);
     }
 
     map<string, Table> tables_metadata;
@@ -410,12 +410,12 @@ void PostgresWrapper::map_sql_query(const string& virtual_name, const string& ra
                 auto parts = Utils::split(table_name, '.');
                 string schema = parts[0];
                 string table = parts[1];
-                Utils::error("Primary key '" + pk + "' of table '" + table_name +
+                RAISE_ERROR("Primary key '" + pk + "' of table '" + table_name +
                              "' must be included in SELECT aliases. Add: " + table + "." + pk + " AS " +
                              schema + "_" + table + "__" + pk);
             }
         } catch (const exception& e) {
-            Utils::error("Error retrieving metadata for table '" + table_name + "': " + e.what());
+            RAISE_ERROR("Error retrieving metadata for table '" + table_name + "': " + e.what());
         }
     }
 
@@ -440,7 +440,7 @@ vector<string> PostgresWrapper::build_columns_to_map(const Table& table,
     for (const auto& skipo_col : skip_columns) {
         if (find(table.column_names.begin(), table.column_names.end(), skipo_col) ==
             table.column_names.end()) {
-            Utils::error("Skip column '" + skipo_col + "' not found in table '" + table.name + "'");
+            RAISE_ERROR("Skip column '" + skipo_col + "' not found in table '" + table.name + "'");
         }
     }
 
@@ -590,7 +590,7 @@ void PostgresWrapper::fetch_rows_paginated(const Table& table,
                 unique_lock<mutex> lock(this->api_mutex);
                 this->output_queue->enqueue((void*) batch_queue);
             } else {
-                Utils::error("Unsupported mapper type.");
+                RAISE_ERROR("Unsupported mapper type.");
             }
 
             LOG_DEBUG("Mapper HandleTrie size: " << this->mapper->handle_trie_size());

--- a/src/distributed_algorithm_node/BusNode.cc
+++ b/src/distributed_algorithm_node/BusNode.cc
@@ -154,7 +154,7 @@ void BusNode::Bus::add(const string& command) {
     if (this->command_owner.find(command) != this->command_owner.end()) {
         if (this->command_owner[command] != "") {
             RAISE_ERROR("Bus: command <" + command + "> " + "is already assigned to " +
-                         this->command_owner[command]);
+                        this->command_owner[command]);
         }
     } else {
         this->command_owner[command] = "";
@@ -170,7 +170,7 @@ void BusNode::Bus::set_ownership(const string& command, const string& node_id) {
         } else {
             if (this->command_owner[command] != node_id) {
                 RAISE_ERROR("Bus: command <" + command + "> " + "is already assigned to " +
-                             this->command_owner[command]);
+                            this->command_owner[command]);
             }
         }
     }

--- a/src/distributed_algorithm_node/BusNode.cc
+++ b/src/distributed_algorithm_node/BusNode.cc
@@ -63,7 +63,7 @@ shared_ptr<Message> BusNode::message_factory(string& command, vector<string>& ar
     if (command == BusNode::SET_COMMAND_OWNERSHIP) {
         unsigned int n = args.size();
         if (n == 0) {
-            Utils::error("Invalid command args: " + command);
+            RAISE_ERROR("Invalid command args: " + command);
         }
         vector<string> command_list;
         for (unsigned int i = 1; i < n; i++) {
@@ -86,7 +86,7 @@ const string& BusNode::get_ownership(const string& command) { return this->bus.g
 void BusNode::send_bus_command(const string& command, const vector<string>& args) {
     string target_id = this->bus.get_ownership(command);
     if (target_id == "") {
-        Utils::error("Bus: no owner is defined for command <" + command + ">");
+        RAISE_ERROR("Bus: no owner is defined for command <" + command + ">");
     } else {
         LOG_DEBUG("BUS node " << this->node_id() << " is routing command " << command << " to "
                               << target_id);
@@ -153,7 +153,7 @@ BusNode::Bus& BusNode::Bus::operator+(const string& command) {
 void BusNode::Bus::add(const string& command) {
     if (this->command_owner.find(command) != this->command_owner.end()) {
         if (this->command_owner[command] != "") {
-            Utils::error("Bus: command <" + command + "> " + "is already assigned to " +
+            RAISE_ERROR("Bus: command <" + command + "> " + "is already assigned to " +
                          this->command_owner[command]);
         }
     } else {
@@ -163,13 +163,13 @@ void BusNode::Bus::add(const string& command) {
 
 void BusNode::Bus::set_ownership(const string& command, const string& node_id) {
     if (this->command_owner.find(command) == this->command_owner.end()) {
-        Utils::error("Bus: command <" + command + "> " + "is not defined");
+        RAISE_ERROR("Bus: command <" + command + "> " + "is not defined");
     } else {
         if (this->command_owner[command] == "") {
             this->command_owner[command] = node_id;
         } else {
             if (this->command_owner[command] != node_id) {
-                Utils::error("Bus: command <" + command + "> " + "is already assigned to " +
+                RAISE_ERROR("Bus: command <" + command + "> " + "is already assigned to " +
                              this->command_owner[command]);
             }
         }
@@ -179,7 +179,7 @@ void BusNode::Bus::set_ownership(const string& command, const string& node_id) {
 const string& BusNode::Bus::get_ownership(const string& command) {
     auto pair = this->command_owner.find(command);
     if (pair == this->command_owner.end()) {
-        Utils::error("Bus: unknown command <" + command + ">");
+        RAISE_ERROR("Bus: unknown command <" + command + ">");
     }
     return pair->second;
 }

--- a/src/distributed_algorithm_node/LeadershipBroker.cc
+++ b/src/distributed_algorithm_node/LeadershipBroker.cc
@@ -20,7 +20,7 @@ shared_ptr<LeadershipBroker> LeadershipBroker::factory(LeadershipBrokerType inst
             return shared_ptr<LeadershipBroker>(new TrustedBusPeer());
         }
         default: {
-            Utils::error("Invalid LeadershipBrokerType: " + to_string((int) instance_type));
+            RAISE_ERROR("Invalid LeadershipBrokerType: " + to_string((int) instance_type));
             return shared_ptr<LeadershipBroker>{};
         }
     }

--- a/src/distributed_algorithm_node/MessageBroker.cc
+++ b/src/distributed_algorithm_node/MessageBroker.cc
@@ -38,7 +38,7 @@ shared_ptr<MessageBroker> MessageBroker::factory(MessageBrokerType instance_type
             return shared_ptr<MessageBroker>(new SynchronousGRPC(host_node, node_id));
         }
         default: {
-            Utils::error("Invalid MessageBrokerType: " + to_string((int) instance_type));
+            RAISE_ERROR("Invalid MessageBrokerType: " + to_string((int) instance_type));
             return shared_ptr<MessageBroker>{};  // to avoid warnings
         }
     }
@@ -46,7 +46,7 @@ shared_ptr<MessageBroker> MessageBroker::factory(MessageBrokerType instance_type
 
 MessageBroker::MessageBroker(shared_ptr<MessageFactory> host_node, const string& node_id) {
     if (!host_node) {
-        Utils::error("Invalid NULL host_node");
+        RAISE_ERROR("Invalid NULL host_node");
     }
     this->host_node = host_node;
     this->node_id = node_id;
@@ -67,7 +67,7 @@ SynchronousSharedRAM::~SynchronousSharedRAM() {
         NODE_QUEUE_MUTEX.lock();
         if (NODE_QUEUE.find(this->node_id) == NODE_QUEUE.end()) {
             NODE_QUEUE_MUTEX.unlock();
-            Utils::error("Unable to remove node from network: " + this->node_id);
+            RAISE_ERROR("Unable to remove node from network: " + this->node_id);
         } else {
             auto node_queue = NODE_QUEUE[this->node_id];
             while (!node_queue->empty()) {
@@ -125,7 +125,7 @@ void SynchronousGRPC::grpc_thread_method(shared_ptr<StoppableThread> monitor) {
             LOG_ERROR("Failed attempt to start GRPC server on " + this->node_id + ". Retrying...");
             Utils::sleep(10000);
             delete builder;
-            // Utils::error("Couldn't start GRPC server on " + this->node_id);
+            // RAISE_ERROR("Couldn't start GRPC server on " + this->node_id);
             // return;
         }
     } while (true);
@@ -170,7 +170,7 @@ void SynchronousSharedRAM::inbox_thread_method(shared_ptr<StoppableThread> monit
                 delete message_data;
             } else {
                 delete message_data;
-                Utils::error("Invalid NULL Message");
+                RAISE_ERROR("Invalid NULL Message");
             }
         } else {
             if (monitor->stopped()) {
@@ -231,7 +231,7 @@ void SynchronousGRPC::inbox_thread_method(shared_ptr<StoppableThread> monitor) {
                 LOG_DEBUG("Acting command: " << command << " at node " << this->node_id);
                 message->act(this->host_node);
             } else {
-                Utils::error("Invalid NULL Message");
+                RAISE_ERROR("Invalid NULL Message");
             }
         } else {
             if (monitor->stopped()) {
@@ -280,7 +280,7 @@ void SynchronousSharedRAM::join_network() {
     NODE_QUEUE_MUTEX.lock();
     if (NODE_QUEUE.find(this->node_id) != NODE_QUEUE.end()) {
         NODE_QUEUE_MUTEX.unlock();
-        Utils::error("Node ID already in the network: " + this->node_id);
+        RAISE_ERROR("Node ID already in the network: " + this->node_id);
     } else {
         NODE_QUEUE[this->node_id] = &(this->incoming_messages);
         NODE_QUEUE_MUTEX.unlock();
@@ -300,7 +300,7 @@ void SynchronousSharedRAM::send(const string& command,
                                 const string& recipient) {
     if (!this->stopped()) {
         if (!is_peer(recipient)) {
-            Utils::error("Unknown peer: " + recipient);
+            RAISE_ERROR("Unknown peer: " + recipient);
         }
         CommandLinePackage* command_line = new CommandLinePackage(command, args);
         NODE_QUEUE[recipient]->enqueue((void*) command_line);
@@ -358,7 +358,7 @@ void SynchronousGRPC::add_peer(const string& peer_id) { MessageBroker::add_peer(
 
 void SynchronousGRPC::send(const string& command, const vector<string>& args, const string& recipient) {
     if (!is_peer(recipient)) {
-        Utils::error("Unknown peer: " + recipient);
+        RAISE_ERROR("Unknown peer: " + recipient);
     }
     dasproto::MessageData message_data;
     message_data.set_command(command);

--- a/src/main/bus_client.cc
+++ b/src/main/bus_client.cc
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
                         das_config.at_path(it_known_peer->second + ".endpoint").get<string>();
                 } else {
                     RAISE_ERROR("Required argument missing: " + cmd_args[Helper::CLIENT] +
-                                 " is not a bus node.");
+                                " is not a bus node.");
                 }
 
             } else {
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
         auto proxy = ProxyFactory::create_proxy(cmd_args[Helper::CLIENT], props);
         if (proxy == nullptr) {
             RAISE_ERROR("Could not create proxy for service or client is inactive: " +
-                         cmd_args[Helper::CLIENT]);
+                        cmd_args[Helper::CLIENT]);
         }
         auto ports_range = Utils::parse_ports_range(props.get<string>(Helper::PORTS_RANGE));
         ServiceBusSingleton::init(props.get<string>(Helper::ENDPOINT),

--- a/src/main/bus_client.cc
+++ b/src/main/bus_client.cc
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
         }
 
         if (cmd_args.find(Helper::CLIENT) == cmd_args.end()) {
-            Utils::error("Required argument missing: " + Helper::CLIENT);
+            RAISE_ERROR("Required argument missing: " + Helper::CLIENT);
         }
 
         ///////// Optional JsonConfig
@@ -49,12 +49,12 @@ int main(int argc, char* argv[]) {
                     cmd_args[Helper::BUS_ENDPOINT] =
                         das_config.at_path(it_known_peer->second + ".endpoint").get<string>();
                 } else {
-                    Utils::error("Required argument missing: " + cmd_args[Helper::CLIENT] +
+                    RAISE_ERROR("Required argument missing: " + cmd_args[Helper::CLIENT] +
                                  " is not a bus node.");
                 }
 
             } else {
-                Utils::error("params.das-config-file is missing");
+                RAISE_ERROR("params.das-config-file is missing");
             }
 
             cmd_args[Helper::ENDPOINT] = json_config.at_path("params.endpoint").get<string>();
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
 
         for (auto req_arg : required_cmd_args) {
             if (cmd_args.find(req_arg) == cmd_args.end()) {
-                Utils::error("Required argument missing: " + string(req_arg));
+                RAISE_ERROR("Required argument missing: " + string(req_arg));
             }
         }
 
@@ -74,7 +74,7 @@ int main(int argc, char* argv[]) {
             Helper::get_required_arguments(cmd_args[Helper::CLIENT], ServiceCallerType::CLIENT);
         for (auto req_arg : required_args) {
             if (cmd_args.find(req_arg) == cmd_args.end()) {
-                Utils::error("Required argument missing: " + string(req_arg));
+                RAISE_ERROR("Required argument missing: " + string(req_arg));
             }
         }
 
@@ -101,7 +101,7 @@ int main(int argc, char* argv[]) {
 
         auto proxy = ProxyFactory::create_proxy(cmd_args[Helper::CLIENT], props);
         if (proxy == nullptr) {
-            Utils::error("Could not create proxy for service or client is inactive: " +
+            RAISE_ERROR("Could not create proxy for service or client is inactive: " +
                          cmd_args[Helper::CLIENT]);
         }
         auto ports_range = Utils::parse_ports_range(props.get<string>(Helper::PORTS_RANGE));

--- a/src/main/bus_node.cc
+++ b/src/main/bus_node.cc
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
         auto service = ProcessorFactory::create_processor(cmd_args[Helper::SERVICE], props);
         if (service == nullptr) {
             RAISE_ERROR("Could not create processor for service or service is inactive: " +
-                         cmd_args[Helper::SERVICE]);
+                        cmd_args[Helper::SERVICE]);
         }
 
         LOG_INFO("Registering processor for service: " + cmd_args[Helper::SERVICE]);

--- a/src/main/bus_node.cc
+++ b/src/main/bus_node.cc
@@ -54,7 +54,7 @@ int main(int argc, char* argv[]) {
         }
         for (auto req_arg : required_cmd_args) {
             if (cmd_args.find(req_arg) == cmd_args.end()) {
-                Utils::error("Required argument missing: " + string(req_arg));
+                RAISE_ERROR("Required argument missing: " + string(req_arg));
             }
         }
         auto required_args = Helper::get_required_arguments(cmd_args[Helper::SERVICE]);
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
                     auto val = json_config.at_path(it_path->second);
                     cmd_args[req_arg] = val.get<string>();
                 } else {
-                    Utils::error("Required argument missing: " + string(req_arg));
+                    RAISE_ERROR("Required argument missing: " + string(req_arg));
                 }
             }
         }
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
         ///////// Registering processor
         auto service = ProcessorFactory::create_processor(cmd_args[Helper::SERVICE], props);
         if (service == nullptr) {
-            Utils::error("Could not create processor for service or service is inactive: " +
+            RAISE_ERROR("Could not create processor for service or service is inactive: " +
                          cmd_args[Helper::SERVICE]);
         }
 

--- a/src/main/helpers/ProcessorFactory.h
+++ b/src/main/helpers/ProcessorFactory.h
@@ -48,7 +48,7 @@ class ProcessorFactory {
             case ProcessorType::QUERY_ENGINE:
                 return make_shared<PatternMatchingQueryProcessor>();
             default:
-                Utils::error("Unknown processor type: " + processor_type);
+                RAISE_ERROR("Unknown processor type: " + processor_type);
         }
         return nullptr;
     };

--- a/src/main/helpers/ProxyFactory.h
+++ b/src/main/helpers/ProxyFactory.h
@@ -53,7 +53,7 @@ class ProxyFactory {
                 proxy->parameters[param_name] = param_value;
                 return;
             default:
-                Utils::error("Unknown proxy parameter type");
+                RAISE_ERROR("Unknown proxy parameter type");
         }
     }
 
@@ -259,7 +259,7 @@ class ProxyFactory {
                 return make_shared<AtomDBProxy>();
             }
             default:
-                Utils::error("Unknown proxy type: " + proxy_type);
+                RAISE_ERROR("Unknown proxy type: " + proxy_type);
                 break;
         }
         return nullptr;

--- a/src/metta/MettaLexer.cc
+++ b/src/metta/MettaLexer.cc
@@ -234,8 +234,8 @@ void MettaLexer::pop_metta_string() {
 void MettaLexer::_attach_string(const string& metta_string) {
     if (metta_string.size() > this->input_buffer_size) {
         RAISE_ERROR("Can't attach strings larger than input buffer size (" +
-                     std::to_string(metta_string.size()) + " > " +
-                     std::to_string(this->input_buffer_size) + ")");
+                    std::to_string(metta_string.size()) + " > " +
+                    std::to_string(this->input_buffer_size) + ")");
     } else {
         this->attached_strings.push(metta_string);
     }

--- a/src/metta/MettaLexer.cc
+++ b/src/metta/MettaLexer.cc
@@ -43,10 +43,10 @@ MettaLexer::~MettaLexer() { free(this->input_buffer); }
 void MettaLexer::attach_string(const string& metta_string) {
     LOG_DEBUG("Attaching string <" + metta_string + ">");
     if (this->single_string_flag) {
-        Utils::error("Can't attach strings to MettaLexer initialized with a string.");
+        RAISE_ERROR("Can't attach strings to MettaLexer initialized with a string.");
     } else if (this->file_input_flag) {
         if (this->attached_file_names.size() > 0) {
-            Utils::error("Can't attach strings to MettaLexer which is processing files.");
+            RAISE_ERROR("Can't attach strings to MettaLexer which is processing files.");
         } else {
             _attach_string(metta_string);
             this->file_input_flag = false;
@@ -62,7 +62,7 @@ void MettaLexer::attach_file(const string& file_name) {
         this->attached_file_names.push(file_name);
         this->current_offset[file_name] = 0;
     } else {
-        Utils::error("Can't attach files to MettaLexer which is processing strings.");
+        RAISE_ERROR("Can't attach files to MettaLexer which is processing strings.");
     }
 }
 
@@ -233,7 +233,7 @@ void MettaLexer::pop_metta_string() {
 
 void MettaLexer::_attach_string(const string& metta_string) {
     if (metta_string.size() > this->input_buffer_size) {
-        Utils::error("Can't attach strings larger than input buffer size (" +
+        RAISE_ERROR("Can't attach strings larger than input buffer size (" +
                      std::to_string(metta_string.size()) + " > " +
                      std::to_string(this->input_buffer_size) + ")");
     } else {
@@ -264,7 +264,7 @@ void MettaLexer::_rewind_input_buffer(unsigned int n) {
             this->current_metta_string.pop_back();
         }
     } else {
-        Utils::error("Trying to rewind input buffer beyond its start");
+        RAISE_ERROR("Trying to rewind input buffer beyond its start");
     }
 }
 
@@ -272,7 +272,7 @@ void MettaLexer::_feed_from_file() {
     string filename = this->attached_file_names.front();
     FILE* file = fopen(filename.c_str(), "r");
     if (file == NULL) {
-        Utils::error("Unable to open file: " + filename);
+        RAISE_ERROR("Unable to open file: " + filename);
     }
     fseek(file, this->current_offset[filename], SEEK_SET);
     int c = fgetc(file);
@@ -338,5 +338,5 @@ void MettaLexer::_error(LexerState state, const string& error_message, char c) {
     } else {
         prefix += "Unexpected state value: " + std::to_string((unsigned int) state);
     }
-    Utils::error(prefix + " - " + error_message);
+    RAISE_ERROR(prefix + " - " + error_message);
 }

--- a/src/metta/MettaTokens.cc
+++ b/src/metta/MettaTokens.cc
@@ -60,7 +60,7 @@ string MettaTokens::to_string(unsigned char token) {
     } else if (token == VARIABLE) {
         return "VARIABLE";
     } else {
-        Utils::error("Unknown token: " + std::to_string(token));
+        RAISE_ERROR("Unknown token: " + std::to_string(token));
         return "";
     }
 }

--- a/src/service_bus/BusCommandProxy.cc
+++ b/src/service_bus/BusCommandProxy.cc
@@ -58,7 +58,7 @@ ProxyNode::~ProxyNode() {}
 
 void BusCommandProxy::setup_proxy_node(const string& client_id, const string& server_id) {
     if (this->proxy_port == 0) {
-        Utils::error("Proxy node can't be set up");
+        RAISE_ERROR("Proxy node can't be set up");
     } else {
         if (client_id == "") {
             LOG_DEBUG("ProxyNode on CLIENT");
@@ -113,7 +113,7 @@ void BusCommandProxy::raise_error(const string& error_message, unsigned int erro
     if (error_code > 0) {
         prefix += std::to_string(error_code) + " ";
     }
-    Utils::error(prefix + " on peer - " + error_message);
+    RAISE_ERROR(prefix + " on peer - " + error_message);
 }
 
 void BusCommandProxy::raise_error_on_peer(const string& error_message, unsigned int error_code) {
@@ -130,7 +130,7 @@ void ProxyNode::remote_call(const string& command, const vector<string>& args) {
 
 void ProxyNode::to_remote_peer(const string& command, const vector<string>& args) {
     if (this->peer_id == "") {
-        Utils::error("Unknown peer");
+        RAISE_ERROR("Unknown peer");
     }
     vector<string> new_args(args);
     new_args.push_back(command);

--- a/src/service_bus/PortPool.cc
+++ b/src/service_bus/PortPool.cc
@@ -11,7 +11,7 @@ unsigned int PortPool::PORT_UPPER = 0;
 
 void PortPool::initialize_statics(unsigned int port_lower, unsigned int port_upper) {
     if (port_lower > port_upper) {
-        Utils::error("Invalid port limits [" + to_string(port_lower) + ".." + to_string(port_upper) +
+        RAISE_ERROR("Invalid port limits [" + to_string(port_lower) + ".." + to_string(port_upper) +
                      "]");
     }
     LOG_INFO("Port range: [" << port_lower << " : " << port_upper << "]");
@@ -30,7 +30,7 @@ void PortPool::initialize_statics(unsigned int port_lower, unsigned int port_upp
 unsigned int PortPool::get_port() {
     unsigned int port = (unsigned int) ((unsigned long) POOL->dequeue());
     if (!port) {
-        Utils::error("Unable to get available PORT number in [" + to_string(PORT_LOWER) + ".." +
+        RAISE_ERROR("Unable to get available PORT number in [" + to_string(PORT_LOWER) + ".." +
                      to_string(PORT_UPPER) + "]");
     }
     return port;

--- a/src/service_bus/PortPool.cc
+++ b/src/service_bus/PortPool.cc
@@ -12,7 +12,7 @@ unsigned int PortPool::PORT_UPPER = 0;
 void PortPool::initialize_statics(unsigned int port_lower, unsigned int port_upper) {
     if (port_lower > port_upper) {
         RAISE_ERROR("Invalid port limits [" + to_string(port_lower) + ".." + to_string(port_upper) +
-                     "]");
+                    "]");
     }
     LOG_INFO("Port range: [" << port_lower << " : " << port_upper << "]");
     PORT_LOWER = port_lower;
@@ -31,7 +31,7 @@ unsigned int PortPool::get_port() {
     unsigned int port = (unsigned int) ((unsigned long) POOL->dequeue());
     if (!port) {
         RAISE_ERROR("Unable to get available PORT number in [" + to_string(PORT_LOWER) + ".." +
-                     to_string(PORT_UPPER) + "]");
+                    to_string(PORT_UPPER) + "]");
     }
     return port;
 }

--- a/src/service_bus/ServiceBus.cc
+++ b/src/service_bus/ServiceBus.cc
@@ -76,14 +76,14 @@ void ServiceBus::issue_bus_command(shared_ptr<BusCommandProxy> proxy) {
     lock_guard<mutex> semaphore(this->api_mutex);
     LOG_DEBUG(bus_node->node_id() << " is issuing BUS command <" << proxy->command << ">");
     if (proxy->issued) {
-        Utils::error("Attempt to issue the same proxy twice");
+        RAISE_ERROR("Attempt to issue the same proxy twice");
     }
     proxy->issued = true;
     proxy->requestor_id = this->bus_node->node_id();
     proxy->serial = this->next_request_serial++;
     proxy->proxy_port = PortPool::get_port();
     if (proxy->proxy_port == 0) {
-        Utils::error("No port is available to start bus command proxy");
+        RAISE_ERROR("No port is available to start bus command proxy");
     } else {
         proxy->setup_proxy_node();
         vector<string> args;
@@ -125,10 +125,10 @@ void ServiceBus::BusCommandMessage::act(shared_ptr<MessageFactory> node) {
         shared_ptr<BusCommandProxy> proxy = service_bus_node->processor->factory_empty_proxy();
         proxy->proxy_port = PortPool::get_port();
         if (proxy->proxy_port == 0) {
-            Utils::error("No port is available to start bus command proxy");
+            RAISE_ERROR("No port is available to start bus command proxy");
         }
         if (this->args.size() < 2) {
-            Utils::error("Invalid BUS command syntax");
+            RAISE_ERROR("Invalid BUS command syntax");
         }
         proxy->requestor_id = this->args[0];
         proxy->serial = stoi(this->args[1]);
@@ -142,6 +142,6 @@ void ServiceBus::BusCommandMessage::act(shared_ptr<MessageFactory> node) {
         }
         service_bus_node->processor->run_command(proxy);
     } else {
-        Utils::error("Processor is not registered to process command: " + this->command);
+        RAISE_ERROR("Processor is not registered to process command: " + this->command);
     }
 }

--- a/src/service_bus/ServiceBusSingleton.cc
+++ b/src/service_bus/ServiceBusSingleton.cc
@@ -21,7 +21,7 @@ void ServiceBusSingleton::init(const string& host_id,
                                unsigned int port_upper) {
     lock_guard<mutex> semaphore(API_MUTEX);
     if (INITIALIZED) {
-        Utils::error(
+        RAISE_ERROR(
             "ServiceBusSingleton already initialized. "
             "ServiceBusSingleton::init() should be called only once.");
     } else {
@@ -35,7 +35,7 @@ void ServiceBusSingleton::init(const string& host_id,
 shared_ptr<ServiceBus> ServiceBusSingleton::get_instance() {
     lock_guard<mutex> semaphore(API_MUTEX);
     if (!INITIALIZED) {
-        Utils::error(
+        RAISE_ERROR(
             "Uninitialized ServiceBusSingleton. ServiceBusSingleton::init() "
             "must be called before ServiceBusSingleton::get_instance()");
         return shared_ptr<ServiceBus>{};  // To avoid warnings

--- a/src/tests/benchmark/atomdb/atomdb_main.cc
+++ b/src/tests/benchmark/atomdb/atomdb_main.cc
@@ -57,7 +57,7 @@ shared_ptr<AtomDB> factory_create_atomdb(string type, const JsonConfig& atomdb_c
     } else if (type == "morkdb") {
         return make_shared<MorkDB>("", atomdb_config);
     } else {
-        Utils::error("Unknown AtomDB type: " + type);
+        RAISE_ERROR("Unknown AtomDB type: " + type);
     }
 }
 
@@ -138,7 +138,7 @@ int main(int argc, char** argv) {
             };
             dispatch_handler(benchmark_handlers, method);
         } else {
-            Utils::error(
+            RAISE_ERROR(
                 "Invalid action. Choose either 'AddAtom' or 'AddAtoms' or 'GetAtom' or 'GetAtoms' "
                 "or 'DeleteAtom' or 'DeleteAtoms'");
         }

--- a/src/tests/benchmark/benchmark_utils.cc
+++ b/src/tests/benchmark/benchmark_utils.cc
@@ -19,10 +19,10 @@ using namespace commons;
 
 double compute_percentile(const vector<double>& vec, double percentile_fraction) {
     if (vec.empty()) {
-        Utils::error("vector is empty");
+        RAISE_ERROR("vector is empty");
     }
     if (percentile_fraction < 0.0 || percentile_fraction > 1.0) {
-        Utils::error("percentile fraction out of range");
+        RAISE_ERROR("percentile fraction out of range");
     }
 
     size_t vec_size = vec.size();
@@ -42,7 +42,7 @@ map<string, map<string, double>> calculate_metric_statistics(map<string, Metrics
 
     for (auto& [operation, metric] : metrics) {
         if (metric.operation_time.empty()) {
-            Utils::error("metrics for operation '" + operation + "' are empty");
+            RAISE_ERROR("metrics for operation '" + operation + "' are empty");
         }
 
         sort(metric.operation_time.begin(), metric.operation_time.end());
@@ -124,7 +124,7 @@ void dispatch_handler(const map<string, function<void()>>& handlers, const strin
     if (it != handlers.end()) {
         it->second();
     } else {
-        Utils::error("Invalid method: " + method);
+        RAISE_ERROR("Invalid method: " + method);
     }
 }
 

--- a/src/tests/benchmark/query_agent/query_agent_main.cc
+++ b/src/tests/benchmark/query_agent/query_agent_main.cc
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
     } else if (action == "LinkTemplateCache") {
         benchmark.link_template_cache();
     } else {
-        Utils::error(
+        RAISE_ERROR(
             "Invalid action. Choose either SimpleQuery, PositiveImportance, ComplexQuery, "
             "UpdateAttentionBroker, or LinkTemplateCache.");
     }

--- a/src/tests/cpp/remote_atomdb_test.cc
+++ b/src/tests/cpp/remote_atomdb_test.cc
@@ -361,7 +361,7 @@ string resolve_config_path(const string& filename) {
 JsonConfig load_config(const string& filename) {
     ifstream f(filename);
     if (!f.good()) {
-        Utils::error("RemoteAtomDBTest: Cannot open config file: " + filename);
+        RAISE_ERROR("RemoteAtomDBTest: Cannot open config file: " + filename);
     }
     stringstream buf;
     buf << f.rdbuf();

--- a/src/tests/main/evaluation_evolution.cc
+++ b/src/tests/main/evaluation_evolution.cc
@@ -133,7 +133,7 @@ static void save_link(Link& link) {
         file << endl;
         file.close();
     } else {
-        Utils::error("Couldn't open file for writing: " + NEW_LINKS_FILE_NAME);
+        RAISE_ERROR("Couldn't open file for writing: " + NEW_LINKS_FILE_NAME);
     }
 }
 
@@ -632,7 +632,7 @@ static void add_to_context_file(const filesystem::path& context_file_name,
                         if (mnemonic == "") mnemonic = "COR";
                         for (auto pair : selector) {
                             if (pair.size() != 2) {
-                                Utils::error("Invalid context task selector for " + mnemonic);
+                                RAISE_ERROR("Invalid context task selector for " + mnemonic);
                                 return;
                             }
                             file << mnemonic << " " << query_answer->get(pair[0]) << " "
@@ -642,7 +642,7 @@ static void add_to_context_file(const filesystem::path& context_file_name,
                     case ACTIVATION:
                         mnemonic = "ACT";
                         if (selector.size() != 1) {
-                            Utils::error("Invalid context task selector for " + mnemonic);
+                            RAISE_ERROR("Invalid context task selector for " + mnemonic);
                         }
                         file << mnemonic;
                         for (auto element : selector[0]) {
@@ -651,14 +651,14 @@ static void add_to_context_file(const filesystem::path& context_file_name,
                         file << endl;
                         break;
                     default:
-                        Utils::error("Invalid context creation task: " +
+                        RAISE_ERROR("Invalid context creation task: " +
                                      std::to_string((unsigned int) task));
                 }
             }
         }
         file.close();
     } else {
-        Utils::error("Couldn't open file for writing: " + string(context_file_name));
+        RAISE_ERROR("Couldn't open file for writing: " + string(context_file_name));
     }
 }
 
@@ -672,22 +672,22 @@ static void add_to_context_file(const filesystem::path& context_file_name,
         for (string handle : handles) {
             switch (task) {
                 case DETERMINER:
-                    Utils::error("Not implemented");
+                    RAISE_ERROR("Not implemented");
                     break;
                 case CORRELATION:
-                    Utils::error("Not implemented");
+                    RAISE_ERROR("Not implemented");
                     break;
                 case ACTIVATION:
                     file << "ACT " << handle << endl;
                     break;
                 default:
-                    Utils::error("Invalid context creation task: " +
+                    RAISE_ERROR("Invalid context creation task: " +
                                  std::to_string((unsigned int) task));
             }
         }
         file.close();
     } else {
-        Utils::error("Couldn't open file for writing: " + string(context_file_name));
+        RAISE_ERROR("Couldn't open file for writing: " + string(context_file_name));
     }
 }
 
@@ -999,7 +999,7 @@ int main(int argc, char* argv[]) {
     NUM_ITERATIONS = (unsigned int) Utils::string_to_int(string(argv[++cursor]));
 
     if (cursor != 15) {
-        Utils::error("Error setting up parameters");
+        RAISE_ERROR("Error setting up parameters");
     }
 
     auto json_config = JsonConfigParser::load(config_file);

--- a/src/tests/main/evaluation_evolution.cc
+++ b/src/tests/main/evaluation_evolution.cc
@@ -652,7 +652,7 @@ static void add_to_context_file(const filesystem::path& context_file_name,
                         break;
                     default:
                         RAISE_ERROR("Invalid context creation task: " +
-                                     std::to_string((unsigned int) task));
+                                    std::to_string((unsigned int) task));
                 }
             }
         }
@@ -681,8 +681,7 @@ static void add_to_context_file(const filesystem::path& context_file_name,
                     file << "ACT " << handle << endl;
                     break;
                 default:
-                    RAISE_ERROR("Invalid context creation task: " +
-                                 std::to_string((unsigned int) task));
+                    RAISE_ERROR("Invalid context creation task: " + std::to_string((unsigned int) task));
             }
         }
         file.close();

--- a/src/tests/main/implication_query_evolution_main.cc
+++ b/src/tests/main/implication_query_evolution_main.cc
@@ -113,7 +113,7 @@ static void save_link(Link& link) {
         file << endl;
         file.close();
     } else {
-        Utils::error("Couldn't open file for writing: " + NEW_LINKS_FILE_NAME);
+        RAISE_ERROR("Couldn't open file for writing: " + NEW_LINKS_FILE_NAME);
     }
 }
 
@@ -149,7 +149,7 @@ static void print_answer(shared_ptr<QueryAnswer> query_answer) {
             cout << source_predicate;
         }
         // if (source_predicate != last_predicate) {
-        //     Utils::error("Bad predicate chaining: " + source_predicate + " != " + last_predicate);
+        //     RAISE_ERROR("Bad predicate chaining: " + source_predicate + " != " + last_predicate);
         // }
         target_predicate = get_predicate_name(implication_link->targets[2]);
         cout << " --> " << target_predicate;

--- a/src/tests/main/inference_toy_kb_generator.cc
+++ b/src/tests/main/inference_toy_kb_generator.cc
@@ -124,7 +124,7 @@ void enforce_bcd_sort(vector<vector<string>>& concepts) {
     while (count < BCD_SORT_COUNT) {
         if (cursor == concepts.size()) {
             RAISE_ERROR("Invalid parameters. BCD_SORT_COUNT = " + std::to_string(BCD_SORT_COUNT) +
-                         " concepts.size() = " + std::to_string(concepts.size()));
+                        " concepts.size() = " + std::to_string(concepts.size()));
             return;
         }
         if (!hidden_predicates(concepts[cursor])) {

--- a/src/tests/main/inference_toy_kb_generator.cc
+++ b/src/tests/main/inference_toy_kb_generator.cc
@@ -81,7 +81,7 @@ bool predicate_bcd(vector<string>& _concept) {
         unsigned int count = 0;
         for (char c : part) {
             if (c == ' ') {
-                Utils::error("Invalid char ' ' in context part");
+                RAISE_ERROR("Invalid char ' ' in context part");
             }
             if (c == k) {
                 count++;
@@ -123,7 +123,7 @@ void enforce_bcd_sort(vector<vector<string>>& concepts) {
     unsigned int cursor = 0;
     while (count < BCD_SORT_COUNT) {
         if (cursor == concepts.size()) {
-            Utils::error("Invalid parameters. BCD_SORT_COUNT = " + std::to_string(BCD_SORT_COUNT) +
+            RAISE_ERROR("Invalid parameters. BCD_SORT_COUNT = " + std::to_string(BCD_SORT_COUNT) +
                          " concepts.size() = " + std::to_string(concepts.size()));
             return;
         }
@@ -188,7 +188,7 @@ void export_metta(vector<vector<string>>& concepts) {
                        std::to_string(SORT_COUNT) + ".metta";
     ofstream metta_file(file_name);
     if (!metta_file.is_open()) {
-        Utils::error("Unable to open file: " + file_name);
+        RAISE_ERROR("Unable to open file: " + file_name);
     }
     for (auto& _concept : concepts) {
         export_concept(metta_file, _concept);
@@ -201,7 +201,7 @@ void export_metta(vector<vector<string>>& concepts) {
 
 int main(int argc, char* argv[]) {
     if (argc != 7) {
-        Utils::error(
+        RAISE_ERROR(
             "Usage: inference_toy_kb_generator <KB size> <concept size> "
             "<concept part size> <charset> <BCD-SORT count> <SORT count>");
     }
@@ -216,7 +216,7 @@ int main(int argc, char* argv[]) {
     print_setup();
 
     if ((SORT_COUNT > BCD_SORT_COUNT) || (BCD_SORT_COUNT > KB_SIZE) || (CONCEPT_SIZE < 3)) {
-        Utils::error("Invalid parameters");
+        RAISE_ERROR("Invalid parameters");
     }
 
     vector<vector<string>> concepts;

--- a/src/tests/main/link_creation_engine_main.cc
+++ b/src/tests/main/link_creation_engine_main.cc
@@ -262,7 +262,7 @@ void run(string atomdb_type_str,
     } else if (link_type_tag == "LINK2") {
         response = client.pattern_matcher_query(query_same_size, context, true);
     } else {
-        Utils::error("Invalid link_type_tag: " + link_type_tag);
+        RAISE_ERROR("Invalid link_type_tag: " + link_type_tag);
     }
 
     shared_ptr<atomdb_api_types::AtomDocument> sentence_document1;
@@ -327,7 +327,7 @@ int main(int argc, char* argv[]) {
     string link_type_tag = argv[2];
 
     if ((link_type_tag != "LINK1") && (link_type_tag != "LINK2")) {
-        Utils::error("Invalid link_type_tag: " + link_type_tag);
+        RAISE_ERROR("Invalid link_type_tag: " + link_type_tag);
     }
 
     string atomdb_type = string(argv[3]) == string("--use-mork") ? "morkdb" : "redismongodb";

--- a/src/tests/main/tests_db_loader.cc
+++ b/src/tests/main/tests_db_loader.cc
@@ -297,7 +297,7 @@ int main(int argc, char* argv[]) {
                     auto result = db->query_for_pattern(link_schema);
                     if (result->size() != 2) {
                         RAISE_ERROR("[" + to_string(thread_id) + "] Expected 2 results, got " +
-                                     to_string(result->size()));
+                                    to_string(result->size()));
                         return;
                     }
 

--- a/src/tests/main/tests_db_loader.cc
+++ b/src/tests/main/tests_db_loader.cc
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) {
             STOP_WATCH_START(tests_db_loader_from_file);
 
             if (argc < 6) {
-                Utils::error(
+                RAISE_ERROR(
                     "File mode requires file path as argument. Usage: context atomdb_type num_threads "
                     "file "
                     "<file_path> [chunk_size]");
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) {
             // First, read all lines from the file to determine line ranges for each thread
             ifstream file(file_path);
             if (!file.is_open()) {
-                Utils::error("Failed to open file: " + file_path);
+                RAISE_ERROR("Failed to open file: " + file_path);
                 return 1;
             }
 
@@ -296,7 +296,7 @@ int main(int argc, char* argv[]) {
 
                     auto result = db->query_for_pattern(link_schema);
                     if (result->size() != 2) {
-                        Utils::error("[" + to_string(thread_id) + "] Expected 2 results, got " +
+                        RAISE_ERROR("[" + to_string(thread_id) + "] Expected 2 results, got " +
                                      to_string(result->size()));
                         return;
                     }


### PR DESCRIPTION
Resolves #1099 

A call like this:

```
Utils::error("My error message");
```

Was producing a log message like this:

```
2026-05-08 18:46:56 | [ERROR] | commons/Utils.cc | error : 28 | My error message
```

With file/line referencing Utils.cc instead of the actual file where the error was raised. In this PR we added a macro in Util.h to be called instead of Utils::error() this way:

```
RAISE_ERROR("My error message");
```

which produces the following log message instead:

```
2026-05-08 18:49:44 | [ERROR] | tests/cpp/utils_test.cc | TestBody : 15 | My error message
```

with proper file/line reference. Utils:error() is still there and work exactly the same way but now its optional flag parameter (to actually raise or not an exception) has been changed to no longer be defaulted. Now it's mandatory.