### PR TITLE
[#665] Add optional parameter to make AND operator consider last clause as a NOT

### DIFF
--- a/src/agents/query_engine/query_element/And.h
+++ b/src/agents/query_engine/query_element/And.h
@@ -219,7 +219,7 @@ class And : public Operator<N> {
                 LOG_DEBUG("NOT clause didn't match. Disregarding it.");
             } else {
                 for (auto answer : this->query_answer[this->num_and_clauses]) {
-                    LOG_DEBUG(new_query_answer->to_string() +  " AND NOT " + answer->to_string());
+                    LOG_DEBUG(new_query_answer->to_string() + " AND NOT " + answer->to_string());
                     if (new_query_answer->assignment.is_compatible(answer->assignment)) {
                         LOG_DEBUG("Discarding query answer");
                         delete new_query_answer;
@@ -256,10 +256,12 @@ class And : public Operator<N> {
         CandidateRecord candidate;
         unsigned int index_in_queue;
         bool abort_candidate;
-        for (unsigned int new_candidate_count = 0; new_candidate_count < this->num_and_clauses; new_candidate_count++) {
+        for (unsigned int new_candidate_count = 0; new_candidate_count < this->num_and_clauses;
+             new_candidate_count++) {
             abort_candidate = false;
             candidate.fitness = 1.0;
-            for (unsigned int answer_queue_index = 0; answer_queue_index < this->num_and_clauses; answer_queue_index++) {
+            for (unsigned int answer_queue_index = 0; answer_queue_index < this->num_and_clauses;
+                 answer_queue_index++) {
                 index_in_queue = last_used_candidate.index[answer_queue_index];
                 if (answer_queue_index == new_candidate_count) {
                     index_in_queue++;

--- a/src/agents/query_engine/query_element/And.h
+++ b/src/agents/query_engine/query_element/And.h
@@ -28,11 +28,15 @@ class And : public Operator<N> {
      * @param clauses Array with N clauses (each clause is supposed to be a Source or an Operator).
      * @param link_templates Vector with all the query elements in clauses which are LinkTemplate
      * objects. This is stored in the And object just to make shure they don't get released before
+     * @param not_operator_flag A flag indicating if this AND operator should act like a AND_NOT
+     * operator instead. An AND_NOT operator is like an AND operator but it assumes a NOT attached
+     * to its last clause. For instance AND_NOT(A, B, C) is true if A AND B AND NOT C is true.
      * the And operation ends.
      */
     And(const array<shared_ptr<QueryElement>, N>& clauses,
-        const vector<shared_ptr<QueryElement>>& link_templates = {})
-        : Operator<N>(clauses) {
+        const vector<shared_ptr<QueryElement>>& link_templates = {},
+        bool not_operator_flag = false)
+        : Operator<N>(clauses), not_operator_flag(not_operator_flag) {
         initialize(clauses);
         this->link_templates = link_templates;
     }
@@ -42,12 +46,14 @@ class And : public Operator<N> {
      */
     ~And() {
         graceful_shutdown();
+        LOG_LOCAL_DEBUG("AND operator destructor. Deleting query answers...");
         for (size_t i = 0; i < N; i++) {
             for (auto answer : this->query_answer[i]) {
                 delete answer;
             }
             this->query_answer[i].clear();
         }
+        LOG_LOCAL_DEBUG("AND operator destructor. Deleting query answers... DONE");
     }
 
     // --------------------------------------------------------------------------------------------
@@ -59,7 +65,9 @@ class And : public Operator<N> {
     }
 
     virtual void graceful_shutdown() {
+        LOG_LOCAL_DEBUG("And::graceful_shutdown() BEGIN");
         if (Operator<N>::is_flow_finished()) {
+            LOG_LOCAL_DEBUG("And::graceful_shutdown() early END");
             return;
         }
         Operator<N>::graceful_shutdown();
@@ -68,6 +76,7 @@ class And : public Operator<N> {
             delete this->operator_thread;
             this->operator_thread = NULL;
         }
+        LOG_LOCAL_DEBUG("And::graceful_shutdown() END");
     }
 
     // --------------------------------------------------------------------------------------------
@@ -124,6 +133,8 @@ class And : public Operator<N> {
     thread* operator_thread;
     unsigned int query_answer_count;
     vector<shared_ptr<QueryElement>> link_templates;
+    bool not_operator_flag;
+    unsigned int num_and_clauses;
 
     void initialize(const array<shared_ptr<QueryElement>, N>& clauses) {
         this->operator_thread = NULL;
@@ -133,7 +144,13 @@ class And : public Operator<N> {
         }
         this->no_more_answers_to_arrive = false;
         this->query_answer_count = 0;
-        this->id = "And(";
+        if (this->not_operator_flag) {
+            this->id = "AndNot(";
+            this->num_and_clauses = N - 1;
+        } else {
+            this->id = "And(";
+            this->num_and_clauses = N;
+        }
         for (unsigned int i = 0; i < N; i++) {
             this->id += clauses[i]->id;
             if (i != (N - 1)) {
@@ -145,13 +162,20 @@ class And : public Operator<N> {
     }
 
     bool ready_to_process_candidate() {
-        for (unsigned int i = 0; i < N; i++) {
+        for (unsigned int i = 0; i < this->num_and_clauses; i++) {
             if ((!this->all_answers_arrived[i]) &&
                 (this->query_answer[i].size() <= (this->next_input_to_process[i] + 1))) {
                 return false;
             }
         }
-        return true;
+        if (this->not_operator_flag) {
+            // If running an AndNot operator, all answers of the NOT clause must arrive
+            // BEFORE any combination is eavaluated because we must be sure that any potentially
+            // approved combination aren't returned in the NOT clause.
+            return this->all_answers_arrived[this->num_and_clauses];
+        } else {
+            return true;
+        }
     }
 
     void ingest_newly_arrived_answers() {
@@ -184,13 +208,28 @@ class And : public Operator<N> {
 
     void operate_candidate(const CandidateRecord& candidate) {
         QueryAnswer* new_query_answer = QueryAnswer::copy(candidate.answer[0]);
-        for (unsigned int i = 1; i < N; i++) {
+        for (unsigned int i = 1; i < this->num_and_clauses; i++) {
             if (!new_query_answer->merge(candidate.answer[i])) {
                 delete new_query_answer;
                 return;
             }
         }
+        if (this->not_operator_flag) {
+            if (this->query_answer[this->num_and_clauses].size() == 0) {
+                LOG_DEBUG("NOT clause didn't match. Disregarding it.");
+            } else {
+                for (auto answer : this->query_answer[this->num_and_clauses]) {
+                    LOG_DEBUG(new_query_answer->to_string() +  " AND NOT " + answer->to_string());
+                    if (new_query_answer->assignment.is_compatible(answer->assignment)) {
+                        LOG_DEBUG("Discarding query answer");
+                        delete new_query_answer;
+                        return;
+                    }
+                }
+            }
+        }
         this->query_answer_count++;
+        LOG_DEBUG("Reporting answer: " + new_query_answer->to_string());
         this->output_buffer->add_query_answer(new_query_answer);
     }
 
@@ -198,13 +237,13 @@ class And : public Operator<N> {
         if (this->border.size() > 0) {
             return false;
         } else {
-            for (unsigned int i = 0; i < N; i++) {
+            for (unsigned int i = 0; i < this->num_and_clauses; i++) {
                 if ((this->next_input_to_process[i] == this->query_answer[i].size()) &&
                     (this->all_answers_arrived[i])) {
                     return true;
                 }
             }
-            for (unsigned int i = 0; i < N; i++) {
+            for (unsigned int i = 0; i < this->num_and_clauses; i++) {
                 if (this->next_input_to_process[i] < this->query_answer[i].size()) {
                     return false;
                 }
@@ -217,10 +256,10 @@ class And : public Operator<N> {
         CandidateRecord candidate;
         unsigned int index_in_queue;
         bool abort_candidate;
-        for (unsigned int new_candidate_count = 0; new_candidate_count < N; new_candidate_count++) {
+        for (unsigned int new_candidate_count = 0; new_candidate_count < this->num_and_clauses; new_candidate_count++) {
             abort_candidate = false;
             candidate.fitness = 1.0;
-            for (unsigned int answer_queue_index = 0; answer_queue_index < N; answer_queue_index++) {
+            for (unsigned int answer_queue_index = 0; answer_queue_index < this->num_and_clauses; answer_queue_index++) {
                 index_in_queue = last_used_candidate.index[answer_queue_index];
                 if (answer_queue_index == new_candidate_count) {
                     index_in_queue++;
@@ -240,6 +279,10 @@ class And : public Operator<N> {
             }
             if (abort_candidate) {
                 continue;
+            }
+            if (this->not_operator_flag) {
+                candidate.answer[this->num_and_clauses] = NULL;
+                candidate.index[this->num_and_clauses] = 0;
             }
             if (visited.find(candidate) == visited.end()) {
                 this->border.push(candidate);
@@ -277,7 +320,7 @@ class And : public Operator<N> {
                     // processed_all_input() is double-checked on purpose to avoid race condition
                     processed_all_input()) {
                     this->output_buffer->query_answers_finished();
-                    LOG_INFO(this->id << " processed " << this->query_answer_count << " answers.");
+                    LOG_INFO(this->id << " reported " << this->query_answer_count << " answers.");
                 }
                 STOP_WATCH_STOP(and_operator);
                 Utils::sleep();
@@ -291,11 +334,15 @@ class And : public Operator<N> {
                 }
                 CandidateRecord candidate;
                 double fitness = 1.0;
-                for (unsigned int i = 0; i < N; i++) {
+                for (unsigned int i = 0; i < this->num_and_clauses; i++) {
                     candidate.answer[i] = this->query_answer[i][this->next_input_to_process[i]],
                     candidate.index[i] = this->next_input_to_process[i];
                     this->next_input_to_process[i]++;
                     fitness *= candidate.answer[i]->importance;
+                }
+                if (this->not_operator_flag) {
+                    candidate.answer[this->num_and_clauses] = NULL;
+                    candidate.index[this->num_and_clauses] = 0;
                 }
                 candidate.fitness = fitness;
                 this->border.push(candidate);

--- a/src/tests/cpp/and_operator_test.cc
+++ b/src/tests/cpp/and_operator_test.cc
@@ -16,7 +16,7 @@ using namespace query_element;
 class TestSource : public Source {
    public:
     TestSource(unsigned int count) { this->id = "TestSource_" + std::to_string(count); }
-    TestSource() { this->id = "TestSource_" +  Utils::random_string(30); }
+    TestSource() { this->id = "TestSource_" + Utils::random_string(30); }
 
     ~TestSource() {}
 
@@ -40,7 +40,8 @@ class TestSource : public Source {
 
 class TestSink : public Sink {
    public:
-    TestSink(shared_ptr<QueryElement> precedent) : Sink(precedent, "TestSink(" + precedent->id + "," + Utils::random_string(30) + ")") {}
+    TestSink(shared_ptr<QueryElement> precedent)
+        : Sink(precedent, "TestSink(" + precedent->id + "," + Utils::random_string(30) + ")") {}
     ~TestSink() {}
     bool empty() { return this->input_buffer->is_query_answers_empty(); }
     bool finished() { return this->input_buffer->is_query_answers_finished(); }
@@ -264,7 +265,8 @@ TEST(AndOperator, not_operator_1) {
     source[1] = make_shared<TestSource>();
     source[2] = make_shared<TestSource>();
     vector<shared_ptr<QueryElement>> dummy;
-    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    auto and_operator = make_shared<And<3>>(
+        array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
     TestSink sink(and_operator);
     QueryAnswer* query_answer;
 
@@ -312,7 +314,8 @@ TEST(AndOperator, not_operator_2) {
     source[1] = make_shared<TestSource>();
     source[2] = make_shared<TestSource>();
     vector<shared_ptr<QueryElement>> dummy;
-    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    auto and_operator = make_shared<And<3>>(
+        array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
     TestSink sink(and_operator);
     QueryAnswer* query_answer;
 
@@ -359,7 +362,8 @@ TEST(AndOperator, not_operator_3) {
     source[1] = make_shared<TestSource>();
     source[2] = make_shared<TestSource>();
     vector<shared_ptr<QueryElement>> dummy;
-    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    auto and_operator = make_shared<And<3>>(
+        array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
     TestSink sink(and_operator);
     QueryAnswer* query_answer;
 
@@ -393,7 +397,8 @@ TEST(AndOperator, not_operator_4) {
     source[1] = make_shared<TestSource>();
     source[2] = make_shared<TestSource>();
     vector<shared_ptr<QueryElement>> dummy;
-    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    auto and_operator = make_shared<And<3>>(
+        array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
     TestSink sink(and_operator);
     QueryAnswer* query_answer;
 
@@ -441,7 +446,8 @@ TEST(AndOperator, not_operator_5) {
     source[1] = make_shared<TestSource>();
     source[2] = make_shared<TestSource>();
     vector<shared_ptr<QueryElement>> dummy;
-    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    auto and_operator = make_shared<And<3>>(
+        array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
     TestSink sink(and_operator);
     QueryAnswer* query_answer;
 

--- a/src/tests/cpp/and_operator_test.cc
+++ b/src/tests/cpp/and_operator_test.cc
@@ -16,13 +16,14 @@ using namespace query_element;
 class TestSource : public Source {
    public:
     TestSource(unsigned int count) { this->id = "TestSource_" + std::to_string(count); }
+    TestSource() { this->id = "TestSource_" +  Utils::random_string(30); }
 
     ~TestSource() {}
 
     void add(const char* handle,
              double importance,
-             const array<const char*, 1>& labels,
-             const array<const char*, 1>& values,
+             const vector<string>& labels,
+             const vector<string>& values,
              bool sleep_flag = true) {
         QueryAnswer* query_answer = new QueryAnswer(handle, importance);
         for (unsigned int i = 0; i < labels.size(); i++) {
@@ -39,7 +40,7 @@ class TestSource : public Source {
 
 class TestSink : public Sink {
    public:
-    TestSink(shared_ptr<QueryElement> precedent) : Sink(precedent, "TestSink(" + precedent->id + ")") {}
+    TestSink(shared_ptr<QueryElement> precedent) : Sink(precedent, "TestSink(" + precedent->id + "," + Utils::random_string(30) + ")") {}
     ~TestSink() {}
     bool empty() { return this->input_buffer->is_query_answers_empty(); }
     bool finished() { return this->input_buffer->is_query_answers_finished(); }
@@ -51,7 +52,7 @@ void check_query_answer(string tag,
                         double importance,
                         unsigned int handles_size,
                         const array<const char*, 2>& handles) {
-    cout << "check_query_answer(" + tag + ")" << endl;
+    LOG_INFO("check_query_answer(" + tag + "); " + query_answer->to_string());
     EXPECT_TRUE(double_equals(query_answer->importance, importance));
     EXPECT_EQ(query_answer->get_handles_size(), 2);
     set<string> set_handles;
@@ -63,8 +64,8 @@ void check_query_answer(string tag,
 }
 
 TEST(AndOperator, basics) {
-    auto source1 = make_shared<TestSource>(10);
-    auto source2 = make_shared<TestSource>(20);
+    auto source1 = make_shared<TestSource>();
+    auto source2 = make_shared<TestSource>();
     auto and_operator = make_shared<And<2>>(array<shared_ptr<QueryElement>, 2>({source1, source2}));
     TestSink sink(and_operator);
     QueryAnswer* query_answer;
@@ -237,8 +238,8 @@ TEST(AndOperator, operation_logic) {
 }
 
 TEST(AndOperator, empty_source) {
-    auto source1 = make_shared<TestSource>(100);
-    auto source2 = make_shared<TestSource>(200);
+    auto source1 = make_shared<TestSource>();
+    auto source2 = make_shared<TestSource>();
     auto and_operator = make_shared<And<2>>(array<shared_ptr<QueryElement>, 2>({source1, source2}));
     TestSink sink(and_operator);
     Utils::sleep(1000);
@@ -252,6 +253,227 @@ TEST(AndOperator, empty_source) {
     EXPECT_FALSE(sink.finished());
     source1->query_answers_finished();
     source2->query_answers_finished();
+    Utils::sleep(SLEEP_DURATION);
+    EXPECT_TRUE(sink.empty());
+    EXPECT_TRUE(sink.finished());
+}
+
+TEST(AndOperator, not_operator_1) {
+    array<shared_ptr<TestSource>, 3> source;
+    source[0] = make_shared<TestSource>();
+    source[1] = make_shared<TestSource>();
+    source[2] = make_shared<TestSource>();
+    vector<shared_ptr<QueryElement>> dummy;
+    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    TestSink sink(and_operator);
+    QueryAnswer* query_answer;
+
+    source[0]->add("S0_1", 0.9, {"v1"}, {"1"});
+    source[0]->add("S0_2", 0.8, {"v1"}, {"2"});
+    source[0]->add("S0_3", 0.7, {"v1"}, {"3"});
+    source[1]->add("S1_1", 0.3, {"v2"}, {"1"});
+    source[1]->add("S1_2", 0.2, {"v2"}, {"2"});
+    source[1]->add("S1_3", 0.1, {"v2"}, {"3"});
+
+    source[2]->add("S2_1", 1.0, {"v1"}, {"2"});
+    unsigned int expected_count = 6;
+
+    Utils::sleep(SLEEP_DURATION);
+    source[0]->query_answers_finished();
+    source[1]->query_answers_finished();
+    source[2]->query_answers_finished();
+
+    unsigned int count = 0;
+    while (count < expected_count) {
+        if (sink.empty()) {
+            Utils::sleep();
+            continue;
+        }
+        if (sink.finished() && sink.empty()) {
+            break;
+        }
+        EXPECT_FALSE((query_answer = dynamic_cast<QueryAnswer*>(sink.pop())) == NULL);
+        LOG_INFO("query_answer: " + query_answer->to_string());
+        EXPECT_EQ(query_answer->get_handles_vector().size(), 2);
+        for (string handle : query_answer->get_handles_vector()) {
+            EXPECT_NE(handle, string("S0_2"));
+        }
+        count++;
+    }
+    EXPECT_EQ(count, expected_count);
+    Utils::sleep(SLEEP_DURATION);
+    EXPECT_TRUE(sink.empty());
+    EXPECT_TRUE(sink.finished());
+}
+
+TEST(AndOperator, not_operator_2) {
+    array<shared_ptr<TestSource>, 3> source;
+    source[0] = make_shared<TestSource>();
+    source[1] = make_shared<TestSource>();
+    source[2] = make_shared<TestSource>();
+    vector<shared_ptr<QueryElement>> dummy;
+    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    TestSink sink(and_operator);
+    QueryAnswer* query_answer;
+
+    source[0]->add("S0_1", 0.9, {"v1"}, {"1"});
+    source[0]->add("S0_2", 0.8, {"v1"}, {"2"});
+    source[0]->add("S0_3", 0.7, {"v1"}, {"3"});
+    source[1]->add("S1_1", 0.3, {"v2"}, {"1"});
+    source[1]->add("S1_2", 0.2, {"v2"}, {"2"});
+    source[1]->add("S1_3", 0.1, {"v2"}, {"3"});
+
+    source[2]->add("S2_1", 1.0, {"v1", "v2"}, {"2", "3"});
+    unsigned int expected_count = 8;
+
+    Utils::sleep(SLEEP_DURATION);
+    source[0]->query_answers_finished();
+    source[1]->query_answers_finished();
+    source[2]->query_answers_finished();
+
+    unsigned int count = 0;
+    while (count < expected_count) {
+        if (sink.empty()) {
+            Utils::sleep();
+            continue;
+        }
+        if (sink.finished() && sink.empty()) {
+            break;
+        }
+        EXPECT_FALSE((query_answer = dynamic_cast<QueryAnswer*>(sink.pop())) == NULL);
+        LOG_INFO("query_answer: " + query_answer->to_string());
+        EXPECT_EQ(query_answer->get_handles_vector().size(), 2);
+        auto handles = query_answer->get_handles_vector();
+        EXPECT_FALSE((handles[0] == "S0_2") && (handles[1] == "S1_3"));
+        count++;
+    }
+    EXPECT_EQ(count, expected_count);
+    Utils::sleep(SLEEP_DURATION);
+    EXPECT_TRUE(sink.empty());
+    EXPECT_TRUE(sink.finished());
+}
+
+TEST(AndOperator, not_operator_3) {
+    array<shared_ptr<TestSource>, 3> source;
+    source[0] = make_shared<TestSource>();
+    source[1] = make_shared<TestSource>();
+    source[2] = make_shared<TestSource>();
+    vector<shared_ptr<QueryElement>> dummy;
+    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    TestSink sink(and_operator);
+    QueryAnswer* query_answer;
+
+    source[0]->add("S0_1", 0.9, {"v1"}, {"1"});
+    source[0]->add("S0_2", 0.8, {"v1"}, {"2"});
+    source[0]->add("S0_3", 0.7, {"v1"}, {"3"});
+    source[1]->add("S1_1", 0.3, {"v2"}, {"1"});
+    source[1]->add("S1_2", 0.2, {"v2"}, {"2"});
+    source[1]->add("S1_3", 0.1, {"v2"}, {"3"});
+
+    source[2]->add("S2_1", 1.0, {"v3"}, {"0"});
+    unsigned int expected_count = 0;
+
+    Utils::sleep(SLEEP_DURATION);
+    source[0]->query_answers_finished();
+    source[1]->query_answers_finished();
+    source[2]->query_answers_finished();
+
+    while (!(sink.empty() && sink.finished())) {
+        if (sink.empty()) {
+            Utils::sleep();
+            continue;
+        }
+        FAIL();
+    }
+}
+
+TEST(AndOperator, not_operator_4) {
+    array<shared_ptr<TestSource>, 3> source;
+    source[0] = make_shared<TestSource>();
+    source[1] = make_shared<TestSource>();
+    source[2] = make_shared<TestSource>();
+    vector<shared_ptr<QueryElement>> dummy;
+    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    TestSink sink(and_operator);
+    QueryAnswer* query_answer;
+
+    source[0]->add("S0_1", 0.9, {"v1"}, {"1"});
+    source[0]->add("S0_2", 0.8, {"v1"}, {"2"});
+    source[0]->add("S0_3", 0.7, {"v1"}, {"3"});
+    source[1]->add("S1_1", 0.3, {"v2"}, {"1"});
+    source[1]->add("S1_2", 0.2, {"v2"}, {"2"});
+    source[1]->add("S1_3", 0.1, {"v2"}, {"3"});
+
+    source[2]->add("S2_1", 1.0, {"v1"}, {"2"});
+    source[2]->add("S2_2", 1.0, {"v2"}, {"3"});
+    unsigned int expected_count = 4;
+
+    Utils::sleep(SLEEP_DURATION);
+    source[0]->query_answers_finished();
+    source[1]->query_answers_finished();
+    source[2]->query_answers_finished();
+
+    unsigned int count = 0;
+    while (count < expected_count) {
+        if (sink.empty()) {
+            Utils::sleep();
+            continue;
+        }
+        if (sink.finished() && sink.empty()) {
+            break;
+        }
+        EXPECT_FALSE((query_answer = dynamic_cast<QueryAnswer*>(sink.pop())) == NULL);
+        LOG_INFO("query_answer: " + query_answer->to_string());
+        EXPECT_EQ(query_answer->get_handles_vector().size(), 2);
+        auto handles = query_answer->get_handles_vector();
+        EXPECT_FALSE((handles[0] == "S0_2") || (handles[1] == "S1_3"));
+        count++;
+    }
+    EXPECT_EQ(count, expected_count);
+    Utils::sleep(SLEEP_DURATION);
+    EXPECT_TRUE(sink.empty());
+    EXPECT_TRUE(sink.finished());
+}
+
+TEST(AndOperator, not_operator_5) {
+    array<shared_ptr<TestSource>, 3> source;
+    source[0] = make_shared<TestSource>();
+    source[1] = make_shared<TestSource>();
+    source[2] = make_shared<TestSource>();
+    vector<shared_ptr<QueryElement>> dummy;
+    auto and_operator = make_shared<And<3>>(array<shared_ptr<QueryElement>, 3>({source[0], source[1], source[2]}), dummy, true);
+    TestSink sink(and_operator);
+    QueryAnswer* query_answer;
+
+    source[0]->add("S0_1", 0.9, {"v1"}, {"1"});
+    source[0]->add("S0_2", 0.8, {"v1"}, {"2"});
+    source[0]->add("S0_3", 0.7, {"v1"}, {"3"});
+    source[1]->add("S1_1", 0.3, {"v2"}, {"1"});
+    source[1]->add("S1_2", 0.2, {"v2"}, {"2"});
+    source[1]->add("S1_3", 0.1, {"v2"}, {"3"});
+
+    unsigned int expected_count = 9;
+
+    Utils::sleep(SLEEP_DURATION);
+    source[0]->query_answers_finished();
+    source[1]->query_answers_finished();
+    source[2]->query_answers_finished();
+
+    unsigned int count = 0;
+    while (count < expected_count) {
+        if (sink.empty()) {
+            Utils::sleep();
+            continue;
+        }
+        if (sink.finished() && sink.empty()) {
+            break;
+        }
+        EXPECT_FALSE((query_answer = dynamic_cast<QueryAnswer*>(sink.pop())) == NULL);
+        LOG_INFO("query_answer: " + query_answer->to_string());
+        EXPECT_EQ(query_answer->get_handles_vector().size(), 2);
+        count++;
+    }
+    EXPECT_EQ(count, expected_count);
     Utils::sleep(SLEEP_DURATION);
     EXPECT_TRUE(sink.empty());
     EXPECT_TRUE(sink.finished());


### PR DESCRIPTION
WIP towards #665 

In this PR we added an optional flag to AND operator constructor to define that the last clause is to be considered a NOT clause. For instance `AND(A, B, C)` is considered as `A AND B AND (NOT C)`.

Regarding #665 , we are still missing allowing `ANDNOT` as a token (or a valid metta tag) in a PM query. I.e. after this PR we have the required functionality in the AND operator but we still don't have means to make a query with ANDNOT in the pattern matching agent. This will be implemented in a follow up PR.