### PR TITLE
[#1131] Print stack trace in RAISE_ERROR when LOG_LEVEL is >= DEBUG_LEVEL

### DIFF
--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -21,6 +21,9 @@
 using namespace commons;
 using namespace std;
 
+mutex StackTrace::api_mutex;
+map<pid_t, stack<StackTrace::StackRecord>> StackTrace::stack_trace;
+
 // --------------------------------------------------------------------------------
 // Public methods
 

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -59,9 +59,8 @@ class StackTrace {
         string file;
         string function;
         int line;
-        string message;
         string to_string() {
-            return file + "#L" + std::to_string(line) + " " + function + " " + message;
+            return file + "#L" + std::to_string(line) + " " + function;
         }
     };
     static void push(StackRecord& record) {
@@ -83,14 +82,12 @@ class StackTrace {
     }
     static mutex api_mutex;
     static map<pid_t, stack<StackRecord>> stack_trace;
-
-   public:
-    StackTrace(const string& file, const string& function, int line, const string& message) {
+    public:
+    StackTrace(const string& file, const string& function, int line) {
         StackRecord record;
         record.file = file;
         record.function = function;
         record.line = line;
-        record.message = message;
         StackTrace::push(record);
     }
     ~StackTrace() { StackTrace::pop(); }
@@ -176,9 +173,10 @@ class Utils {
 
 #ifdef LOG_LEVEL
 #if LOG_LEVEL >= DEBUG_LEVEL
-#define STACK_TRACE(msg) StackTrace scope_variable(__FILE__, __FUNCTION__, __LINE__, msg);
+#define STACK_TRACE() StackTrace scope_variable(__FILE__, __FUNCTION__, __LINE__);
 #else
-#define STACK_TRACE(msg)
+#define STACK_TRACE()
 #endif
 #endif
+
 #endif  // _COMMONS_UTILS_H

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -59,9 +59,7 @@ class StackTrace {
         string file;
         string function;
         int line;
-        string to_string() {
-            return file + "#L" + std::to_string(line) + " " + function;
-        }
+        string to_string() { return file + "#L" + std::to_string(line) + " " + function; }
     };
     static void push(StackRecord& record) {
         lock_guard<mutex> semaphore(api_mutex);
@@ -82,7 +80,8 @@ class StackTrace {
     }
     static mutex api_mutex;
     static map<pid_t, stack<StackRecord>> stack_trace;
-    public:
+
+   public:
     StackTrace(const string& file, const string& function, int line) {
         StackRecord record;
         record.file = file;

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -1,11 +1,15 @@
 #ifndef _COMMONS_UTILS_H
 #define _COMMONS_UTILS_H
 
+#include <unistd.h>
+#include <sys/types.h>
 #include <chrono>
 #include <functional>
 #include <map>
 #include <string>
 #include <vector>
+#include <stack>
+#include <mutex>
 
 #include "Logger.h"
 
@@ -45,6 +49,68 @@ class MemoryFootprint {
     unsigned long last_snapshot;
     unsigned long final_snapshot;
     vector<pair<long, string>> delta_ram;
+};
+
+class StackTrace {
+    private:
+    class StackRecord {
+        public:
+        string file;
+        string function;
+        int line;
+        string message;
+        string to_string() {
+            return file + "#L" + std::to_string(line) + " " + function + " " + message;
+        }
+    };
+    static void push(StackRecord& record) {
+        lock_guard<mutex> semaphore(api_mutex);
+        pid_t tid = gettid();
+        if (stack_trace.find(tid) == stack_trace.end()) {
+            stack_trace[tid] = stack<StackRecord>();
+        }
+        stack_trace[tid].push(record);
+    }
+    static void pop() {
+        lock_guard<mutex> semaphore(api_mutex);
+        pid_t tid = gettid();
+        if (stack_trace.find(tid) == stack_trace.end()) {
+            LOG_ERROR("Invalid attempt to unstack a record from a non-existent stack trace");
+            return;
+        }
+        stack_trace[tid].pop();
+    }
+    static mutex api_mutex;
+    static map<pid_t, stack<StackRecord>> stack_trace;
+    public:
+    StackTrace(const string& file, const string& function, int line, const string& message) {
+        StackRecord record;
+        record.file = file;
+        record.function = function;
+        record.line = line;
+        record.message = message;
+        StackTrace::push(record);
+    }
+    ~StackTrace() {
+        StackTrace::pop();
+    }
+    static string to_string() {
+        lock_guard<mutex> semaphore(api_mutex);
+        string answer = "";
+        if (stack_trace.size() > 0) {
+            answer += "\n-------------------- Stack trace --------------------\n";
+            for (auto pair : stack_trace) {
+                answer += "Thread tid: " + std::to_string((unsigned int) pair.first) + "\n";
+                stack<StackRecord> stack_copy = pair.second;
+                while (! stack_copy.empty()) {
+                    answer += "  " + stack_copy.top().to_string() + "\n";
+                    stack_copy.pop();
+                }
+            }
+            answer += "-----------------------------------------------------\n";
+        }
+        return answer;
+    }
 };
 
 class Utils {
@@ -102,10 +168,18 @@ class Utils {
 
 }  // namespace commons
 
-#define RAISE_ERROR(msg)                \
-    {                                   \
-        LOG_ERROR(msg);                 \
-        Utils::error(msg, true, false); \
+#define RAISE_ERROR(msg)                                 \
+    {                                                    \
+        LOG_ERROR(string(msg) + StackTrace::to_string()); \
+        Utils::error(msg, true, false);                  \
     }
 
+#ifdef LOG_LEVEL
+#if LOG_LEVEL >= DEBUG_LEVEL
+#define STACK_TRACE(msg)                                                  \
+    StackTrace scope_variable(__FILE__, __FUNCTION__, __LINE__, msg);
+#else
+#define STACK_TRACE(msg)
+#endif
+#endif
 #endif  // _COMMONS_UTILS_H

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -1,15 +1,16 @@
 #ifndef _COMMONS_UTILS_H
 #define _COMMONS_UTILS_H
 
-#include <unistd.h>
 #include <sys/types.h>
+#include <unistd.h>
+
 #include <chrono>
 #include <functional>
 #include <map>
+#include <mutex>
+#include <stack>
 #include <string>
 #include <vector>
-#include <stack>
-#include <mutex>
 
 #include "Logger.h"
 
@@ -52,9 +53,9 @@ class MemoryFootprint {
 };
 
 class StackTrace {
-    private:
+   private:
     class StackRecord {
-        public:
+       public:
         string file;
         string function;
         int line;
@@ -82,7 +83,8 @@ class StackTrace {
     }
     static mutex api_mutex;
     static map<pid_t, stack<StackRecord>> stack_trace;
-    public:
+
+   public:
     StackTrace(const string& file, const string& function, int line, const string& message) {
         StackRecord record;
         record.file = file;
@@ -91,9 +93,7 @@ class StackTrace {
         record.message = message;
         StackTrace::push(record);
     }
-    ~StackTrace() {
-        StackTrace::pop();
-    }
+    ~StackTrace() { StackTrace::pop(); }
     static string to_string() {
         lock_guard<mutex> semaphore(api_mutex);
         string answer = "";
@@ -102,7 +102,7 @@ class StackTrace {
             for (auto pair : stack_trace) {
                 answer += "Thread tid: " + std::to_string((unsigned int) pair.first) + "\n";
                 stack<StackRecord> stack_copy = pair.second;
-                while (! stack_copy.empty()) {
+                while (!stack_copy.empty()) {
                     answer += "  " + stack_copy.top().to_string() + "\n";
                     stack_copy.pop();
                 }
@@ -168,16 +168,15 @@ class Utils {
 
 }  // namespace commons
 
-#define RAISE_ERROR(msg)                                 \
-    {                                                    \
+#define RAISE_ERROR(msg)                                  \
+    {                                                     \
         LOG_ERROR(string(msg) + StackTrace::to_string()); \
-        Utils::error(msg, true, false);                  \
+        Utils::error(msg, true, false);                   \
     }
 
 #ifdef LOG_LEVEL
 #if LOG_LEVEL >= DEBUG_LEVEL
-#define STACK_TRACE(msg)                                                  \
-    StackTrace scope_variable(__FILE__, __FUNCTION__, __LINE__, msg);
+#define STACK_TRACE(msg) StackTrace scope_variable(__FILE__, __FUNCTION__, __LINE__, msg);
 #else
 #define STACK_TRACE(msg)
 #endif

--- a/src/tests/cpp/utils_test.cc
+++ b/src/tests/cpp/utils_test.cc
@@ -1,3 +1,4 @@
+#define LOG_LEVEL DEBUG_LEVEL
 #include "Utils.h"
 
 #include <gtest/gtest.h>
@@ -10,6 +11,24 @@
 
 using namespace std;
 using namespace commons;
+
+void f1() {
+    STACK_TRACE("f1() scope");
+    RAISE_ERROR("Error on f1()");
+    return;
+}
+
+void f2() {
+    STACK_TRACE("");
+    f1();
+    return;
+}
+
+void f3() {
+    STACK_TRACE("f3() scope");
+    f2();
+    return;
+}
 
 TEST(UtilsTest, read_and_split) {
     string fname = "UtilsTest_read_and_aplit.txt";
@@ -52,4 +71,12 @@ TEST(UtilsTest, read_and_split) {
     line.push_back("blah");
     EXPECT_FALSE(Utils::read_and_split(line, file));
     EXPECT_EQ(line, vector<string>({"blah"}));
+}
+
+TEST(UtilsTest, stack_trace) {
+    STACK_TRACE("UtilsTest::stack_trace()");
+    EXPECT_THROW(RAISE_ERROR("Error on toplevel"), runtime_error);
+    EXPECT_THROW(f3(), runtime_error);
+    EXPECT_THROW(f2(), runtime_error);
+    EXPECT_THROW(f1(), runtime_error);
 }

--- a/src/tests/cpp/utils_test.cc
+++ b/src/tests/cpp/utils_test.cc
@@ -13,19 +13,19 @@ using namespace std;
 using namespace commons;
 
 void f1() {
-    STACK_TRACE("f1() scope");
-    RAISE_ERROR("Error on f1()");
+    STACK_TRACE();
+    RAISE_ERROR("Error in f1()");
     return;
 }
 
 void f2() {
-    STACK_TRACE("");
+    STACK_TRACE();
     f1();
     return;
 }
 
 void f3() {
-    STACK_TRACE("f3() scope");
+    STACK_TRACE();
     f2();
     return;
 }
@@ -74,7 +74,7 @@ TEST(UtilsTest, read_and_split) {
 }
 
 TEST(UtilsTest, stack_trace) {
-    STACK_TRACE("UtilsTest::stack_trace()");
+    STACK_TRACE();
     EXPECT_THROW(RAISE_ERROR("Error on toplevel"), runtime_error);
     EXPECT_THROW(f3(), runtime_error);
     EXPECT_THROW(f2(), runtime_error);


### PR DESCRIPTION
Resolves #1131 

Overhead of keeping the stack trace is paid only when LOG_LEVEL >= DEBUG_LEVEL
See in `TEST(UtilsTest, stack_trace)` in `utils_test.cc` for examples on how to use it. basically:

```
void f1() {
    STACK_TRACE();
    RAISE_ERROR("Error in f1()");
    return;
}

void f2() {
    STACK_TRACE();
    f1();
    return;
}

void f3() {
    STACK_TRACE();
    f2();
    return;
}

STACK_TRACE();
f3();
```

will print something like:

```
2026-06-01 19:05:51 | [ERROR] | tests/cpp/utils_test.cc | f1 : 17 | Error on f1()
-------------------- Stack trace --------------------
Thread tid: 502
  tests/cpp/utils_test.cc#L16 f1
  tests/cpp/utils_test.cc#L22 f2 
  tests/cpp/utils_test.cc#L28 f3
  tests/cpp/utils_test.cc#L77 TestBody
-----------------------------------------------------
```

Note that different threads will have their own stack traces, printed separately.