### PR TITLE
[#1102] Add Mork Adapter support (Design)

### DIFF
--- a/src/db_adapter/BUILD
+++ b/src/db_adapter/BUILD
@@ -18,6 +18,7 @@ cc_library(
         ":metta_file_writer",
         "//commons:commons_lib",
         "//commons/atoms:atoms_lib",
+        "//db_adapter/non_sql:non_sql_lib",
         "//db_adapter/sql:sql_lib",
     ],
 )
@@ -154,6 +155,7 @@ cc_library(
         ":database_mapper",
         ":database_types",
         "//commons:commons_lib",
+        "//db_adapter/non_sql:metta2atoms_mapper",
         "//db_adapter/sql:sql2atoms_mapper",
     ],
 )

--- a/src/db_adapter/ContextLoader.cc
+++ b/src/db_adapter/ContextLoader.cc
@@ -45,3 +45,8 @@ vector<string> ContextLoader::load_sql_queries(const string& file_path) {
 
     return queries;
 }
+
+vector<string> ContextLoader::load_metta_queries(const string& file_path) {
+    RAISE_ERROR("ContextLoader::load_metta_queries() not implemented yet");
+    return {};
+}

--- a/src/db_adapter/ContextLoader.h
+++ b/src/db_adapter/ContextLoader.h
@@ -9,4 +9,5 @@ using namespace db_adapter;
 class ContextLoader {
    public:
     static vector<string> load_sql_queries(const string& file_path);
+    static vector<string> load_metta_queries(const string& file_path);
 };

--- a/src/db_adapter/DatabaseTypes.h
+++ b/src/db_adapter/DatabaseTypes.h
@@ -57,6 +57,10 @@ struct SqlRow {
     size_t size() const { return (primary_key ? 1 : 0) + fields.size(); }
 };
 
+struct MettaExpression {
+    string expression;
+};
+
 struct NoSqlDocument {};
 
 /**
@@ -64,7 +68,7 @@ struct NoSqlDocument {};
  * @brief A variant representing raw input from the database, which can be a SQL row, a NoSQL document,
  * or a Metta expression.
  */
-using DbInput = variant<SqlRow, NoSqlDocument>;
+using DbInput = variant<SqlRow, NoSqlDocument, MettaExpression>;
 
 /**
  * @struct Table
@@ -82,7 +86,7 @@ struct Table {
  * @enum MAPPER_TYPE
  * @brief Defines the strategy used to transform database rows.
  */
-enum class MAPPER_TYPE { SQL2ATOMS };
+enum class MAPPER_TYPE { SQL2ATOMS, METTA2ATOMS };
 
 struct TableMapping {
     string table_name;

--- a/src/db_adapter/MapperFactory.cc
+++ b/src/db_adapter/MapperFactory.cc
@@ -1,5 +1,6 @@
 #include "MapperFactory.h"
 
+#include "Metta2AtomsMapper.h"
 #include "Sql2AtomsMapper.h"
 #include "Utils.h"
 
@@ -10,6 +11,8 @@ shared_ptr<DatabaseMapper> MapperFactory::create(MAPPER_TYPE mapper_type) {
     switch (mapper_type) {
         case MAPPER_TYPE::SQL2ATOMS:
             return make_shared<SQL2AtomsMapper>();
+        case MAPPER_TYPE::METTA2ATOMS:
+            return make_shared<Metta2AtomsMapper>();
         default:
             RAISE_ERROR("Unknown mapper type");
     }

--- a/src/db_adapter/non_sql/BUILD
+++ b/src/db_adapter/non_sql/BUILD
@@ -1,0 +1,26 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "non_sql_lib",
+    includes = ["."],
+    deps = [
+        ":metta2atoms_mapper",
+        "//db_adapter/non_sql/mork:mork_lib",
+    ],
+)
+
+cc_library(
+    name = "metta2atoms_mapper",
+    srcs = ["Metta2AtomsMapper.cc"],
+    hdrs = ["Metta2AtomsMapper.h"],
+    includes = ["."],
+    deps = [
+        "//commons:commons_lib",
+        "//commons/atoms:atoms_lib",
+        "//db_adapter:database_mapper",
+        "//db_adapter:database_types",
+        "//metta:metta_lib",
+    ],
+)

--- a/src/db_adapter/non_sql/Metta2AtomsMapper.cc
+++ b/src/db_adapter/non_sql/Metta2AtomsMapper.cc
@@ -1,0 +1,27 @@
+#include "Metta2AtomsMapper.h"
+
+#define LOG_LEVEL INFO_LEVEL
+#include "Logger.h"
+
+using namespace db_adapter;
+using namespace commons;
+using namespace atoms;
+
+// ==============================
+//  Construction / destruction
+// ==============================
+
+Metta2AtomsMapper::Metta2AtomsMapper() {
+    RAISE_ERROR("Metta2AtomsMapper constructor not implemented yet");
+}
+
+Metta2AtomsMapper::~Metta2AtomsMapper() {}
+
+// ==============================
+//  Public
+// ==============================
+
+const vector<Atom*> Metta2AtomsMapper::map(const DbInput& data) {
+    RAISE_ERROR("Metta2AtomsMapper::map() not implemented yet");
+    return vector<Atom*>{};
+}

--- a/src/db_adapter/non_sql/Metta2AtomsMapper.h
+++ b/src/db_adapter/non_sql/Metta2AtomsMapper.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "Atom.h"
+#include "DatabaseMapper.h"
+#include "DatabaseTypes.h"
+#include "MettaMapping.h"
+#include "MettaParserActions.h"
+
+using namespace std;
+using namespace atoms;
+using namespace commons;
+
+namespace db_adapter {
+
+class Metta2AtomsMapper : public DatabaseMapper {
+   public:
+    Metta2AtomsMapper();
+    ~Metta2AtomsMapper() override;
+
+    const vector<Atom*> map(const DbInput& data) override;
+
+   private:
+    vector<Atom*> atoms;
+    shared_ptr<MettaParserActions> parser_actions;
+};
+
+}  // namespace db_adapter

--- a/src/db_adapter/non_sql/mork/BUILD
+++ b/src/db_adapter/non_sql/mork/BUILD
@@ -1,0 +1,52 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "mork_lib",
+    includes = ["."],
+    deps = [
+        ":mork_connection",
+        ":mork_mapping_strategy",
+        ":mork_wrapper",
+    ],
+)
+
+cc_library(
+    name = "mork_wrapper",
+    srcs = ["MorkWrapper.cc"],
+    hdrs = ["MorkWrapper.h"],
+    includes = ["."],
+    deps = [
+        ":mork_connection",
+        "//commons:commons_lib",
+        "//db_adapter:bounded_shared_queue",
+        "//db_adapter:database_types",
+        "//db_adapter:database_wrapper",
+        "//db_adapter:mapper_factory",
+    ],
+)
+
+cc_library(
+    name = "mork_connection",
+    srcs = ["MorkConnection.cc"],
+    hdrs = ["MorkConnection.h"],
+    includes = ["."],
+    deps = [
+        "//atomdb/morkdb:morkdb_lib",
+        "//commons:commons_lib",
+        "//db_adapter:database_connection",
+    ],
+)
+
+cc_library(
+    name = "mork_mapping_strategy",
+    srcs = ["MorkMappingStrategy.cc"],
+    hdrs = ["MorkMappingStrategy.h"],
+    includes = ["."],
+    deps = [
+        ":mork_wrapper",
+        "//commons:commons_lib",
+        "//db_adapter:database_mapping_strategy",
+    ],
+)

--- a/src/db_adapter/non_sql/mork/MorkConnection.cc
+++ b/src/db_adapter/non_sql/mork/MorkConnection.cc
@@ -1,0 +1,37 @@
+#include "MorkConnection.h"
+
+#include "Utils.h"
+
+using namespace std;
+using namespace atomdb;
+using namespace db_adapter;
+
+// ==============================
+//  Construction / destruction
+// ==============================
+
+MorkConnection::MorkConnection(const string& id, const string& host, int port)
+    : DatabaseConnection(id, host, port) {
+    RAISE_ERROR("MorkConnection constructor not implemented yet");
+}
+
+MorkConnection::~MorkConnection() {}
+
+// ==============================
+// Public
+// ==============================
+
+void MorkConnection::connect() {
+    RAISE_ERROR("MorkConnection::connect() not implemented yet");
+    return;
+}
+
+void MorkConnection::disconnect() {
+    RAISE_ERROR("MorkConnection::disconnect() not implemented yet");
+    return;
+}
+
+vector<string> MorkConnection::query(const string& metta_query) {
+    RAISE_ERROR("MorkConnection::query() not implemented yet");
+    return {};
+}

--- a/src/db_adapter/non_sql/mork/MorkConnection.h
+++ b/src/db_adapter/non_sql/mork/MorkConnection.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "DatabaseConnection.h"
+#include "MorkDB.h"
+
+using namespace std;
+using namespace atomdb;
+
+namespace db_adapter {
+
+class MorkConnection : public DatabaseConnection {
+   public:
+    MorkConnection(const string& id, const string& host, int port);
+    ~MorkConnection();
+
+    void connect() override;
+    void disconnect() override;
+
+    vector<string> query(const string& metta_query);
+
+   protected:
+    shared_ptr<MorkClient> conn;
+};
+
+}  // namespace db_adapter

--- a/src/db_adapter/non_sql/mork/MorkMappingStrategy.cc
+++ b/src/db_adapter/non_sql/mork/MorkMappingStrategy.cc
@@ -1,0 +1,29 @@
+#include "MorkMappingStrategy.h"
+
+using namespace std;
+using namespace db_adapter;
+
+// ==============================
+//  Construction / destruction
+// ==============================
+
+db_adapter::MorkMappingStrategy::MorkMappingStrategy(const JsonConfig& config,
+                                                     shared_ptr<MorkConnection> conn,
+                                                     shared_ptr<BoundedSharedQueue> queue)
+    : DatabaseMappingStrategy(conn), config(config) {
+    this->wrapper = make_shared<MorkWrapper>(*conn, queue);
+}
+
+// ==============================
+//  Public
+// ============================
+
+vector<MappingTask> MorkMappingStrategy::create_tasks() {
+    RAISE_ERROR("MorkMappingStrategy::create_tasks() not implemented yet");
+    return vector<MappingTask>{};
+}
+
+void MorkMappingStrategy::execute_task(const MappingTask& task) {
+    RAISE_ERROR("MorkMappingStrategy::execute_task() not implemented yet");
+    return;
+}

--- a/src/db_adapter/non_sql/mork/MorkMappingStrategy.h
+++ b/src/db_adapter/non_sql/mork/MorkMappingStrategy.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "BoundedSharedQueue.h"
+#include "DatabaseMappingStrategy.h"
+#include "DatabaseTypes.h"
+#include "JsonConfig.h"
+#include "MorkConnection.h"
+#include "MorkWrapper.h"
+
+using namespace std;
+using namespace commons;
+
+namespace db_adapter {
+
+class MorkMappingStrategy : public DatabaseMappingStrategy {
+   public:
+    MorkMappingStrategy(const JsonConfig& config,
+                        shared_ptr<MorkConnection> conn,
+                        shared_ptr<BoundedSharedQueue> queue);
+    vector<MappingTask> create_tasks() override;
+    void execute_task(const MappingTask& task) override;
+
+   private:
+    const JsonConfig& config;
+    shared_ptr<MorkWrapper> wrapper;
+};
+
+}  // namespace db_adapter

--- a/src/db_adapter/non_sql/mork/MorkWrapper.cc
+++ b/src/db_adapter/non_sql/mork/MorkWrapper.cc
@@ -1,0 +1,29 @@
+#include "MorkWrapper.h"
+
+#include "MapperFactory.h"
+#include "MorkConnection.h"
+#include "Utils.h"
+
+#define LOG_LEVEL INFO_LEVEL
+#include "Logger.h"
+
+using namespace std;
+using namespace db_adapter;
+
+// ==============================
+//  Construction / destruction
+// ==============================
+
+MorkWrapper::MorkWrapper(MorkConnection& conn,
+                         shared_ptr<BoundedSharedQueue> output_queue,
+                         MAPPER_TYPE mapper_type)
+    : DatabaseWrapper(conn, MapperFactory::create(mapper_type)), conn(conn), output_queue(output_queue) {
+    RAISE_ERROR("MorkWrapper constructor not implemented yet");
+}
+
+MorkWrapper::~MorkWrapper() {}
+
+void MorkWrapper::map(const string& metta_query) {
+    RAISE_ERROR("MorkWrapper::map() not implemented yet");
+    return;
+}

--- a/src/db_adapter/non_sql/mork/MorkWrapper.h
+++ b/src/db_adapter/non_sql/mork/MorkWrapper.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "BoundedSharedQueue.h"
+#include "DatabaseTypes.h"
+#include "DatabaseWrapper.h"
+#include "MorkConnection.h"
+
+using namespace std;
+
+namespace db_adapter {
+
+class MorkWrapper : public DatabaseWrapper {
+   public:
+    MorkWrapper(MorkConnection& conn,
+                shared_ptr<BoundedSharedQueue> output_queue,
+                MAPPER_TYPE mapper_type = MAPPER_TYPE::METTA2ATOMS);
+    ~MorkWrapper();
+
+    void map(const string& metta_query);
+
+   private:
+    MorkConnection& conn;
+    shared_ptr<BoundedSharedQueue> output_queue;
+};
+
+}  // namespace db_adapter


### PR DESCRIPTION
- Extend AdapterDbType to include Mork.
- Update AdapterDB initialization to support Mork.
- Refactor ContextLoader methods and rename for clarity.
- Implement MorkConnection and MorkWrapper classes.
- Add MorkMappingStrategy for future mapping tasks.
- Update DatabaseWrapper to create Metta2AtomsMapper.
- Create BUILD files for Mork integration.