### PR TITLE
[Fix] `db-loader` and `QueryAnswer::read_metta_expression()`

### DIFF
--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -214,40 +214,42 @@ static inline void read_token(const char* token_string,
     cursor++;
 }
 
-static inline string read_metta_expression(const char* token_string, unsigned int& cursor) {
+static inline string read_paren_metta_expression(const char* token_string, unsigned int& cursor) {
     unsigned int start = cursor;
-    if (token_string[start] == '(') {
-        unsigned int unmatched = 1;
-        bool in_string = false;
-        bool escape = false;
-        while (unmatched > 0) {
-            cursor++;
-            if (token_string[cursor] == '\0') {
-                RAISE_ERROR("Invalid metta expression string: <" + string(token_string) +
-                            "> at cursor: " + std::to_string(cursor));
-            }
-            char c = token_string[cursor];
-            if (in_string) {
-                if (escape) {
-                    escape = false;
-                } else if (c == '\\') {
-                    escape = true;
-                } else if (c == '"') {
-                    in_string = false;
-                }
-            } else if (c == '"') {
-                in_string = true;
-            } else if (c == '(') {
-                unmatched++;
-            } else if (c == ')') {
-                unmatched--;
-            }
-        }
+    unsigned int unmatched = 1;
+    bool in_string = false;
+    bool escape = false;
+    while (unmatched > 0) {
         cursor++;
-        unsigned int end = cursor++;
-        return string(token_string + start, token_string + end);
+        if (token_string[cursor] == '\0') {
+            RAISE_ERROR("Invalid metta expression string: <" + string(token_string) +
+                        "> at cursor: " + std::to_string(cursor));
+        }
+        char c = token_string[cursor];
+        if (in_string) {
+            if (escape) {
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+        } else if (c == '"') {
+            in_string = true;
+        } else if (c == '(') {
+            unmatched++;
+        } else if (c == ')') {
+            unmatched--;
+        }
     }
+    cursor++;
+    unsigned int end = cursor++;
+    return string(token_string + start, token_string + end);
+}
 
+static inline string read_quoted_or_atom_metta_expression(const char* token_string,
+                                                          unsigned int& cursor) {
+    unsigned int start = cursor;
     unsigned int unmatched = 1;
     char open_char;
     char close_char;
@@ -274,6 +276,13 @@ static inline string read_metta_expression(const char* token_string, unsigned in
     }
     unsigned int end = cursor++;
     return string(token_string + start, token_string + end);
+}
+
+static inline string read_metta_expression(const char* token_string, unsigned int& cursor) {
+    if (token_string[cursor] == '(') {
+        return read_paren_metta_expression(token_string, cursor);
+    }
+    return read_quoted_or_atom_metta_expression(token_string, cursor);
 }
 
 void QueryAnswer::untokenize(const string& tokens) {

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -157,6 +157,10 @@ const string& QueryAnswer::tokenize() {
         char_count += 4;  // (up to 3 digits) to represent this->handles[i].size() + space
         char_count += vector.size() * (HANDLE_HASH_SIZE + 1);  // handles[i] + spaces
     }
+    for (auto pair : this->metta_expression) {
+        char_count += HANDLE_HASH_SIZE + 1;    // handle + space
+        char_count += pair.second.size() + 1;  // MeTTa expression + space
+    }
 
     this->token_representation.clear();
     this->token_representation.reserve(char_count);
@@ -212,13 +216,42 @@ static inline void read_token(const char* token_string,
 
 static inline string read_metta_expression(const char* token_string, unsigned int& cursor) {
     unsigned int start = cursor;
+    if (token_string[start] == '(') {
+        unsigned int unmatched = 1;
+        bool in_string = false;
+        bool escape = false;
+        while (unmatched > 0) {
+            cursor++;
+            if (token_string[cursor] == '\0') {
+                RAISE_ERROR("Invalid metta expression string: <" + string(token_string) +
+                            "> at cursor: " + std::to_string(cursor));
+            }
+            char c = token_string[cursor];
+            if (in_string) {
+                if (escape) {
+                    escape = false;
+                } else if (c == '\\') {
+                    escape = true;
+                } else if (c == '"') {
+                    in_string = false;
+                }
+            } else if (c == '"') {
+                in_string = true;
+            } else if (c == '(') {
+                unmatched++;
+            } else if (c == ')') {
+                unmatched--;
+            }
+        }
+        cursor++;
+        unsigned int end = cursor++;
+        return string(token_string + start, token_string + end);
+    }
+
     unsigned int unmatched = 1;
     char open_char;
     char close_char;
-    if (token_string[start] == '(') {
-        open_char = '(';
-        close_char = ')';
-    } else if (token_string[start] == '\"') {
+    if (token_string[start] == '\"') {
         open_char = '\"';
         close_char = '\"';
     } else {
@@ -229,7 +262,7 @@ static inline string read_metta_expression(const char* token_string, unsigned in
         cursor++;
         if (token_string[cursor] == '\0') {
             RAISE_ERROR("Invalid metta expression string: <" + string(token_string) +
-                        "> Cursor :" + to_string(cursor));
+                        "> at cursor:" + to_string(cursor));
         } else if ((token_string[cursor] == close_char) && (token_string[cursor - 1] != '\\')) {
             unmatched--;
         } else if ((token_string[cursor] == open_char) && (token_string[cursor - 1] != '\\')) {
@@ -240,8 +273,7 @@ static inline string read_metta_expression(const char* token_string, unsigned in
         cursor++;
     }
     unsigned int end = cursor++;
-    string answer(token_string + start, token_string + end);
-    return answer;
+    return string(token_string + start, token_string + end);
 }
 
 void QueryAnswer::untokenize(const string& tokens) {

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -1,3 +1,4 @@
+#define LOG_LEVEL INFO_LEVEL
 #include "MorkDB.h"
 
 #include <algorithm>
@@ -9,13 +10,11 @@
 
 #include "HandleDecoder.h"
 #include "Hasher.h"
+#include "Logger.h"
 #include "MettaMapping.h"
 #include "MettaParser.h"
 #include "MettaParserActions.h"
 #include "Utils.h"
-
-#define LOG_LEVEL INFO_LEVEL
-#include "Logger.h"
 
 using namespace atomdb;
 using namespace atoms;

--- a/src/main/db_loader.cc
+++ b/src/main/db_loader.cc
@@ -40,15 +40,6 @@ static string flag_from_argv_or(int argc,
     return default_value;
 }
 
-static bool has_flag(int argc, char* argv[], const string& flag) {
-    for (int i = 1; i < argc; i++) {
-        if (string(argv[i]).rfind(flag, 0) == 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void ctrl_c_handler(int) {
     cout << "Stopping db_loader..." << endl;
     cout << "Done." << endl;
@@ -120,8 +111,12 @@ int main(int argc, char* argv[]) {
             return 0;
         }
 
-        size_t lines_per_thread = lines.size() / num_threads;
-        size_t remainder = lines.size() % num_threads;
+        if (static_cast<size_t>(num_threads) > lines.size()) {
+            num_threads = static_cast<int>(lines.size());
+        }
+
+        size_t lines_per_thread = lines.size() / static_cast<size_t>(num_threads);
+        size_t remainder = lines.size() % static_cast<size_t>(num_threads);
 
         LOG_INFO("Processing " + to_string(lines.size()) + " lines with " + to_string(num_threads) +
                  " threads (chunk size: " + to_string(chunk_size) + " | lines per thread: " +
@@ -168,7 +163,11 @@ int main(int argc, char* argv[]) {
 
                             auto atom = pair.second.get();
                             if (atom->arity() > 0) {
-                                atom->custom_attributes["metta_expression"] = metta_expr;
+                                auto metta_it =
+                                    parser_actions->handle_to_metta_expression.find(pair.first);
+                                if (metta_it != parser_actions->handle_to_metta_expression.end()) {
+                                    atom->custom_attributes["metta_expression"] = metta_it->second;
+                                }
                             }
                             batch_atoms.push_back(atom);
                             thread_atoms_count++;
@@ -193,8 +192,13 @@ int main(int argc, char* argv[]) {
                 }
 
                 total_atoms_processed += thread_atoms_count;
-                LOG_INFO("Thread " + to_string(i) + " processed " + to_string(thread_atoms_count) +
-                         " atoms (lines " + to_string(start_line) + "-" + to_string(end_line - 1) + ")");
+                if (start_line >= end_line) {
+                    LOG_INFO("Thread " + to_string(i) + " processed 0 atoms (no lines assigned)");
+                } else {
+                    LOG_INFO("Thread " + to_string(i) + " processed " + to_string(thread_atoms_count) +
+                             " atoms (lines " + to_string(start_line) + "-" + to_string(end_line - 1) +
+                             ")");
+                }
             });
         }
 

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -360,12 +360,12 @@ TEST(QueryAnswer, metta_expression_tokenization_with_quoted_parens) {
     input.assignment.assign("P", pred_handle);
     input.assignment.assign("C", concept_handle);
 
-    string value_expr =
-        "\"[VERTEBRAL HYPERSEGMENTATION AND OROFACIAL ANOMALIES; VHO](https://omim.org/entry/20781)\"";
-    string inner_expr = "(public.humanhealthprop " + value_expr + ")";
-    string pred_expr =
-        "(Predicate (public.humanhealthprop public.humanhealthprop.value " + value_expr + "))";
-    string concept_expr = "(Concept (public.humanhealthprop \"20781\"))";
+    static const char* value_content = "Symbol (open1 (open2 test close2) no_close1";
+
+    string value_expr = string("\"") + value_content + "\"";
+    string inner_expr = "(public.humanhealthprop public.humanhealthprop.value " + value_expr + ")";
+    string pred_expr = "(Predicate " + inner_expr + ")";
+    string concept_expr = "(Concept (public.humanhealthprop \"1287\"))";
     string eval_expr = "(Evaluation " + pred_expr + " " + concept_expr + ")";
 
     input.metta_expression[eval_handle] = eval_expr;

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -355,10 +355,12 @@ TEST(QueryAnswer, metta_expression_tokenization_with_quoted_parens) {
     string concept_handle = random_handle();
     string value_handle = random_handle();
     string inner_handle = random_handle();
+    string s1_handle = random_handle();
 
     input.add_handle(eval_handle);
     input.assignment.assign("P", pred_handle);
     input.assignment.assign("C", concept_handle);
+    input.assignment.assign("S1", s1_handle);
 
     static const char* value_content =
         R"VAL(Dmel\@Pink1@ (These experiments @Pink1[Scer\UAS.cYa]@ and UAS-RNAi allele @Pink1[dsRNA.Scer\UAS]@.)VAL";
@@ -368,12 +370,14 @@ TEST(QueryAnswer, metta_expression_tokenization_with_quoted_parens) {
     string pred_expr = "(Predicate " + inner_expr + ")";
     string concept_expr = "(Concept (public.humanhealthprop \"1287\"))";
     string eval_expr = "(Evaluation " + pred_expr + " " + concept_expr + ")";
+    string s1_expr = "(Concept xxx\(xxx)";
 
     input.metta_expression[eval_handle] = eval_expr;
     input.metta_expression[pred_handle] = pred_expr;
     input.metta_expression[concept_handle] = concept_expr;
     input.metta_expression[value_handle] = value_expr;
     input.metta_expression[inner_handle] = inner_expr;
+    input.metta_expression[s1_handle] = s1_expr;
 
     string token_string = input.tokenize();
     QueryAnswer output(0.0);

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -360,7 +360,8 @@ TEST(QueryAnswer, metta_expression_tokenization_with_quoted_parens) {
     input.assignment.assign("P", pred_handle);
     input.assignment.assign("C", concept_handle);
 
-    static const char* value_content = "Symbol (open1 (open2 test close2) no_close1";
+    static const char* value_content =
+        R"VAL(Dmel\@Pink1@ (These experiments @Pink1[Scer\UAS.cYa]@ and UAS-RNAi allele @Pink1[dsRNA.Scer\UAS]@.)VAL";
 
     string value_expr = string("\"") + value_content + "\"";
     string inner_expr = "(public.humanhealthprop public.humanhealthprop.value " + value_expr + ")";

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -348,6 +348,42 @@ void query_answers_equal(QueryAnswer* qa1, QueryAnswer* qa2) {
     EXPECT_EQ(qa1->to_string(), qa2->to_string());
 }
 
+TEST(QueryAnswer, metta_expression_tokenization_with_quoted_parens) {
+    QueryAnswer input(0.0);
+    string eval_handle = random_handle();
+    string pred_handle = random_handle();
+    string concept_handle = random_handle();
+    string value_handle = random_handle();
+    string inner_handle = random_handle();
+
+    input.add_handle(eval_handle);
+    input.assignment.assign("P", pred_handle);
+    input.assignment.assign("C", concept_handle);
+
+    string value_expr =
+        "\"[VERTEBRAL HYPERSEGMENTATION AND OROFACIAL ANOMALIES; VHO](https://omim.org/entry/20781)\"";
+    string inner_expr = "(public.humanhealthprop " + value_expr + ")";
+    string pred_expr =
+        "(Predicate (public.humanhealthprop public.humanhealthprop.value " + value_expr + "))";
+    string concept_expr = "(Concept (public.humanhealthprop \"20781\"))";
+    string eval_expr = "(Evaluation " + pred_expr + " " + concept_expr + ")";
+
+    input.metta_expression[eval_handle] = eval_expr;
+    input.metta_expression[pred_handle] = pred_expr;
+    input.metta_expression[concept_handle] = concept_expr;
+    input.metta_expression[value_handle] = value_expr;
+    input.metta_expression[inner_handle] = inner_expr;
+
+    string token_string = input.tokenize();
+    QueryAnswer output(0.0);
+    output.untokenize(token_string);
+
+    EXPECT_EQ(output.metta_expression.size(), input.metta_expression.size());
+    for (const auto& pair : input.metta_expression) {
+        EXPECT_EQ(output.metta_expression[pair.first], pair.second);
+    }
+}
+
 TEST(QueryAnswer, tokenization) {
     unsigned int NUM_TESTS = 100000;
     unsigned int MAX_PATHS = 5;

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -370,7 +370,7 @@ TEST(QueryAnswer, metta_expression_tokenization_with_quoted_parens) {
     string pred_expr = "(Predicate " + inner_expr + ")";
     string concept_expr = "(Concept (public.humanhealthprop \"1287\"))";
     string eval_expr = "(Evaluation " + pred_expr + " " + concept_expr + ")";
-    string s1_expr = "(Concept xxx\(xxx)";
+    string s1_expr = "(Concept \"xxx\(xxx)\"";
 
     input.metta_expression[eval_handle] = eval_expr;
     input.metta_expression[pred_handle] = pred_expr;

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -370,7 +370,7 @@ TEST(QueryAnswer, metta_expression_tokenization_with_quoted_parens) {
     string pred_expr = "(Predicate " + inner_expr + ")";
     string concept_expr = "(Concept (public.humanhealthprop \"1287\"))";
     string eval_expr = "(Evaluation " + pred_expr + " " + concept_expr + ")";
-    string s1_expr = "(Concept \"xxx\(xxx)\"";
+    string s1_expr = "(Concept \"xxx\(xxx\")";
 
     input.metta_expression[eval_handle] = eval_expr;
     input.metta_expression[pred_handle] = pred_expr;


### PR DESCRIPTION
## Summary

- Fix `db_loader` assigning the full input line as `metta_expression` on every parsed link, which caused duplicate entries in MORK when loading MeTTa files
- Fix `QueryAnswer` MeTTa expression parsing during tokenization/untokenization so parentheses inside quoted strings are handled correctly, preventing crashes on long literal values with embedded `(` and `)`
- Add regression coverage for MeTTa expression round-trip with quoted literals containing special characters

## Changes

### `db_loader`
- Set each link's `metta_expression` from `MettaParserActions::handle_to_metta_expression` instead of reusing the entire source line for all links
- Cap `--threads` to the number of non-empty lines when loading from file
- Improve per-thread logging for threads with no assigned lines (avoids invalid line-range output)
- Remove unused `has_flag()` helper

### `QueryAnswer`
- Split `read_metta_expression()` into two parsers dispatched by the first character:
  - `read_paren_metta_expression()` for `(`-delimited expressions
  - `read_quoted_or_atom_metta_expression()` for quoted strings and space-delimited atoms
- In `read_paren_metta_expression()`, track quoted-string boundaries (`in_string` / escape handling) so `)` inside `"..."` does not terminate parsing early
- Include `metta_expression` payload sizes in `tokenize()` buffer reservation to avoid undersized allocations for large expressions

### `MorkDB`
- Reorder `LOG_LEVEL` / `Logger.h` includes (no behavior change)

### Tests
- Add `metta_expression_tokenization_with_quoted_parens` in `query_answer_test.cc` using a realistic `humanhealthprop` Evaluation with a long quoted value containing `@`, `\`, brackets, and parentheses

## Test plan

- [ ] `make bazel 'test --cache_test_results=no //tests/cpp:query_answer_test'`
- [ ] `make bazel 'test --cache_test_results=no //tests/cpp:query_answer_test --test_filter=QueryAnswer.metta_expression_tokenization_with_quoted_parens'`
- Create the following metta file (save it at `/tmp/test.metta`):
```
(Test "test" "test with whitespace")
(Evaluation (Predicate (public.humanhealthprop public.humanhealthprop.value "[VERTEBRAL HYPERSEGMENTATION AND OROFACIAL ANOMALIES; VHO](https://omim.org/entry/619122)")) (Concept (public.humanhealthprop "20781")))
(public.humanhealthprop public.humanhealthprop.value "Autosomal dominant intellectual developmental disorder-75 (MRD75) is a neurodevelopmental disorder with highly variable severity and features. Affected individuals have developmental delay and most have mild to severely impaired intellectual development, often accompanied by neuropsychiatric disorders. Additional more variable features may include hypotonia, seizures, nonspecific dysmorphic features, poor overall growth with small head circumference, abnormal brain imaging, and heart disease (Calame et al., 2023; pubmed:37467750). [from MIM:620988; 2025.03.08]")
(public.humanhealthprop public.humanhealthprop.value "Using imaging of mitochondrial transport in motor neurons of third instar larvae, Dmel\@Pink1@ mutations were shown to affect both mitochondrial motility and mitochondrial length in motor neurons. (These experiments used an unspecified GAL4 allele, UAS allele @Pink1[Scer\UAS.cYa]@ and UAS-RNAi allele @Pink1[dsRNA.Scer\UAS]@.")
```
- [ ] Load a small MeTTa file via `make run-db-loader OPTIONS="--config=config/das.json --file=/tmp/test.metta"` and confirm MORK POST logs show distinct link expressions (no repeated top-level `Evaluation` lines per link)
- [ ] Run a query against loaded `humanhealthprop` data with `populate_metta_mapping: true` and verify answers deserialize without crashing
```
make run-client OPTIONS="--service=command-router --config=config/das.json --cmd=query --arg='(public.humanhealthprop public.humanhealthprop.value %P)'"
```
