### PR TITLE
[FIX] MorkDB test

### DIFF
--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -66,10 +66,11 @@ httplib::Result MorkClient::send_request(const string& method, const string& pat
     }
 
     if (!res) {
-        RAISE_ERROR("Connection error at http://" + this->base_url_ + path);
+        RAISE_ERROR("Connection error at http://" + this->base_url_ + path + ": " +
+                    httplib::to_string(res.error()));
     } else if (res->status != httplib::StatusCode::OK_200) {
-        auto err = res.error();
-        RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": " + httplib::to_string(err));
+        RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": status " +
+                    std::to_string(res->status));
     }
     return res;
 }
@@ -101,7 +102,7 @@ MorkDB::~MorkDB() {}
 bool MorkDB::allow_nested_indexing() { return true; }
 
 void MorkDB::mork_setup(const JsonConfig& config) {
-    string address = config.at_path("morkdb.endpoint").get_or<string>("");
+    string address = Utils::trim(config.at_path("morkdb.endpoint").get_or<string>(""));
     if (address.empty()) {
         RAISE_ERROR("Missing morkdb.endpoint in AtomDB configuration");
     }

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -23,7 +23,7 @@ using namespace metta;
 
 // --> MorkClient
 MorkClient::MorkClient(const string& base_url)
-    : base_url_(Utils::trim(base_url)), cli(httplib::Client(base_url)) {
+    : base_url_(Utils::trim(base_url)), cli(httplib::Client(base_url_)) {
     send_request("GET", "/status/-");
 }
 
@@ -56,23 +56,20 @@ string MorkClient::clear(const string& pattern) {
 httplib::Result MorkClient::send_request(const string& method, const string& path, const string& data) {
     httplib::Result res;
 
-    // TODO: Improve the way build with schema
-    string url = "http://" + this->base_url_ + path;
-
     if (method == "GET") {
-        res = this->cli.Get(url);
+        res = this->cli.Get(path);
     } else if (method == "POST") {
         if (data.empty()) {
             RAISE_ERROR("POST request data is empty. Cannot send an empty payload to MORK server.");
         }
-        res = this->cli.Post(url, data, "text/plain");
+        res = this->cli.Post(path, data, "text/plain");
     }
 
     if (!res) {
-        RAISE_ERROR("Connection error at " + url);
+        RAISE_ERROR("Connection error at http://" + this->base_url_ + path);
     } else if (res->status != httplib::StatusCode::OK_200) {
         auto err = res.error();
-        RAISE_ERROR("Http error: " + httplib::to_string(err));
+        RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": " + httplib::to_string(err));
     }
     return res;
 }
@@ -104,13 +101,16 @@ MorkDB::~MorkDB() {}
 bool MorkDB::allow_nested_indexing() { return true; }
 
 void MorkDB::mork_setup(const JsonConfig& config) {
-    string address = config.at_path("morkdb.endpoint").get<string>();
-
+    string address = config.at_path("morkdb.endpoint").get_or<string>("");
+    if (address.empty()) {
+        RAISE_ERROR("Missing morkdb.endpoint in AtomDB configuration");
+    }
     try {
         this->mork_client = make_shared<MorkClient>(address);
         LOG_INFO("Connected to MORK at " << address);
     } catch (const exception& e) {
-        RAISE_ERROR(e.what());
+        const char* msg = e.what();
+        RAISE_ERROR(msg != nullptr ? msg : "Failed to connect to MORK server");
     }
 }
 

--- a/src/tests/cpp/morkdb_test.cc
+++ b/src/tests/cpp/morkdb_test.cc
@@ -476,6 +476,18 @@ TEST_F(MorkDBTest, ReIndexPatterns) {
     EXPECT_EQ(result->size(), 4);
 }
 
+TEST(MorkDBSetupTest, RejectsMissingEndpoint) {
+    auto config = test_atomdb_json_config("morkdb");
+    config["morkdb"].erase("endpoint");
+    EXPECT_THROW({ MorkDB db("setup_test_", config); }, runtime_error);
+}
+
+TEST(MorkDBSetupTest, RejectsBlankEndpoint) {
+    auto config = test_atomdb_json_config("morkdb");
+    config["morkdb"]["endpoint"] = "   ";
+    EXPECT_THROW({ MorkDB db("setup_test_", config); }, runtime_error);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(new MorkDBTestEnvironment());

--- a/src/tests/cpp/morkdb_test.cc
+++ b/src/tests/cpp/morkdb_test.cc
@@ -20,7 +20,7 @@ using namespace std;
 class MorkDBTestEnvironment : public ::testing::Environment {
    public:
     void SetUp() override {
-        auto atomdb = new MorkDB("morkdb_test_", test_atomdb_json_config());
+        auto atomdb = new MorkDB("morkdb_test_", test_atomdb_json_config("morkdb"));
         atomdb->drop_all();
         AtomDBSingleton::provide(shared_ptr<AtomDB>(atomdb));
         load_animals_data();
@@ -297,7 +297,7 @@ TEST_F(MorkDBTest, AddLinksWithDuplicateTargets) {
 }
 
 TEST_F(MorkDBTest, ConcurrentAddLinks) {
-    int num_links = 5000;
+    int num_links = 1000;
     int arity = 3;
     int chunck_size = 500;
 


### PR DESCRIPTION
## Summary

Fixes `morkdb_test` failing in CI with `basic_string::_M_construct null not valid`.

- **MorkClient HTTP calls**: pass the path (`/status/-`, etc.) to httplib instead of a full URL — the client already has the host from the constructor.
- **MorkDB setup**: validate `morkdb.endpoint` is present and handle null `e.what()` safely in error reporting.
- **morkdb_test**: use `test_atomdb_json_config("morkdb")` and reduce `ConcurrentAddLinks` load (5000 → 1000 links).

## Test plan

- [ ] `make bazel 'test --cache_test_results=no //tests/cpp:morkdb_test'`
- [ ] CI unit test workflow passes with MORK server running
