### PR TITLE
[1/2] RemoteDB fixes and improvements

### DIFF
--- a/config/das.json
+++ b/config/das.json
@@ -77,20 +77,19 @@
         "remote_peers": [
             {
                 "uid": "peer1",
-                "type": "redismongodb",
+                "type": "morkdb",
                 "context": "",
+                "local_persistence": {
+                    "type": "inmemorydb",
+                    "context": "peer1_local_"
+                },
                 "mongodb": {
                     "endpoint": "localhost:40021",
                     "username": "admin",
                     "password": "admin"
                 },
-                "redis": {
-                    "endpoint": "localhost:40020",
-                    "cluster": false
-                },
-                "local_persistence": {
-                    "type": "inmemorydb",
-                    "context": "peer1_local_"
+                "morkdb": {
+                    "endpoint": "localhost:40022"
                 }
             },
             {

--- a/config/das.json
+++ b/config/das.json
@@ -1,6 +1,6 @@
 {
     "atomdb": {
-        "type": "redismongodb",
+        "type": "remotedb",
         "redis": {
             "image": "redis:7.2.3-alpine",
             "endpoint": "localhost:40020",
@@ -15,7 +15,7 @@
         },
         "mongodb": {
             "image": "mongodb/mongodb-community-server:8.2-ubuntu2204",
-            "endpoint": "localhost:40021",
+            "endpoint": "localhost:40031",
             "username": "admin",
             "password": "admin",
             "cluster": false,
@@ -72,13 +72,13 @@
         },
         "morkdb": {
             "image": "trueagi/das:mork-server-1.0.4",
-            "endpoint": "localhost:40022"
+            "endpoint": "localhost:40032"
         },
         "remote_peers": [
             {
                 "uid": "peer1",
                 "type": "redismongodb",
-                "context": "remotedb_test_peer1_",
+                "context": "",
                 "mongodb": {
                     "endpoint": "localhost:40021",
                     "username": "admin",
@@ -89,25 +89,25 @@
                     "cluster": false
                 },
                 "local_persistence": {
-                    "type": "morkdb",
-                    "context": "remotedb_test_peer1_local_",
-                    "mongodb": {
-                        "endpoint": "localhost:40021",
-                        "username": "admin",
-                        "password": "admin"
-                    },
-                    "morkdb": {
-                        "endpoint": "localhost:40022"
-                    }
+                    "type": "inmemorydb",
+                    "context": "peer1_local_"
                 }
             },
             {
                 "uid": "peer2",
-                "type": "inmemorydb",
-                "context": "remotedb_test_peer2_",
+                "type": "morkdb",
+                "context": "",
                 "local_persistence": {
                     "type": "inmemorydb",
-                    "context": "remotedb_test_peer2_local_"
+                    "context": "peer2_local_"
+                },
+                "mongodb": {
+                    "endpoint": "localhost:40031",
+                    "username": "admin",
+                    "password": "admin"
+                },
+                "morkdb": {
+                    "endpoint": "localhost:40032"
                 }
             }
         ]
@@ -133,8 +133,8 @@
                 "max_bundle_size": 1000,
                 "max_answers": 0,
                 "use_link_template_cache": false,
-                "populate_metta_mapping": false,
-                "use_metta_as_query_tokens": false,
+                "populate_metta_mapping": true,
+                "use_metta_as_query_tokens": true,
                 "allow_incomplete_chain_path": false
             }
         },

--- a/config/das.json
+++ b/config/das.json
@@ -1,6 +1,6 @@
 {
     "atomdb": {
-        "type": "remotedb",
+        "type": "redismongodb",
         "redis": {
             "image": "redis:7.2.3-alpine",
             "endpoint": "localhost:40020",
@@ -15,7 +15,7 @@
         },
         "mongodb": {
             "image": "mongodb/mongodb-community-server:8.2-ubuntu2204",
-            "endpoint": "localhost:40031",
+            "endpoint": "localhost:40021",
             "username": "admin",
             "password": "admin",
             "cluster": false,
@@ -72,41 +72,42 @@
         },
         "morkdb": {
             "image": "trueagi/das:mork-server-1.0.4",
-            "endpoint": "localhost:40032"
+            "endpoint": "localhost:40022"
         },
         "remote_peers": [
             {
                 "uid": "peer1",
-                "type": "morkdb",
-                "context": "",
-                "local_persistence": {
-                    "type": "inmemorydb",
-                    "context": "peer1_local_"
-                },
+                "type": "redismongodb",
+                "context": "remotedb_test_peer1_",
                 "mongodb": {
                     "endpoint": "localhost:40021",
                     "username": "admin",
                     "password": "admin"
                 },
-                "morkdb": {
-                    "endpoint": "localhost:40022"
+                "redis": {
+                    "endpoint": "localhost:40020",
+                    "cluster": false
+                },
+                "local_persistence": {
+                    "type": "morkdb",
+                    "context": "remotedb_test_peer1_local_",
+                    "mongodb": {
+                        "endpoint": "localhost:40021",
+                        "username": "admin",
+                        "password": "admin"
+                    },
+                    "morkdb": {
+                        "endpoint": "localhost:40022"
+                    }
                 }
             },
             {
                 "uid": "peer2",
-                "type": "morkdb",
-                "context": "",
+                "type": "inmemorydb",
+                "context": "remotedb_test_peer2_",
                 "local_persistence": {
                     "type": "inmemorydb",
-                    "context": "peer2_local_"
-                },
-                "mongodb": {
-                    "endpoint": "localhost:40031",
-                    "username": "admin",
-                    "password": "admin"
-                },
-                "morkdb": {
-                    "endpoint": "localhost:40032"
+                    "context": "remotedb_test_peer2_local_"
                 }
             }
         ]
@@ -132,8 +133,8 @@
                 "max_bundle_size": 1000,
                 "max_answers": 0,
                 "use_link_template_cache": false,
-                "populate_metta_mapping": true,
-                "use_metta_as_query_tokens": true,
+                "populate_metta_mapping": false,
+                "use_metta_as_query_tokens": false,
                 "allow_incomplete_chain_path": false
             }
         },

--- a/src/atomdb/AtomDBSingleton.cc
+++ b/src/atomdb/AtomDBSingleton.cc
@@ -26,7 +26,8 @@ void AtomDBSingleton::init(const JsonConfig& atomdb_config) {
         } else if (atomdb_type == "redismongodb") {
             AtomDBSingleton::atom_db = shared_ptr<AtomDB>(new RedisMongoDB("", false, atomdb_config));
         } else if (atomdb_type == "remotedb") {
-            AtomDBSingleton::atom_db = shared_ptr<AtomDB>(new RemoteAtomDB(atomdb_config));
+            auto remote_peers_config = atomdb_config.at_path("remote_peers").get_or<JsonConfig>(JsonConfig());
+            AtomDBSingleton::atom_db = shared_ptr<AtomDB>(new RemoteAtomDB(remote_peers_config));
         } else if (atomdb_type == "adapterdb") {
             AtomDBSingleton::atom_db = shared_ptr<AtomDB>(new AdapterDB(atomdb_config));
         } else {

--- a/src/atomdb/AtomDBSingleton.cc
+++ b/src/atomdb/AtomDBSingleton.cc
@@ -26,7 +26,8 @@ void AtomDBSingleton::init(const JsonConfig& atomdb_config) {
         } else if (atomdb_type == "redismongodb") {
             AtomDBSingleton::atom_db = shared_ptr<AtomDB>(new RedisMongoDB("", false, atomdb_config));
         } else if (atomdb_type == "remotedb") {
-            auto remote_peers_config = atomdb_config.at_path("remote_peers").get_or<JsonConfig>(JsonConfig());
+            auto remote_peers_config =
+                atomdb_config.at_path("remote_peers").get_or<JsonConfig>(JsonConfig());
             AtomDBSingleton::atom_db = shared_ptr<AtomDB>(new RemoteAtomDB(remote_peers_config));
         } else if (atomdb_type == "adapterdb") {
             AtomDBSingleton::atom_db = shared_ptr<AtomDB>(new AdapterDB(atomdb_config));

--- a/src/atomdb/inmemorydb/InMemoryDBAPITypes.cc
+++ b/src/atomdb/inmemorydb/InMemoryDBAPITypes.cc
@@ -59,22 +59,18 @@ void HandleSetInMemory::add_handle(const string& handle) { handles.insert(handle
 HandleSetInMemoryIterator::HandleSetInMemoryIterator(HandleSetInMemory* handle_set)
     : handle_set(handle_set), it(handle_set->handles.begin()) {}
 
-HandleSetInMemoryIterator::~HandleSetInMemoryIterator() {
-    for (auto ptr : allocated_strings) {
-        delete[] ptr;
-    }
-}
+HandleSetInMemoryIterator::~HandleSetInMemoryIterator() {}
 
 char* HandleSetInMemoryIterator::next() {
     if (it == handle_set->handles.end()) {
         return nullptr;
     }
-    string handle = *it;
+    // Return a pointer into the handle stored by the HandleSet (not the iterator), so that the
+    // returned char* stays valid for the lifetime of the HandleSet. Consumers (e.g. LinkTemplate)
+    // keep the char* around after the iterator is destroyed, mirroring HandleSetRedis semantics.
+    const char* handle_cstr = it->c_str();
     ++it;
-    char* handle_cstr = new char[handle.size() + 1];
-    strcpy(handle_cstr, handle.c_str());
-    allocated_strings.push_back(handle_cstr);
-    return handle_cstr;
+    return const_cast<char*>(handle_cstr);
 }
 
 // HandleListInMemory

--- a/src/atomdb/inmemorydb/InMemoryDBAPITypes.cc
+++ b/src/atomdb/inmemorydb/InMemoryDBAPITypes.cc
@@ -55,6 +55,16 @@ Assignment HandleSetInMemory::get_assignments_by_handle(const string& handle) {
 
 void HandleSetInMemory::add_handle(const string& handle) { handles.insert(handle); }
 
+void HandleSetInMemory::add_handle(const string& handle,
+                                   const map<string, string>& metta_expressions,
+                                   const Assignment& assignment) {
+    handles.insert(handle);
+    if (!metta_expressions.empty()) {
+        metta_expressions_by_handle[handle] = metta_expressions;
+    }
+    assignments_by_handle[handle] = assignment;
+}
+
 // HandleSetInMemoryIterator
 HandleSetInMemoryIterator::HandleSetInMemoryIterator(HandleSetInMemory* handle_set)
     : handle_set(handle_set), it(handle_set->handles.begin()) {}

--- a/src/atomdb/inmemorydb/InMemoryDBAPITypes.h
+++ b/src/atomdb/inmemorydb/InMemoryDBAPITypes.h
@@ -29,6 +29,11 @@ class HandleSetInMemory : public HandleSet {
     Assignment get_assignments_by_handle(const string& handle) override;
 
     void add_handle(const string& handle);
+    // Metadata-preserving overload used when federating nested-indexing backends (e.g. MorkDB),
+    // so per-handle assignments / metta expressions survive the merge into the aggregated result.
+    void add_handle(const string& handle,
+                    const map<string, string>& metta_expressions,
+                    const Assignment& assignment);
 
    private:
     set<string> handles;

--- a/src/atomdb/inmemorydb/InMemoryDBAPITypes.h
+++ b/src/atomdb/inmemorydb/InMemoryDBAPITypes.h
@@ -46,7 +46,6 @@ class HandleSetInMemoryIterator : public HandleSetIterator {
    private:
     HandleSetInMemory* handle_set;
     set<string>::iterator it;
-    vector<char*> allocated_strings;
 };
 
 class HandleListInMemory : public HandleList {

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -21,7 +21,6 @@ using namespace atomdb;
 using namespace commons;
 using namespace atoms;
 
-bool RedisMongoDB::SKIP_REDIS;
 string RedisMongoDB::REDIS_PATTERNS_PREFIX;
 string RedisMongoDB::REDIS_OUTGOING_PREFIX;
 string RedisMongoDB::REDIS_INCOMING_PREFIX;
@@ -33,8 +32,9 @@ string RedisMongoDB::MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME;
 string RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::size];
 uint RedisMongoDB::MONGODB_CHUNK_SIZE;
 
-RedisMongoDB::RedisMongoDB(const string& context, bool skip_redis, const JsonConfig& config) {
-    initialize_statics(context, skip_redis);
+RedisMongoDB::RedisMongoDB(const string& context, bool skip_redis, const JsonConfig& config)
+    : context(context), skip_redis_(skip_redis), cluster_flag(false) {
+    initialize_statics(context);
     mongodb_setup(config);
     load_pattern_index_schema();
     redis_setup(config);
@@ -44,13 +44,13 @@ RedisMongoDB::RedisMongoDB(const string& context, bool skip_redis, const JsonCon
 
 RedisMongoDB::~RedisMongoDB() {
     delete this->mongodb_pool;
-    if (!SKIP_REDIS) delete this->redis_pool;
+    if (!skip_redis_) delete this->redis_pool;
 }
 
 bool RedisMongoDB::allow_nested_indexing() { return false; }
 
 void RedisMongoDB::redis_setup(const JsonConfig& config) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     string address = config.at_path("redis.endpoint").get<string>();
     auto tokens = Utils::split(address, ':');
@@ -146,7 +146,7 @@ shared_ptr<Link> RedisMongoDB::get_link(const string& handle) {
 }
 
 shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(const LinkSchema& link_schema) {
-    if (SKIP_REDIS) return nullptr;
+    if (skip_redis_) return nullptr;
 
     auto pattern_handle = link_schema.handle();
 
@@ -187,7 +187,7 @@ shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_pattern(const Li
 }
 
 shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(const string& handle) {
-    if (SKIP_REDIS) return nullptr;
+    if (skip_redis_) return nullptr;
 
     redisReply* reply;
     try {
@@ -218,7 +218,7 @@ shared_ptr<atomdb_api_types::HandleList> RedisMongoDB::query_for_targets(const s
 }
 
 shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_incoming_set(const string& handle) {
-    if (SKIP_REDIS) return nullptr;
+    if (skip_redis_) return nullptr;
 
     unsigned int redis_cursor = 0;
     bool redis_has_more = true;
@@ -257,7 +257,7 @@ shared_ptr<atomdb_api_types::HandleSet> RedisMongoDB::query_for_incoming_set(con
 }
 
 void RedisMongoDB::add_pattern(const string& pattern_handle, const string& handle) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
     string command = "ZADD " + REDIS_PATTERNS_PREFIX + ":" + pattern_handle + " " +
@@ -273,7 +273,7 @@ void RedisMongoDB::add_pattern(const string& pattern_handle, const string& handl
 }
 
 void RedisMongoDB::add_patterns(const vector<pair<string, string>>& pattern_handles) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     if (pattern_handles.empty()) return;
 
@@ -308,7 +308,7 @@ void RedisMongoDB::add_patterns(const vector<pair<string, string>>& pattern_hand
 }
 
 void RedisMongoDB::delete_pattern(const string& handle) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
 
@@ -322,7 +322,7 @@ void RedisMongoDB::delete_pattern(const string& handle) {
 }
 
 void RedisMongoDB::update_pattern(const string& key, const string& value) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
     string command = "ZREM " + REDIS_PATTERNS_PREFIX + ":" + key + " " + value;
@@ -331,7 +331,7 @@ void RedisMongoDB::update_pattern(const string& key, const string& value) {
 }
 
 uint RedisMongoDB::get_next_score(const string& key) {
-    if (SKIP_REDIS) return 0;
+    if (skip_redis_) return 0;
 
     auto ctx = this->redis_pool->acquire();
     string command = "GET " + key;
@@ -350,7 +350,7 @@ uint RedisMongoDB::get_next_score(const string& key) {
 }
 
 void RedisMongoDB::set_next_score(const string& key, uint score) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
     auto ctx = this->redis_pool->acquire();
     set_next_score_with_context(ctx, key, score);
 }
@@ -358,7 +358,7 @@ void RedisMongoDB::set_next_score(const string& key, uint score) {
 void RedisMongoDB::set_next_score_with_context(shared_ptr<RedisContext> ctx,
                                                const string& key,
                                                uint score) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     string command = "SET " + key + " " + to_string(score);
     redisReply* reply = ctx->execute(command.c_str());
@@ -375,7 +375,7 @@ void RedisMongoDB::reset_scores() {
 }
 
 void RedisMongoDB::add_outgoing_set(const string& handle, const vector<string>& outgoing_handles) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
     string command = "SET " + REDIS_OUTGOING_PREFIX + ":" + handle + " ";
@@ -391,7 +391,7 @@ void RedisMongoDB::add_outgoing_set(const string& handle, const vector<string>& 
 }
 
 void RedisMongoDB::delete_outgoing_set(const string& handle) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
     string command = "DEL " + REDIS_OUTGOING_PREFIX + ":" + handle;
@@ -400,7 +400,7 @@ void RedisMongoDB::delete_outgoing_set(const string& handle) {
 }
 
 void RedisMongoDB::add_incoming_set(const string& handle, const string& incoming_handle) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
     string command = "ZADD " + REDIS_INCOMING_PREFIX + ":" + handle + " " +
@@ -416,7 +416,7 @@ void RedisMongoDB::add_incoming_set(const string& handle, const string& incoming
 }
 
 void RedisMongoDB::delete_incoming_set(const string& handle) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
 
@@ -430,7 +430,7 @@ void RedisMongoDB::delete_incoming_set(const string& handle) {
 }
 
 void RedisMongoDB::update_incoming_set(const string& key, const string& value) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
 
@@ -993,7 +993,7 @@ bool RedisMongoDB::delete_document(const string& handle,
     auto reply = mongodb_collection.delete_one(bsoncxx::v_noabi::builder::basic::make_document(
         bsoncxx::v_noabi::builder::basic::kvp(MONGODB_FIELD_NAME[MONGODB_FIELD::ID], handle)));
 
-    if (!SKIP_REDIS) {
+    if (!skip_redis_) {
         auto incoming_set = query_for_incoming_set(handle);
         auto it = incoming_set->get_iterator();
         char* incoming_handle;
@@ -1031,7 +1031,7 @@ bool RedisMongoDB::delete_link(const string& handle, bool delete_targets) {
         auto target_handle = link_document->get(MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS], i);
         // If target is referenced more than once, we need to update incoming_set or delete target
         // otherwise
-        if (!SKIP_REDIS && query_for_incoming_set(target_handle)->size() > 1) {
+        if (!skip_redis_ && query_for_incoming_set(target_handle)->size() > 1) {
             update_incoming_set(target_handle, handle);
         } else if (delete_targets) {
             delete_atom(target_handle, delete_targets);
@@ -1289,7 +1289,7 @@ void RedisMongoDB::re_index_patterns(bool flush_patterns) {
 }
 
 void RedisMongoDB::flush_redis_by_prefix(const string& prefix) {
-    if (SKIP_REDIS) return;
+    if (skip_redis_) return;
 
     auto ctx = this->redis_pool->acquire();
     std::string cursor = "0";
@@ -1324,7 +1324,7 @@ void RedisMongoDB::drop_all() {
     (*conn)[MONGODB_DB_NAME].drop();
 
     // Drop Redis database (by prefixes)
-    if (!SKIP_REDIS) {
+    if (!skip_redis_) {
         auto ctx = this->redis_pool->acquire();
         vector<string> keys = {REDIS_PATTERNS_PREFIX, REDIS_OUTGOING_PREFIX, REDIS_INCOMING_PREFIX};
         for (const auto& key : keys) {

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -33,7 +33,6 @@ class RedisMongoDB : public AtomDB {
 
     bool allow_nested_indexing() override;
 
-    static bool SKIP_REDIS;
     static string REDIS_PATTERNS_PREFIX;
     static string REDIS_OUTGOING_PREFIX;
     static string REDIS_INCOMING_PREFIX;
@@ -45,8 +44,7 @@ class RedisMongoDB : public AtomDB {
     static string MONGODB_FIELD_NAME[MONGODB_FIELD::size];
     static uint MONGODB_CHUNK_SIZE;
 
-    static void initialize_statics(const string& context = "", bool skip_redis = false) {
-        SKIP_REDIS = skip_redis;
+    static void initialize_statics(const string& context = "") {
         REDIS_PATTERNS_PREFIX = context + "patterns";
         REDIS_OUTGOING_PREFIX = context + "outgoing_set";
         REDIS_INCOMING_PREFIX = context + "incoming_set";
@@ -148,6 +146,7 @@ class RedisMongoDB : public AtomDB {
 
    private:
     string context;
+    bool skip_redis_;
     bool cluster_flag;
     RedisContextPool* redis_pool;
     mongocxx::pool* mongodb_pool;

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -52,15 +52,15 @@ RemoteAtomDB::RemoteAtomDB(const JsonConfig& peers_config) {
         auto peer_config = JsonConfig(entry);
         string uid = peer_config.at_path("uid").get_or<string>("");
         if (uid.empty()) continue;
+
+        shared_ptr<AtomDB> local_persistence = nullptr;
         auto local_persistence_config =
             peer_config.at_path("local_persistence").get_or<JsonConfig>(JsonConfig());
-        if (local_persistence_config.empty()) {
-            RAISE_ERROR("Missing local persistence configuration for peer " + uid);
+        if (!local_persistence_config.empty()) {
+            local_persistence = create_atomdb_from_config(local_persistence_config);
         }
-        remote_db_[uid] =
-            make_shared<RemoteAtomDBPeer>(create_atomdb_from_config(peer_config),
-                                          create_atomdb_from_config(local_persistence_config),
-                                          uid);
+        remote_db_[uid] = make_shared<RemoteAtomDBPeer>(
+            create_atomdb_from_config(peer_config), local_persistence, uid);
     }
 
     LOG_INFO("RemoteAtomDB initialized with " << remote_db_.size() << " remote peers");

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <sstream>
+#include <utility>
 
 #include "InMemoryDB.h"
 #include "InMemoryDBAPITypes.h"
@@ -64,7 +65,18 @@ RemoteAtomDB::RemoteAtomDB(const JsonConfig& peers_config) {
     }
 
     LOG_INFO("RemoteAtomDB initialized with " << remote_db_.size() << " remote peers");
+    derive_nested_indexing();
+}
 
+RemoteAtomDB::RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers)
+    : remote_db_(std::move(peers)) {
+    LOG_INFO("RemoteAtomDB initialized with " << remote_db_.size() << " pre-built peers");
+    derive_nested_indexing();
+}
+
+RemoteAtomDB::~RemoteAtomDB() = default;
+
+void RemoteAtomDB::derive_nested_indexing() {
     // Derive the aggregated nested-indexing capability from the peers. A single global boolean
     // cannot describe a heterogeneous result set, so mixed configurations are normalized to the
     // lowest common denominator (false: the query engine re-matches every handle locally).
@@ -86,8 +98,6 @@ RemoteAtomDB::RemoteAtomDB(const JsonConfig& peers_config) {
         }
     }
 }
-
-RemoteAtomDB::~RemoteAtomDB() = default;
 
 bool RemoteAtomDB::allow_nested_indexing() { return nested_indexing_; }
 
@@ -307,6 +317,7 @@ set<string> RemoteAtomDB::links_exist(const vector<string>& handles) {
 string RemoteAtomDB::add_atom(const atoms::Atom* atom, bool throw_if_exists) {
     string handle;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("add_atom(" << atom->handle() << ") to peer [" << uid << "]");
         handle = peer->add_atom(atom, throw_if_exists);
     }
     return handle;
@@ -315,6 +326,7 @@ string RemoteAtomDB::add_atom(const atoms::Atom* atom, bool throw_if_exists) {
 string RemoteAtomDB::add_node(const atoms::Node* node, bool throw_if_exists) {
     string handle;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("add_node(" << node->handle() << ") to peer [" << uid << "]");
         handle = peer->add_node(node, throw_if_exists);
     }
     return handle;
@@ -323,6 +335,7 @@ string RemoteAtomDB::add_node(const atoms::Node* node, bool throw_if_exists) {
 string RemoteAtomDB::add_link(const atoms::Link* link, bool throw_if_exists) {
     string handle;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("add_link(" << link->handle() << ") to peer [" << uid << "]");
         handle = peer->add_link(link, throw_if_exists);
     }
     return handle;
@@ -333,6 +346,7 @@ vector<string> RemoteAtomDB::add_atoms(const vector<atoms::Atom*>& atoms,
                                        bool is_transactional) {
     vector<string> handles;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("add_atoms(" << atoms.size() << ") to peer [" << uid << "]");
         handles = peer->add_atoms(atoms, throw_if_exists, is_transactional);
     }
     return handles;
@@ -343,6 +357,7 @@ vector<string> RemoteAtomDB::add_nodes(const vector<atoms::Node*>& nodes,
                                        bool is_transactional) {
     vector<string> handles;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("add_nodes(" << nodes.size() << ") to peer [" << uid << "]");
         handles = peer->add_nodes(nodes, throw_if_exists, is_transactional);
     }
     return handles;
@@ -353,6 +368,7 @@ vector<string> RemoteAtomDB::add_links(const vector<atoms::Link*>& links,
                                        bool is_transactional) {
     vector<string> handles;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("add_links(" << links.size() << ") to peer [" << uid << "]");
         handles = peer->add_links(links, throw_if_exists, is_transactional);
     }
     return handles;
@@ -361,6 +377,7 @@ vector<string> RemoteAtomDB::add_links(const vector<atoms::Link*>& links,
 bool RemoteAtomDB::delete_atom(const string& handle, bool delete_link_targets) {
     bool ok = true;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("delete_atom(" << handle << ") from peer [" << uid << "]");
         ok = peer->delete_atom(handle, delete_link_targets) && ok;
     }
     return ok;
@@ -369,6 +386,7 @@ bool RemoteAtomDB::delete_atom(const string& handle, bool delete_link_targets) {
 bool RemoteAtomDB::delete_node(const string& handle, bool delete_link_targets) {
     bool ok = true;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("delete_node(" << handle << ") from peer [" << uid << "]");
         ok = peer->delete_node(handle, delete_link_targets) && ok;
     }
     return ok;
@@ -377,6 +395,7 @@ bool RemoteAtomDB::delete_node(const string& handle, bool delete_link_targets) {
 bool RemoteAtomDB::delete_link(const string& handle, bool delete_link_targets) {
     bool ok = true;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("delete_link(" << handle << ") from peer [" << uid << "]");
         ok = peer->delete_link(handle, delete_link_targets) && ok;
     }
     return ok;
@@ -385,6 +404,7 @@ bool RemoteAtomDB::delete_link(const string& handle, bool delete_link_targets) {
 uint RemoteAtomDB::delete_atoms(const vector<string>& handles, bool delete_link_targets) {
     uint count = 0;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("delete_atoms(" << handles.size() << ") from peer [" << uid << "]");
         count = peer->delete_atoms(handles, delete_link_targets);
     }
     return count;
@@ -393,6 +413,7 @@ uint RemoteAtomDB::delete_atoms(const vector<string>& handles, bool delete_link_
 uint RemoteAtomDB::delete_nodes(const vector<string>& handles, bool delete_link_targets) {
     uint count = 0;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("delete_nodes(" << handles.size() << ") from peer [" << uid << "]");
         count = peer->delete_nodes(handles, delete_link_targets);
     }
     return count;
@@ -401,6 +422,7 @@ uint RemoteAtomDB::delete_nodes(const vector<string>& handles, bool delete_link_
 uint RemoteAtomDB::delete_links(const vector<string>& handles, bool delete_link_targets) {
     uint count = 0;
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("delete_links(" << handles.size() << ") from peer [" << uid << "]");
         count = peer->delete_links(handles, delete_link_targets);
     }
     return count;
@@ -408,6 +430,7 @@ uint RemoteAtomDB::delete_links(const vector<string>& handles, bool delete_link_
 
 void RemoteAtomDB::re_index_patterns(bool flush_patterns) {
     for (auto& [uid, peer] : remote_db_) {
+        LOG_DEBUG("re_index_patterns(" << flush_patterns << ") from peer [" << uid << "]");
         peer->re_index_patterns(flush_patterns);
     }
 }

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -1,6 +1,4 @@
 #define LOG_LEVEL DEBUG_LEVEL
-#include "Logger.h"
-
 #include "RemoteAtomDB.h"
 
 #include <fstream>
@@ -10,6 +8,7 @@
 
 #include "InMemoryDB.h"
 #include "InMemoryDBAPITypes.h"
+#include "Logger.h"
 #include "MorkDB.h"
 #include "RedisMongoDB.h"
 #include "Utils.h"
@@ -53,20 +52,44 @@ RemoteAtomDB::RemoteAtomDB(const JsonConfig& peers_config) {
         auto peer_config = JsonConfig(entry);
         string uid = peer_config.at_path("uid").get_or<string>("");
         if (uid.empty()) continue;
-        auto local_persistence_config = peer_config.at_path("local_persistence").get_or<JsonConfig>(JsonConfig());
+        auto local_persistence_config =
+            peer_config.at_path("local_persistence").get_or<JsonConfig>(JsonConfig());
         if (local_persistence_config.empty()) {
             RAISE_ERROR("Missing local persistence configuration for peer " + uid);
         }
         remote_db_[uid] =
-            make_shared<RemoteAtomDBPeer>( create_atomdb_from_config(peer_config), create_atomdb_from_config(local_persistence_config), uid);
+            make_shared<RemoteAtomDBPeer>(create_atomdb_from_config(peer_config),
+                                          create_atomdb_from_config(local_persistence_config),
+                                          uid);
     }
 
     LOG_INFO("RemoteAtomDB initialized with " << remote_db_.size() << " remote peers");
+
+    // Derive the aggregated nested-indexing capability from the peers. A single global boolean
+    // cannot describe a heterogeneous result set, so mixed configurations are normalized to the
+    // lowest common denominator (false: the query engine re-matches every handle locally).
+    unsigned int nested_peers = 0;
+    for (auto& [uid, peer] : remote_db_) {
+        if (peer->allow_nested_indexing()) nested_peers++;
+    }
+    if (!remote_db_.empty() && nested_peers == remote_db_.size()) {
+        nested_indexing_ = true;
+    } else {
+        nested_indexing_ = false;
+        if (nested_peers > 0) {
+            LOG_INFO(
+                "WARNING: RemoteAtomDB has a mix of nested-indexing and non-nested-indexing "
+                "peers ("
+                << nested_peers << "/" << remote_db_.size()
+                << " nested); downgrading allow_nested_indexing() to false. Nested peers will "
+                   "be re-matched locally by the query engine.");
+        }
+    }
 }
 
 RemoteAtomDB::~RemoteAtomDB() = default;
 
-bool RemoteAtomDB::allow_nested_indexing() { return false; }
+bool RemoteAtomDB::allow_nested_indexing() { return nested_indexing_; }
 
 shared_ptr<Atom> RemoteAtomDB::get_atom(const string& handle) {
     for (auto& [uid, peer] : remote_db_) {
@@ -117,6 +140,10 @@ shared_ptr<atomdb_api_types::HandleSet> RemoteAtomDB::query_for_pattern(const Li
         auto handle_set = peer->query_for_pattern(link_schema);
         if (!handle_set) continue;
 
+        // Preserve per-handle assignments / metta expressions for nested-indexing peers so the
+        // aggregated result stays faithful instead of silently dropping the backend's match data.
+        bool copy_metadata = peer->allow_nested_indexing();
+
         auto it = handle_set->get_iterator();
         if (!it) continue;
 
@@ -125,7 +152,13 @@ shared_ptr<atomdb_api_types::HandleSet> RemoteAtomDB::query_for_pattern(const Li
             if (!h) break;
             string handle(h);
             if (seen.insert(handle).second) {
-                result->add_handle(handle);
+                if (copy_metadata) {
+                    result->add_handle(handle,
+                                       handle_set->get_metta_expressions_by_handle(handle),
+                                       handle_set->get_assignments_by_handle(handle));
+                } else {
+                    result->add_handle(handle);
+                }
             }
         }
     }

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -1,3 +1,6 @@
+#define LOG_LEVEL DEBUG_LEVEL
+#include "Logger.h"
+
 #include "RemoteAtomDB.h"
 
 #include <fstream>
@@ -10,9 +13,6 @@
 #include "MorkDB.h"
 #include "RedisMongoDB.h"
 #include "Utils.h"
-
-#define LOG_LEVEL INFO_LEVEL
-#include "Logger.h"
 
 using namespace atomdb;
 using namespace atoms;
@@ -53,8 +53,12 @@ RemoteAtomDB::RemoteAtomDB(const JsonConfig& peers_config) {
         auto peer_config = JsonConfig(entry);
         string uid = peer_config.at_path("uid").get_or<string>("");
         if (uid.empty()) continue;
+        auto local_persistence_config = peer_config.at_path("local_persistence").get_or<JsonConfig>(JsonConfig());
+        if (local_persistence_config.empty()) {
+            RAISE_ERROR("Missing local persistence configuration for peer " + uid);
+        }
         remote_db_[uid] =
-            make_shared<RemoteAtomDBPeer>(create_atomdb_from_config(peer_config), nullptr, uid);
+            make_shared<RemoteAtomDBPeer>( create_atomdb_from_config(peer_config), create_atomdb_from_config(local_persistence_config), uid);
     }
 
     LOG_INFO("RemoteAtomDB initialized with " << remote_db_.size() << " remote peers");

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -92,26 +92,52 @@ RemoteAtomDB::~RemoteAtomDB() = default;
 bool RemoteAtomDB::allow_nested_indexing() { return nested_indexing_; }
 
 shared_ptr<Atom> RemoteAtomDB::get_atom(const string& handle) {
+    // Phase 1: probe every peer's in-memory cache first (no network). Silent: this is the hot path.
     for (auto& [uid, peer] : remote_db_) {
-        auto atom = peer->get_atom(handle);
+        auto atom = peer->get_cached_atom(handle);
         if (atom) return atom;
     }
+    // Phase 2: escalate to peers (local_persistence + remote backend) only when no cache has it.
+    for (auto& [uid, peer] : remote_db_) {
+        auto atom = peer->get_atom(handle);
+        if (atom) {
+            LOG_DEBUG("get_atom(" << handle << ") fetched from [" << uid << "]");
+            return atom;
+        }
+    }
+    LOG_DEBUG("get_atom(" << handle << ") not found in any peer");
     return nullptr;
 }
 
 shared_ptr<Node> RemoteAtomDB::get_node(const string& handle) {
     for (auto& [uid, peer] : remote_db_) {
-        auto node = peer->get_node(handle);
+        auto node = peer->get_cached_node(handle);
         if (node) return node;
     }
+    for (auto& [uid, peer] : remote_db_) {
+        auto node = peer->get_node(handle);
+        if (node) {
+            LOG_DEBUG("get_node(" << handle << ") fetched from [" << uid << "]");
+            return node;
+        }
+    }
+    LOG_DEBUG("get_node(" << handle << ") not found in any peer");
     return nullptr;
 }
 
 shared_ptr<Link> RemoteAtomDB::get_link(const string& handle) {
     for (auto& [uid, peer] : remote_db_) {
-        auto link = peer->get_link(handle);
+        auto link = peer->get_cached_link(handle);
         if (link) return link;
     }
+    for (auto& [uid, peer] : remote_db_) {
+        auto link = peer->get_link(handle);
+        if (link) {
+            LOG_DEBUG("get_link(" << handle << ") fetched from [" << uid << "]");
+            return link;
+        }
+    }
+    LOG_DEBUG("get_link(" << handle << ") not found in any peer");
     return nullptr;
 }
 
@@ -136,6 +162,8 @@ shared_ptr<atomdb_api_types::HandleSet> RemoteAtomDB::query_for_pattern(const Li
     auto result = make_shared<atomdb_api_types::HandleSetInMemory>();
     set<string> seen;
 
+    LOG_DEBUG("query_for_pattern(" << link_schema.handle() << ") fan-out to " << remote_db_.size()
+                                   << " peers");
     for (auto& [uid, peer] : remote_db_) {
         auto handle_set = peer->query_for_pattern(link_schema);
         if (!handle_set) continue;
@@ -143,6 +171,8 @@ shared_ptr<atomdb_api_types::HandleSet> RemoteAtomDB::query_for_pattern(const Li
         // Preserve per-handle assignments / metta expressions for nested-indexing peers so the
         // aggregated result stays faithful instead of silently dropping the backend's match data.
         bool copy_metadata = peer->allow_nested_indexing();
+        LOG_DEBUG("  [" << uid << "] returned " << handle_set->size() << " handles"
+                        << (copy_metadata ? " (with metadata)" : ""));
 
         auto it = handle_set->get_iterator();
         if (!it) continue;
@@ -162,14 +192,20 @@ shared_ptr<atomdb_api_types::HandleSet> RemoteAtomDB::query_for_pattern(const Li
             }
         }
     }
+    LOG_DEBUG("query_for_pattern(" << link_schema.handle() << ") aggregated " << result->size()
+                                   << " unique handles");
     return result;
 }
 
 shared_ptr<atomdb_api_types::HandleList> RemoteAtomDB::query_for_targets(const string& handle) {
     for (auto& [uid, peer] : remote_db_) {
         auto list = peer->query_for_targets(handle);
-        if (list) return list;
+        if (list) {
+            LOG_DEBUG("query_for_targets(" << handle << ") served by peer [" << uid << "]");
+            return list;
+        }
     }
+    LOG_DEBUG("query_for_targets(" << handle << ") not found in any peer");
     return nullptr;
 }
 
@@ -177,6 +213,7 @@ shared_ptr<atomdb_api_types::HandleSet> RemoteAtomDB::query_for_incoming_set(con
     auto result = make_shared<atomdb_api_types::HandleSetInMemory>();
     set<string> seen;
 
+    LOG_DEBUG("query_for_incoming_set(" << handle << ") fan-out to " << remote_db_.size() << " peers");
     for (auto& [uid, peer] : remote_db_) {
         auto handle_set = peer->query_for_incoming_set(handle);
         if (!handle_set) continue;
@@ -187,12 +224,14 @@ shared_ptr<atomdb_api_types::HandleSet> RemoteAtomDB::query_for_incoming_set(con
         while (true) {
             char* h = it->next();
             if (!h) break;
-            string handle(h);
-            if (seen.insert(handle).second) {
-                result->add_handle(handle);
+            string member(h);
+            if (seen.insert(member).second) {
+                result->add_handle(member);
             }
         }
     }
+    LOG_DEBUG("query_for_incoming_set(" << handle << ") aggregated " << result->size()
+                                        << " unique handles");
     return result;
 }
 

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -1,4 +1,4 @@
-#define LOG_LEVEL DEBUG_LEVEL
+#define LOG_LEVEL INFO_LEVEL
 #include "RemoteAtomDB.h"
 
 #include <fstream>

--- a/src/atomdb/remotedb/RemoteAtomDB.h
+++ b/src/atomdb/remotedb/RemoteAtomDB.h
@@ -75,6 +75,9 @@ class RemoteAtomDB : public AtomDB {
 
    private:
     map<string, shared_ptr<RemoteAtomDBPeer>> remote_db_;
+    // Aggregated nested-indexing capability, derived from peers at construction. True only when
+    // every peer supports nested indexing; mixed configurations are normalized to false.
+    bool nested_indexing_ = false;
 };
 
 }  // namespace atomdb

--- a/src/atomdb/remotedb/RemoteAtomDB.h
+++ b/src/atomdb/remotedb/RemoteAtomDB.h
@@ -20,6 +20,9 @@ namespace atomdb {
 class RemoteAtomDB : public AtomDB {
    public:
     explicit RemoteAtomDB(const JsonConfig& peers_config);
+    // Dependency-injection constructor: takes pre-built peers directly. Primarily used by tests to
+    // federate controllable backends (e.g. nested-indexing fakes) without a live config/connection.
+    explicit RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers);
     ~RemoteAtomDB();
 
     bool allow_nested_indexing() override;
@@ -74,6 +77,10 @@ class RemoteAtomDB : public AtomDB {
     RemoteAtomDBPeer* get_peer(const string& uid);
 
    private:
+    // Derives the aggregated nested-indexing capability from the current peers. Shared by both
+    // constructors so the config and DI paths stay consistent.
+    void derive_nested_indexing();
+
     map<string, shared_ptr<RemoteAtomDBPeer>> remote_db_;
     // Aggregated nested-indexing capability, derived from peers at construction. True only when
     // every peer supports nested indexing; mixed configurations are normalized to false.

--- a/src/atomdb/remotedb/RemoteAtomDB.h
+++ b/src/atomdb/remotedb/RemoteAtomDB.h
@@ -20,8 +20,10 @@ namespace atomdb {
 class RemoteAtomDB : public AtomDB {
    public:
     explicit RemoteAtomDB(const JsonConfig& peers_config);
-    // Dependency-injection constructor: takes pre-built peers directly. Primarily used by tests to
-    // federate controllable backends (e.g. nested-indexing fakes) without a live config/connection.
+    /**
+     * Dependency-injection constructor for pre-built peers.
+     * Primarily used by tests to federate controllable backends without live config/connection.
+     */
     explicit RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers);
     ~RemoteAtomDB();
 

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -43,6 +43,7 @@ shared_ptr<Atom> RemoteAtomDBPeer::get_atom(const string& handle) {
     if (local_persistence_) {
         atom = local_persistence_->get_atom(handle);
         if (atom) {
+            LOG_DEBUG("[" << uid_ << "] get_atom(" << handle << ") <- local_persistence (cached)");
             cache_.add_atom(atom.get());
             return atom;
         }
@@ -51,11 +52,13 @@ shared_ptr<Atom> RemoteAtomDBPeer::get_atom(const string& handle) {
     if (atomdb_) {
         atom = atomdb_->get_atom(handle);
         if (atom) {
+            LOG_DEBUG("[" << uid_ << "] get_atom(" << handle << ") <- remote atomdb (cached)");
             cache_.add_atom(atom.get());
             return atom;
         }
     }
 
+    LOG_DEBUG("[" << uid_ << "] get_atom(" << handle << ") miss");
     return nullptr;
 }
 
@@ -66,6 +69,7 @@ shared_ptr<Node> RemoteAtomDBPeer::get_node(const string& handle) {
     if (local_persistence_) {
         node = local_persistence_->get_node(handle);
         if (node) {
+            LOG_DEBUG("[" << uid_ << "] get_node(" << handle << ") <- local_persistence (cached)");
             cache_.add_node(node.get());
             return node;
         }
@@ -74,11 +78,13 @@ shared_ptr<Node> RemoteAtomDBPeer::get_node(const string& handle) {
     if (atomdb_) {
         node = atomdb_->get_node(handle);
         if (node) {
+            LOG_DEBUG("[" << uid_ << "] get_node(" << handle << ") <- remote atomdb (cached)");
             cache_.add_node(node.get());
             return node;
         }
     }
 
+    LOG_DEBUG("[" << uid_ << "] get_node(" << handle << ") miss");
     return nullptr;
 }
 
@@ -89,6 +95,7 @@ shared_ptr<Link> RemoteAtomDBPeer::get_link(const string& handle) {
     if (local_persistence_) {
         link = local_persistence_->get_link(handle);
         if (link) {
+            LOG_DEBUG("[" << uid_ << "] get_link(" << handle << ") <- local_persistence (cached)");
             cache_.add_link(link.get());
             return link;
         }
@@ -97,12 +104,26 @@ shared_ptr<Link> RemoteAtomDBPeer::get_link(const string& handle) {
     if (atomdb_) {
         link = atomdb_->get_link(handle);
         if (link) {
+            LOG_DEBUG("[" << uid_ << "] get_link(" << handle << ") <- remote atomdb (cached)");
             cache_.add_link(link.get());
             return link;
         }
     }
 
+    LOG_DEBUG("[" << uid_ << "] get_link(" << handle << ") miss");
     return nullptr;
+}
+
+shared_ptr<Atom> RemoteAtomDBPeer::get_cached_atom(const string& handle) {
+    return cache_.get_atom(handle);
+}
+
+shared_ptr<Node> RemoteAtomDBPeer::get_cached_node(const string& handle) {
+    return cache_.get_node(handle);
+}
+
+shared_ptr<Link> RemoteAtomDBPeer::get_cached_link(const string& handle) {
+    return cache_.get_link(handle);
 }
 
 vector<shared_ptr<Atom>> RemoteAtomDBPeer::get_matching_atoms(bool is_toplevel, Atom& key) {
@@ -147,6 +168,8 @@ void RemoteAtomDBPeer::feed_cache_from_handle_set(shared_ptr<HandleSet> handle_s
     auto it = handle_set->get_iterator();
     if (!it) return;
 
+    LOG_DEBUG("[" << uid_ << "] feed_cache_from_handle_set: warming cache with " << handle_set->size()
+                  << " handles");
     while (true) {
         char* handle_cstr = it->next();
         if (!handle_cstr) break;
@@ -186,11 +209,15 @@ shared_ptr<HandleSet> RemoteAtomDBPeer::query_for_pattern(const LinkSchema& link
     set<string> seen;
 
     if (schema_already_fetched(link_schema)) {
+        LOG_DEBUG("[" << uid_ << "] query_for_pattern(" << link_schema.handle() << ") cache-hit"
+                      << (local_persistence_ ? ", merging cache + local_persistence" : "."));
         merge_handle_set(cache_.query_for_pattern(link_schema), result, seen);
         if (local_persistence_) {
             merge_handle_set(local_persistence_->query_for_pattern(link_schema), result, seen);
         }
     } else {
+        LOG_DEBUG("[" << uid_ << "] query_for_pattern(" << link_schema.handle()
+                      << ") cache-miss, fetching from remote atomdb");
         if (atomdb_) {
             auto handle_set = atomdb_->query_for_pattern(link_schema);
             if (handle_set) {
@@ -201,6 +228,8 @@ shared_ptr<HandleSet> RemoteAtomDBPeer::query_for_pattern(const LinkSchema& link
         fetched_link_templates_.insert(link_schema.handle(), empty_trie_value_);
     }
 
+    LOG_DEBUG("[" << uid_ << "] query_for_pattern(" << link_schema.handle() << ") -> " << result->size()
+                  << " handles");
     return result;
 }
 
@@ -210,10 +239,14 @@ shared_ptr<HandleList> RemoteAtomDBPeer::query_for_targets(const string& handle)
 
     if (local_persistence_) {
         result = local_persistence_->query_for_targets(handle);
-        if (result) return result;
+        if (result) {
+            LOG_DEBUG("[" << uid_ << "] query_for_targets(" << handle << ") <- local_persistence");
+            return result;
+        }
     }
 
     if (atomdb_) {
+        LOG_DEBUG("[" << uid_ << "] query_for_targets(" << handle << ") <- remote atomdb");
         return atomdb_->query_for_targets(handle);
     }
 
@@ -232,6 +265,8 @@ shared_ptr<HandleSet> RemoteAtomDBPeer::query_for_incoming_set(const string& han
         merge_handle_set(atomdb_->query_for_incoming_set(handle), result, seen);
     }
 
+    LOG_DEBUG("[" << uid_ << "] query_for_incoming_set(" << handle << ") -> " << result->size()
+                  << " handles");
     return result;
 }
 
@@ -443,6 +478,8 @@ size_t RemoteAtomDBPeer::atom_count() const {
 
 void RemoteAtomDBPeer::fetch(const LinkSchema& link_schema) {
     if (!schema_already_fetched(link_schema) && atomdb_) {
+        LOG_DEBUG("[" << uid_ << "] fetch(" << link_schema.handle()
+                      << ") prefetching from remote atomdb");
         auto result = atomdb_->query_for_pattern(link_schema);
         if (result) {
             feed_cache_from_handle_set(result);
@@ -455,6 +492,8 @@ void RemoteAtomDBPeer::release(const LinkSchema& link_schema) {
     // Query cache for pattern results before removing, so we can persist them.
     // TODO: This may remove atoms that were also fetched by another schema. We need to handle this
     // properly.
+    LOG_DEBUG("[" << uid_ << "] release(" << link_schema.handle()
+                  << ") evicting from cache to local_persistence");
     auto handle_set = cache_.query_for_pattern(link_schema);
     if (handle_set && local_persistence_) {
         auto it = handle_set->get_iterator();

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -211,9 +211,13 @@ shared_ptr<HandleSet> RemoteAtomDBPeer::query_for_pattern(const LinkSchema& link
     if (schema_already_fetched(link_schema)) {
         LOG_DEBUG("[" << uid_ << "] query_for_pattern(" << link_schema.handle() << ") cache-hit"
                       << (local_persistence_ ? ", merging cache + local_persistence" : "."));
-        merge_handle_set(cache_.query_for_pattern(link_schema), result, seen);
+        merge_handle_set(
+            cache_.query_for_pattern(link_schema), result, seen, cache_.allow_nested_indexing());
         if (local_persistence_) {
-            merge_handle_set(local_persistence_->query_for_pattern(link_schema), result, seen);
+            merge_handle_set(local_persistence_->query_for_pattern(link_schema),
+                             result,
+                             seen,
+                             local_persistence_->allow_nested_indexing());
         }
     } else {
         LOG_DEBUG("[" << uid_ << "] query_for_pattern(" << link_schema.handle()

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -1,4 +1,4 @@
-#define LOG_LEVEL DEBUG_LEVEL
+#define LOG_LEVEL INFO_LEVEL
 #include "RemoteAtomDBPeer.h"
 
 #include <algorithm>

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -1,6 +1,4 @@
 #define LOG_LEVEL DEBUG_LEVEL
-#include "Logger.h"
-
 #include "RemoteAtomDBPeer.h"
 
 #include <algorithm>
@@ -10,6 +8,7 @@
 #include "Atom.h"
 #include "InMemoryDBAPITypes.h"
 #include "Link.h"
+#include "Logger.h"
 #include "Node.h"
 #include "Utils.h"
 #include "expression_hasher.h"
@@ -33,7 +32,9 @@ RemoteAtomDBPeer::RemoteAtomDBPeer(shared_ptr<AtomDB> remote_atomdb,
 
 RemoteAtomDBPeer::~RemoteAtomDBPeer() { stop_cleanup_thread(); }
 
-bool RemoteAtomDBPeer::allow_nested_indexing() { return false; }
+bool RemoteAtomDBPeer::allow_nested_indexing() {
+    return atomdb_ ? atomdb_->allow_nested_indexing() : false;
+}
 
 shared_ptr<Atom> RemoteAtomDBPeer::get_atom(const string& handle) {
     auto atom = cache_.get_atom(handle);
@@ -141,7 +142,6 @@ bool RemoteAtomDBPeer::schema_already_fetched(const LinkSchema& link_schema) {
 }
 
 void RemoteAtomDBPeer::feed_cache_from_handle_set(shared_ptr<HandleSet> handle_set) {
-    LOG_DEBUG("[uid: " << uid_ << "] feed_cache_from_handle_set(" << (handle_set ? handle_set->size() : 0) << ")");
     if (!handle_set) return;
 
     auto it = handle_set->get_iterator();
@@ -152,9 +152,7 @@ void RemoteAtomDBPeer::feed_cache_from_handle_set(shared_ptr<HandleSet> handle_s
         if (!handle_cstr) break;
 
         string handle(handle_cstr);
-        LOG_DEBUG("[uid: " << uid_ << "] feed_cache_from_handle_set(" << handle << ")");
         auto atom = get_atom(handle);
-        LOG_DEBUG("[uid: " << uid_ << "] feed_cache_from_handle_set(" << handle << ") -> " << (atom ? atom->to_string() : "null"));
         if (atom) {
             cache_.add_atom(atom.get());
         }
@@ -163,14 +161,22 @@ void RemoteAtomDBPeer::feed_cache_from_handle_set(shared_ptr<HandleSet> handle_s
 
 void RemoteAtomDBPeer::merge_handle_set(shared_ptr<HandleSet> source,
                                         shared_ptr<HandleSetInMemory> dest,
-                                        set<string>& seen) {
+                                        set<string>& seen,
+                                        bool copy_metadata) {
     if (!source) return;
     auto it = source->get_iterator();
     char* h;
     while ((h = it->next()) != nullptr) {
         string s(h);
         if (seen.insert(s).second) {
-            dest->add_handle(s);
+            // copy_metadata must only be set when the source backend supports nested indexing;
+            // otherwise get_*_by_handle may be unsupported (e.g. HandleSetRedis raises).
+            if (copy_metadata) {
+                dest->add_handle(
+                    s, source->get_metta_expressions_by_handle(s), source->get_assignments_by_handle(s));
+            } else {
+                dest->add_handle(s);
+            }
         }
     }
 }
@@ -180,23 +186,15 @@ shared_ptr<HandleSet> RemoteAtomDBPeer::query_for_pattern(const LinkSchema& link
     set<string> seen;
 
     if (schema_already_fetched(link_schema)) {
-        LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle() << ") from cache");
         merge_handle_set(cache_.query_for_pattern(link_schema), result, seen);
         if (local_persistence_) {
-            LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle() << ") from local_persistence");
             merge_handle_set(local_persistence_->query_for_pattern(link_schema), result, seen);
         }
     } else {
-        LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle() << ") not cached, fetching from atomdb");
         if (atomdb_) {
             auto handle_set = atomdb_->query_for_pattern(link_schema);
             if (handle_set) {
-                LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle()
-                                     << ") -> " << handle_set->size() << " handles from atomdb");
-                merge_handle_set(handle_set, result, seen);
-            } else {
-                LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle()
-                                     << ") -> no handles from atomdb");
+                merge_handle_set(handle_set, result, seen, atomdb_->allow_nested_indexing());
             }
         }
         feed_cache_from_handle_set(result);

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -1,3 +1,6 @@
+#define LOG_LEVEL DEBUG_LEVEL
+#include "Logger.h"
+
 #include "RemoteAtomDBPeer.h"
 
 #include <algorithm>
@@ -10,9 +13,6 @@
 #include "Node.h"
 #include "Utils.h"
 #include "expression_hasher.h"
-
-#define LOG_LEVEL INFO_LEVEL
-#include "Logger.h"
 
 using namespace atomdb;
 using namespace atomdb_api_types;
@@ -141,6 +141,7 @@ bool RemoteAtomDBPeer::schema_already_fetched(const LinkSchema& link_schema) {
 }
 
 void RemoteAtomDBPeer::feed_cache_from_handle_set(shared_ptr<HandleSet> handle_set) {
+    LOG_DEBUG("[uid: " << uid_ << "] feed_cache_from_handle_set(" << (handle_set ? handle_set->size() : 0) << ")");
     if (!handle_set) return;
 
     auto it = handle_set->get_iterator();
@@ -151,7 +152,9 @@ void RemoteAtomDBPeer::feed_cache_from_handle_set(shared_ptr<HandleSet> handle_s
         if (!handle_cstr) break;
 
         string handle(handle_cstr);
+        LOG_DEBUG("[uid: " << uid_ << "] feed_cache_from_handle_set(" << handle << ")");
         auto atom = get_atom(handle);
+        LOG_DEBUG("[uid: " << uid_ << "] feed_cache_from_handle_set(" << handle << ") -> " << (atom ? atom->to_string() : "null"));
         if (atom) {
             cache_.add_atom(atom.get());
         }
@@ -177,13 +180,24 @@ shared_ptr<HandleSet> RemoteAtomDBPeer::query_for_pattern(const LinkSchema& link
     set<string> seen;
 
     if (schema_already_fetched(link_schema)) {
+        LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle() << ") from cache");
         merge_handle_set(cache_.query_for_pattern(link_schema), result, seen);
         if (local_persistence_) {
+            LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle() << ") from local_persistence");
             merge_handle_set(local_persistence_->query_for_pattern(link_schema), result, seen);
         }
     } else {
+        LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle() << ") not cached, fetching from atomdb");
         if (atomdb_) {
-            merge_handle_set(atomdb_->query_for_pattern(link_schema), result, seen);
+            auto handle_set = atomdb_->query_for_pattern(link_schema);
+            if (handle_set) {
+                LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle()
+                                     << ") -> " << handle_set->size() << " handles from atomdb");
+                merge_handle_set(handle_set, result, seen);
+            } else {
+                LOG_DEBUG("[uid: " << uid_ << "] query_for_pattern(" << link_schema.handle()
+                                     << ") -> no handles from atomdb");
+            }
         }
         feed_cache_from_handle_set(result);
         fetched_link_templates_.insert(link_schema.handle(), empty_trie_value_);

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -94,7 +94,8 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
     void feed_cache_from_handle_set(shared_ptr<atomdb_api_types::HandleSet> handle_set);
     void merge_handle_set(shared_ptr<atomdb_api_types::HandleSet> source,
                           shared_ptr<atomdb_api_types::HandleSetInMemory> dest,
-                          set<string>& seen);
+                          set<string>& seen,
+                          bool copy_metadata = false);
     bool schema_already_fetched(const LinkSchema& link_schema);
 
     string uid_;

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -34,6 +34,12 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
     shared_ptr<Node> get_node(const string& handle) override;
     shared_ptr<Link> get_link(const string& handle) override;
 
+    // Cache-only lookups (in-memory, no local_persistence / remote escalation). Used by the
+    // RemoteAtomDB facade to probe every peer's cache before escalating any peer to its backend.
+    shared_ptr<Atom> get_cached_atom(const string& handle);
+    shared_ptr<Node> get_cached_node(const string& handle);
+    shared_ptr<Link> get_cached_link(const string& handle);
+
     vector<shared_ptr<Atom>> get_matching_atoms(bool is_toplevel, Atom& key) override;
     vector<shared_ptr<Atom>> get_matching_atoms(bool is_toplevel, Atom& key, bool local_only);
 

--- a/src/main/db_loader.cc
+++ b/src/main/db_loader.cc
@@ -78,7 +78,9 @@ int main(int argc, char* argv[]) {
     } else if (atomdb_type == "morkdb") {
         AtomDBSingleton::provide(make_shared<MorkDB>(context, atomdb_config));
     } else if (atomdb_type == "remotedb") {
-        AtomDBSingleton::provide(make_shared<RemoteAtomDB>(atomdb_config));
+        auto remote_peers_config =
+            atomdb_config.at_path("remote_peers").get_or<JsonConfig>(JsonConfig());
+        AtomDBSingleton::provide(make_shared<RemoteAtomDB>(remote_peers_config));
     } else if (atomdb_type == "adapterdb") {
         AtomDBSingleton::provide(make_shared<AdapterDB>(atomdb_config));
     } else {

--- a/src/tests/cpp/inmemorydb_test.cc
+++ b/src/tests/cpp/inmemorydb_test.cc
@@ -2,15 +2,22 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
+#include "Assignment.h"
+#include "InMemoryDBAPITypes.h"
 #include "Link.h"
 #include "LinkSchema.h"
 #include "Node.h"
 
 using namespace atomdb;
+using namespace atomdb::atomdb_api_types;
 using namespace atoms;
+using namespace commons;
 using namespace std;
 
 class InMemoryDBTest : public ::testing::Test {
@@ -532,6 +539,116 @@ TEST_F(InMemoryDBTest, AtomsCount) {
 
     EXPECT_EQ(db->atom_count(), 4);
     EXPECT_EQ(db->empty(), false);
+}
+
+// =============================================================================
+// HandleSetInMemory / HandleSetInMemoryIterator tests
+//
+// These cover the metadata-preserving add_handle overload and the iterator
+// pointer-lifetime contract (next() returns a pointer owned by the HandleSet,
+// not the iterator), used when federating nested-indexing backends.
+// =============================================================================
+
+TEST(HandleSetInMemoryTest, MetadataRoundTrip) {
+    HandleSetInMemory set;
+
+    const string handle = "0123456789abcdef0123456789abcdef";
+    map<string, string> metta = {{"$x", "(Symbol human)"}, {"$y", "(Symbol mammal)"}};
+    Assignment assignment;
+    assignment.assign("$x", "human_value");
+    assignment.assign("$y", "mammal_value");
+
+    set.add_handle(handle, metta, assignment);
+
+    EXPECT_EQ(set.size(), 1u);
+
+    auto retrieved_metta = set.get_metta_expressions_by_handle(handle);
+    EXPECT_EQ(retrieved_metta.size(), 2u);
+    EXPECT_EQ(retrieved_metta["$x"], "(Symbol human)");
+    EXPECT_EQ(retrieved_metta["$y"], "(Symbol mammal)");
+
+    auto retrieved_assignment = set.get_assignments_by_handle(handle);
+    EXPECT_EQ(retrieved_assignment.get("$x"), "human_value");
+    EXPECT_EQ(retrieved_assignment.get("$y"), "mammal_value");
+}
+
+TEST(HandleSetInMemoryTest, MetadataAbsentForPlainAddHandle) {
+    HandleSetInMemory set;
+    const string handle = "0123456789abcdef0123456789abcdef";
+
+    set.add_handle(handle);
+
+    EXPECT_EQ(set.size(), 1u);
+    // Plain add_handle stores no metadata; accessors must return empty (never throw).
+    EXPECT_TRUE(set.get_metta_expressions_by_handle(handle).empty());
+    EXPECT_EQ(set.get_assignments_by_handle(handle).variable_count(), 0u);
+}
+
+TEST(HandleSetInMemoryTest, AppendPreservesMetadataFromBothSets) {
+    const string handle_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const string handle_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    auto first = make_shared<HandleSetInMemory>();
+    Assignment assignment_a;
+    assignment_a.assign("$a", "value_a");
+    first->add_handle(handle_a, {{"$a", "(Symbol a)"}}, assignment_a);
+
+    auto second = make_shared<HandleSetInMemory>();
+    Assignment assignment_b;
+    assignment_b.assign("$b", "value_b");
+    second->add_handle(handle_b, {{"$b", "(Symbol b)"}}, assignment_b);
+
+    first->append(second);
+
+    EXPECT_EQ(first->size(), 2u);
+
+    // Metadata from the original set survives.
+    EXPECT_EQ(first->get_metta_expressions_by_handle(handle_a)["$a"], "(Symbol a)");
+    EXPECT_EQ(first->get_assignments_by_handle(handle_a).get("$a"), "value_a");
+
+    // Metadata merged in from the appended set survives.
+    EXPECT_EQ(first->get_metta_expressions_by_handle(handle_b)["$b"], "(Symbol b)");
+    EXPECT_EQ(first->get_assignments_by_handle(handle_b).get("$b"), "value_b");
+}
+
+TEST(HandleSetInMemoryTest, IteratorPointerOutlivesIterator) {
+    auto set = make_shared<HandleSetInMemory>();
+    const string handle = "0123456789abcdef0123456789abcdef";
+    set->add_handle(handle);
+
+    // Grab a pointer from the iterator, then destroy the iterator. The pointer must remain valid
+    // because it points into storage owned by the HandleSet (mirrors HandleSetRedis semantics).
+    char* captured = nullptr;
+    {
+        auto it = set->get_iterator();
+        captured = it->next();
+        ASSERT_NE(captured, nullptr);
+        EXPECT_EQ(it->next(), nullptr);
+    }  // iterator destroyed here
+
+    ASSERT_NE(captured, nullptr);
+    EXPECT_EQ(string(captured), handle);  // still valid while the set is alive
+}
+
+TEST(HandleSetInMemoryTest, IteratorVisitsAllHandlesOnce) {
+    auto set = make_shared<HandleSetInMemory>();
+    const string handle_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const string handle_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    set->add_handle(handle_a);
+    set->add_handle(handle_b);
+    set->add_handle(handle_a);  // duplicate, set semantics collapse it
+
+    EXPECT_EQ(set->size(), 2u);
+
+    vector<string> visited;
+    auto it = set->get_iterator();
+    char* h;
+    while ((h = it->next()) != nullptr) {
+        visited.push_back(string(h));
+    }
+    EXPECT_EQ(visited.size(), 2u);
+    EXPECT_NE(find(visited.begin(), visited.end(), handle_a), visited.end());
+    EXPECT_NE(find(visited.begin(), visited.end(), handle_b), visited.end());
 }
 
 int main(int argc, char** argv) {

--- a/src/tests/cpp/remote_atomdb_test.cc
+++ b/src/tests/cpp/remote_atomdb_test.cc
@@ -3,10 +3,14 @@
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
+#include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
+#include "Assignment.h"
 #include "InMemoryDB.h"
+#include "InMemoryDBAPITypes.h"
 #include "JsonConfig.h"
 #include "Link.h"
 #include "LinkSchema.h"
@@ -15,6 +19,7 @@
 #include "RemoteAtomDBPeer.h"
 
 using namespace atomdb;
+using namespace atomdb::atomdb_api_types;
 using namespace atoms;
 using namespace commons;
 using namespace std;
@@ -490,6 +495,166 @@ TEST_F(RemoteAtomDBConfigTest, SingleConfigWorks) {
     auto human = new Node("Symbol", "\"human\"");
     string human_handle = db_->add_node(human, false);
     EXPECT_TRUE(db_->node_exists(human_handle));
+}
+
+// =============================================================================
+// RemoteAtomDB federation tests (cache-first probing + metadata aggregation)
+//
+// These exercise the facade with controllable, in-process peers (no live config
+// or external connection). A NestedInMemoryDB models a nested-indexing backend
+// (e.g. MorkDB) that returns per-handle metadata from query_for_pattern.
+// =============================================================================
+
+// In-memory backend that advertises nested indexing and attaches per-handle
+// metta expressions / assignments to its pattern query results.
+class NestedInMemoryDB : public InMemoryDB {
+   public:
+    explicit NestedInMemoryDB(const string& context) : InMemoryDB(context) {}
+
+    bool allow_nested_indexing() override { return true; }
+
+    shared_ptr<HandleSet> query_for_pattern(const LinkSchema& link_schema) override {
+        auto base = InMemoryDB::query_for_pattern(link_schema);
+        auto result = make_shared<HandleSetInMemory>();
+        if (base) {
+            auto it = base->get_iterator();
+            char* h;
+            while ((h = it->next()) != nullptr) {
+                string handle(h);
+                map<string, string> metta = {{"$x", "(nested " + handle.substr(0, 6) + ")"}};
+                Assignment assignment;
+                assignment.assign("$x", handle);
+                result->add_handle(handle, metta, assignment);
+            }
+        }
+        return result;
+    }
+};
+
+// Builds an Inheritance(x, "mammal") pattern that matches two links in the
+// helper-populated backends below.
+static LinkSchema inheritance_mammal_schema() {
+    return LinkSchema({"LINK_TEMPLATE",
+                       "Expression",
+                       "3",
+                       "NODE",
+                       "Symbol",
+                       "Inheritance",
+                       "VARIABLE",
+                       "x",
+                       "NODE",
+                       "Symbol",
+                       "\"mammal\""});
+}
+
+// Populates a backend with two Inheritance(*, "mammal") links and returns their handles.
+static vector<string> populate_inheritance_links(shared_ptr<InMemoryDB> backend) {
+    auto human = new Node("Symbol", "\"human\"");
+    auto monkey = new Node("Symbol", "\"monkey\"");
+    auto mammal = new Node("Symbol", "\"mammal\"");
+    auto inheritance = new Node("Symbol", "Inheritance");
+
+    string human_handle = backend->add_node(human, false);
+    string monkey_handle = backend->add_node(monkey, false);
+    string mammal_handle = backend->add_node(mammal, false);
+    string inheritance_handle = backend->add_node(inheritance, false);
+
+    auto link1 = new Link("Expression", {inheritance_handle, human_handle, mammal_handle});
+    auto link2 = new Link("Expression", {inheritance_handle, monkey_handle, mammal_handle});
+    string link1_handle = backend->add_link(link1, false);
+    string link2_handle = backend->add_link(link2, false);
+    backend->re_index_patterns(true);
+    return {link1_handle, link2_handle};
+}
+
+TEST(RemoteAtomDBFederationTest, MetadataAggregationFromNestedPeer) {
+    auto backend = make_shared<NestedInMemoryDB>("fed_nested_backend_");
+    auto handles = populate_inheritance_links(backend);
+
+    map<string, shared_ptr<RemoteAtomDBPeer>> peers;
+    peers["nested"] = make_shared<RemoteAtomDBPeer>(backend, nullptr, "nested");
+    auto db = make_shared<RemoteAtomDB>(peers);
+
+    // All peers are nested-indexing -> facade advertises nested indexing.
+    EXPECT_TRUE(db->allow_nested_indexing());
+
+    auto result = db->query_for_pattern(inheritance_mammal_schema());
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->size(), 2u);
+
+    // Metadata must survive aggregation for every matched handle.
+    auto it = result->get_iterator();
+    char* h;
+    int checked = 0;
+    while ((h = it->next()) != nullptr) {
+        string handle(h);
+        auto metta = result->get_metta_expressions_by_handle(handle);
+        EXPECT_FALSE(metta.empty()) << "metta lost for " << handle;
+        EXPECT_EQ(metta["$x"], "(nested " + handle.substr(0, 6) + ")");
+
+        auto assignment = result->get_assignments_by_handle(handle);
+        EXPECT_EQ(assignment.get("$x"), handle);
+        checked++;
+    }
+    EXPECT_EQ(checked, 2);
+}
+
+TEST(RemoteAtomDBFederationTest, MixedPeersDowngradeAndDeduplicate) {
+    // peer1: nested-indexing backend; peer2: plain in-memory backend.
+    // Both contain the SAME two links so the facade must dedup by handle.
+    auto nested_backend = make_shared<NestedInMemoryDB>("fed_mixed_nested_");
+    auto plain_backend = make_shared<InMemoryDB>("fed_mixed_plain_");
+    auto nested_handles = populate_inheritance_links(nested_backend);
+    auto plain_handles = populate_inheritance_links(plain_backend);
+    ASSERT_EQ(nested_handles, plain_handles);  // identical content -> identical handles
+
+    map<string, shared_ptr<RemoteAtomDBPeer>> peers;
+    peers["nested"] = make_shared<RemoteAtomDBPeer>(nested_backend, nullptr, "nested");
+    peers["plain"] = make_shared<RemoteAtomDBPeer>(plain_backend, nullptr, "plain");
+    auto db = make_shared<RemoteAtomDB>(peers);
+
+    // Mixed nested/non-nested peers -> facade downgrades to false.
+    EXPECT_FALSE(db->allow_nested_indexing());
+
+    auto result = db->query_for_pattern(inheritance_mammal_schema());
+    ASSERT_NE(result, nullptr);
+    // Same two handles from both peers, deduplicated to a unique count of 2.
+    EXPECT_EQ(result->size(), 2u);
+}
+
+TEST(RemoteAtomDBFederationTest, CacheFirstProbingAcrossPeers) {
+    // An atom that exists only in peer2's backend must still resolve via the facade,
+    // and the resolving peer must cache it so subsequent probes are served from cache.
+    auto backend1 = make_shared<InMemoryDB>("fed_cache_peer1_");
+    auto backend2 = make_shared<InMemoryDB>("fed_cache_peer2_");
+
+    auto only_in_peer2 = new Node("Symbol", "\"only_in_peer2\"");
+    string handle = backend2->add_node(only_in_peer2, false);
+
+    map<string, shared_ptr<RemoteAtomDBPeer>> peers;
+    peers["peer1"] = make_shared<RemoteAtomDBPeer>(backend1, nullptr, "peer1");
+    peers["peer2"] = make_shared<RemoteAtomDBPeer>(backend2, nullptr, "peer2");
+    auto db = make_shared<RemoteAtomDB>(peers);
+
+    auto* peer2 = db->get_peer("peer2");
+    ASSERT_NE(peer2, nullptr);
+    // Before any read, nothing is cached.
+    EXPECT_EQ(peer2->get_cached_atom(handle), nullptr);
+
+    // Phase 1 (cache) misses everywhere; Phase 2 escalation resolves from peer2's backend.
+    auto first = db->get_atom(handle);
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(first->handle(), handle);
+
+    // peer2 must have warmed its cache, so a subsequent Phase 1 probe hits.
+    EXPECT_NE(peer2->get_cached_atom(handle), nullptr);
+
+    auto second = db->get_atom(handle);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(second->handle(), handle);
+
+    // A handle present in no peer resolves to nullptr.
+    EXPECT_EQ(db->get_atom("ffffffffffffffffffffffffffffffff"), nullptr);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

This PR makes `RemoteAtomDB` usable as a real federating AtomDB over heterogeneous
peers (`RedisMongoDB` + `MorkDB`), and fixes two crashes that surfaced when running a
`(Similarity $P $C)` query against a multi-peer `remotedb` configuration.

Key outcomes:
- Fixes a use-after-free that crashed the query engine with `Invalid key size: 6 != 32`.
- Fixes a multi-peer segfault caused by a shared static flag in `RedisMongoDB`.
- Derives `allow_nested_indexing()` from the actual peers instead of a hardcoded value.
- Stops the federation merge from silently dropping per-handle match metadata.
- Routes reads cache-first across peers to avoid wasted remote round-trips.

Related: #1037.

## Motivation

Running the query engine with `type: remotedb` (peers: one `redismongodb`, one `morkdb`)
crashed during query execution. Investigation surfaced two independent defects plus
several correctness/efficiency gaps in how `RemoteAtomDB` aggregates and resolves data
across peers.

## Changes

### Crash fixes

- **Use-after-free in `HandleSetInMemory` iteration.**
  `HandleSetInMemoryIterator` allocated per-handle `char*` copies and freed them in its
  destructor, but `LinkTemplate::processor_method` keeps those `char*` in `tagged_handles`
  and dereferences them *after* the iterator goes out of scope. With a `HandleSetInMemory`
  result (returned by `RemoteAtomDB`), this produced a dangling pointer read → a garbage
  6-byte "handle" → `HandleTrie::lookup_node` raised `Invalid key size: 6 != 32`.
  Fixed by returning pointers into the set's stored strings (lifetime tied to the
  `HandleSet`, matching the existing `HandleSetRedis` contract). No more per-iterator
  allocation; iterator destructor is now empty.
  Files: `src/atomdb/inmemorydb/InMemoryDBAPITypes.{h,cc}`.

- **Shared static `RedisMongoDB::SKIP_REDIS` across instances.**
  With multiple `RedisMongoDB` instances (multi-peer), the static `SKIP_REDIS` flag was
  overwritten by the last-constructed instance, causing the wrong skip-redis behavior and
  a segfault. Converted to an instance member `skip_redis_`; `initialize_statics()` no
  longer takes/sets it.
  Files: `src/atomdb/redis_mongodb/RedisMongoDB.{h,cc}`.

### Configuration contract

- **`atomdb.remote_peers`.** `AtomDBSingleton::init` now reads the `remote_peers`
  sub-config when `atomdb_type == "remotedb"` and passes it to `RemoteAtomDB`.
  File: `src/atomdb/AtomDBSingleton.cc`.
- **Optional per-peer `local_persistence`.** A peer may be configured without a
  `local_persistence` backend; it is only constructed when present.
  File: `src/atomdb/remotedb/RemoteAtomDB.cc`.

### Federation correctness

- **`allow_nested_indexing()` derived from peers.** `RemoteAtomDBPeer` now delegates to
  its remote backend, and `RemoteAtomDB` aggregates across peers at construction:
  `true` only if *every* peer supports nested indexing; mixed configurations are
  normalized to `false` (lowest common denominator) with a startup warning. Previously it
  was hardcoded to `false`, which silently disagreed with `MorkDB` peers.
- **Non-lossy merge.** The aggregation in `RemoteAtomDB::query_for_pattern` and
  `RemoteAtomDBPeer::merge_handle_set` previously copied only the handle string, dropping
  the per-handle assignments / metta expressions that nested-indexing peers (e.g. MorkDB)
  compute. It now preserves that metadata via a metadata-aware `HandleSetInMemory::add_handle`
  overload. The copy is gated on the source backend's nested-indexing capability, since
  `HandleSetRedis`'s metadata accessors intentionally raise.
  Files: `src/atomdb/remotedb/RemoteAtomDB.{h,cc}`, `src/atomdb/remotedb/RemoteAtomDBPeer.{h,cc}`,
  `src/atomdb/inmemorydb/InMemoryDBAPITypes.{h,cc}`.

### Read-path efficiency

- **Cache-first cross-peer resolution.** `RemoteAtomDB::get_atom/get_node/get_link` now
  resolve in two phases: first probe every peer's in-memory cache (`get_cached_*`, no
  network), and only escalate any peer to its `local_persistence` / remote backend if all
  caches miss. This avoids the wasted remote round-trips that a non-owning peer would
  otherwise incur (its cache misses, then it queries its remote backend and misses over
  the network). Reuses the existing per-peer cache; no separate ownership index to maintain
  or evict.
  Files: `src/atomdb/remotedb/RemoteAtomDB.cc`, `src/atomdb/remotedb/RemoteAtomDBPeer.{h,cc}`.

### Observability

- Added concise `LOG_DEBUG` lifecycle traces across `RemoteAtomDB` / `RemoteAtomDBPeer`
  (pattern fan-out and aggregation counts, per-peer cache-hit/miss, cold-fetch cache
  warming, and read escalation/not-found). Steady-state cache hits are intentionally not
  logged to keep traces lean.

## Notes / follow-ups (not in this PR)

- `auto_cleanup()` cache eviction is still a TODO. With cache-first resolution there is no
  ownership index to keep in sync — eviction only needs to touch the per-peer cache.
- `delete_*` count aggregation, strict fail-closed read policy, and `release()`
  cross-schema eviction remain open items tracked separately.
- Extend `src/tests/cpp/remote_atomdb_test.cc` to cover the metadata-preserving merge,
  derived `allow_nested_indexing()`, and cache-first resolution.
