### PR TITLE
[DAS#1163] Small improvements and fixes on pipelines

### DIFF
--- a/.github/workflows/check-repos.yml
+++ b/.github/workflows/check-repos.yml
@@ -8,43 +8,34 @@ on:
   workflow_dispatch:
 
 jobs:
-  checking-repos:
+  ci:
+    uses: ./.github/workflows/run-code-quality-and-tests-no-cache.yml@master
+
+  notify-success:
+    needs: ci
+    if: success()
     runs-on: self-hosted
-    strategy:
-      matrix:
-        repo: ${{ fromJson(vars.SCHEDULED_REPOS) }}
     steps:
-      - name: Running workflow
-        id: running-workflow
-        uses: singnet/das-cicd@master
-        with:
-          workflow: ${{ matrix.repo.workflow_id }}
-          repo: ${{ matrix.repo.name }}
-          org: singnet
-          ref: master
-          github-token: ${{ secrets.GH_TOKEN }}
-
       - name: Send success notification
-        if: steps.running-workflow.outputs.conclusion == 'success'
         uses: singnet/integration-github-mattermost@v0.2.0
         with:
           webhook-url: ${{ secrets.SCHEDULED_REPOS_MATTERMOST_WEBHOOK_URL }}
           message: |
-            SUCCESS - CI workflow succeeded in repository ${{ matrix.repo.name }}
+            SUCCESS - CI workflow succeeded in repository ${{ github.repository }}
 
-            ${{ fromJson(steps.running-workflow.outputs.logs).benchmark.performbenchmark != '' && format('Benchmark: {0}', fromJson(steps.running-workflow.outputs.logs).benchmark.performbenchmark) || '' }}
-
+  notify-failure:
+    needs: ci
+    if: failure()
+    runs-on: self-hosted
+    steps:
       - name: Send failure notification
-        if: steps.running-workflow.outputs.conclusion != 'success'
         uses: singnet/integration-github-mattermost@v0.2.0
         with:
           webhook-url: ${{ secrets.SCHEDULED_REPOS_MATTERMOST_WEBHOOK_URL }}
           message: |
-            FAILURE - CI workflow failed in repository ${{ matrix.repo.name }}
+            FAILURE - CI workflow failed in repository ${{ github.repository }}
 
-            ${{ fromJson(steps.running-workflow.outputs.logs).benchmark.performbenchmark != '' && format('Benchmark: {0}', fromJson(steps.running-workflow.outputs.logs).benchmark.performbenchmark) || '' }}
-            Details: ${{ steps.running-workflow.outputs.run_url  }}
-            Failed job:
-            ${{ steps.running-workflow.outputs.failed_jobs_display }}
+            Details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            ${{ needs.ci.outputs.failed_job != '' && format('Failed job: {0}', needs.ci.outputs.failed_job) || '' }}
 
             @channel

--- a/.github/workflows/check-repos.yml
+++ b/.github/workflows/check-repos.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/run-code-quality-and-tests-no-cache.yml@master
+    uses: ./.github/workflows/run-code-quality-and-tests-no-cache.yml
 
   notify-success:
     needs: ci

--- a/.github/workflows/check-repos.yml
+++ b/.github/workflows/check-repos.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   ci:
+    permissions: 
+      contents: read
+      pull-requests: read
+
     uses: ./.github/workflows/run-code-quality-and-tests-no-cache.yml
 
   notify-success:

--- a/.github/workflows/run-code-quality-and-tests-no-cache.yml
+++ b/.github/workflows/run-code-quality-and-tests-no-cache.yml
@@ -2,6 +2,11 @@ name: Code Quality & Tests Without Cache
 
 on:
   workflow_call:
+    outputs:
+      failed_job:
+        description: Name of the job that failed, if any
+        value: ${{ jobs.report.outputs.failed_job }}
+
   workflow_dispatch:
 
 jobs:
@@ -13,3 +18,21 @@ jobs:
     uses: ./.github/workflows/run-unit-tests.yml
     with:
       runner: self-hosted-nocache
+
+  report:
+    needs: [format-check, unit-tests]
+    if: always()
+    runs-on: self-hosted
+    outputs:
+      failed_job: ${{ steps.failed-job.outputs.name }}
+    steps:
+      - name: Determine failed job
+        id: failed-job
+        run: |
+          if [ "${{ needs.format-check.result }}" = "failure" ]; then
+            echo "name=format-check" >> "$GITHUB_OUTPUT"
+          elif [ "${{ needs.unit-tests.result }}" = "failure" ]; then
+            echo "name=unit-tests" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/run-code-quality-and-tests.yml
+++ b/.github/workflows/run-code-quality-and-tests.yml
@@ -8,6 +8,17 @@ on:
       - master
   workflow_dispatch:
 
+  push:
+    paths:
+      - '**/*.h'
+      - '**/*.cc'
+      - '**/*.bazel'
+      - '**/BUILD'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   format-check:
     uses: ./.github/workflows/run-format-check.yaml

--- a/.github/workflows/run-code-quality-and-tests.yml
+++ b/.github/workflows/run-code-quality-and-tests.yml
@@ -26,7 +26,7 @@ on:
       - '**/BUILD'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/run-code-quality-and-tests.yml
+++ b/.github/workflows/run-code-quality-and-tests.yml
@@ -2,13 +2,23 @@ name: Code Quality & Tests
 
 on:
   workflow_call:
+
   pull_request:
+
     branches:
       - develop
       - master
+
+    paths:
+      - '**/*.h'
+      - '**/*.cc'
+      - '**/*.bazel'
+      - '**/BUILD'
+
   workflow_dispatch:
 
   push:
+
     paths:
       - '**/*.h'
       - '**/*.cc'


### PR DESCRIPTION
Added the following params to the 'run-code-quality-and-tests.yml' workflow:

 ```
paths:
      - '**/*.h'
      - '**/*.cc'
      - '**/*.bazel'
      - '**/BUILD'

concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true

```

These parameters will ensure the pipeline only runs when essential files like: header files, C++, .bazel and BUILD files are edited. Also, the concurrency parameter will ensure that only one workflow runs per pull request, automatically canceling any previous or concurrent workflow running with the current one.
