### PR TITLE
[#BUGFIX] Fix flaky adapterdb tests with MORK retry logic and bump MORK image to 1.1.0

### DIFF
--- a/config/das.json
+++ b/config/das.json
@@ -117,7 +117,7 @@
             "image": "trueagi/das:1.0.0-metta-parser"
         },
         "morkdb": {
-            "image": "trueagi/das:mork-loader-1.0.4"
+            "image": "trueagi/das:mork-loader-1.1.0"
         }
     },
     "agents": {

--- a/config/das.json
+++ b/config/das.json
@@ -71,7 +71,7 @@
             }
         },
         "morkdb": {
-            "image": "trueagi/das:mork-server-1.0.4",
+            "image": "trueagi/das:mork-server-1.1.0",
             "endpoint": "localhost:40022"
         },
         "remote_peers": [

--- a/src/atomdb/adapterdb/README.md
+++ b/src/atomdb/adapterdb/README.md
@@ -114,7 +114,7 @@ feature as f WHERE f.feature_id<=500;
             }
         },
         "morkdb": {
-            "image": "trueagi/das:mork-server-1.0.4",
+            "image": "trueagi/das:mork-server-1.1.0",
             "endpoint": "localhost:40022"
         },
         "remote_peers": [
@@ -160,7 +160,7 @@ feature as f WHERE f.feature_id<=500;
             "image": "trueagi/das:1.0.0-metta-parser"
         },
         "morkdb": {
-            "image": "trueagi/das:mork-loader-1.0.4"
+            "image": "trueagi/das:mork-loader-1.1.0"
         }
     },
     "agents": {

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -24,8 +24,6 @@ using namespace metta;
 namespace {
 
 bool is_transient_mork_http_status(int status) {
-    // MORK returns 401 when a path is temporarily locked by a concurrent request, and 409 for
-    // PathForbiddenTemporary. Both are expected under parallel test load and should be retried.
     return status == httplib::StatusCode::Unauthorized_401 ||
            status == httplib::StatusCode::Conflict_409;
 }
@@ -66,7 +64,7 @@ string MorkClient::clear(const string& pattern) {
 
 httplib::Result MorkClient::send_request(const string& method, const string& path, const string& data) {
     const unsigned int max_attempts = 16;
-    const unsigned int initial_delay_ms = 5;  // 0.005s, matching mork_loader.py
+    const unsigned int initial_delay_ms = 5;
     const double backoff = 2.0;
 
     for (unsigned int attempt = 0; attempt < max_attempts; ++attempt) {

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -66,7 +66,8 @@ string MorkClient::clear(const string& pattern) {
 
 httplib::Result MorkClient::send_request(const string& method, const string& path, const string& data) {
     const unsigned int max_attempts = 16;
-    unsigned int delay_ms = 5;
+    const unsigned int initial_delay_ms = 5;  // 0.005s, matching mork_loader.py
+    const double backoff = 2.0;
 
     for (unsigned int attempt = 0; attempt < max_attempts; ++attempt) {
         httplib::Result res;
@@ -89,11 +90,21 @@ httplib::Result MorkClient::send_request(const string& method, const string& pat
             return res;
         }
 
-        if (is_transient_mork_http_status(res->status) && attempt + 1 < max_attempts) {
+        if (is_transient_mork_http_status(res->status)) {
+            if (attempt + 1 >= max_attempts) {
+                RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": exhausted " +
+                            std::to_string(max_attempts) + " retries, last status " +
+                            std::to_string(res->status));
+            }
+
+            unsigned int delay_ms = initial_delay_ms;
+            for (unsigned int i = 0; i < attempt; ++i) {
+                delay_ms = static_cast<unsigned int>(delay_ms * backoff);
+            }
+
             LOG_DEBUG("MORK transient HTTP " << res->status << " at " << path << ", retrying (attempt "
                                              << attempt + 1 << "/" << max_attempts << ")");
             Utils::sleep(delay_ms);
-            delay_ms *= 2;
             continue;
         }
 
@@ -101,7 +112,8 @@ httplib::Result MorkClient::send_request(const string& method, const string& pat
                     std::to_string(res->status));
     }
 
-    RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": exhausted retries");
+    RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": exhausted " +
+                std::to_string(max_attempts) + " retries");
 }
 
 string MorkClient::url_encode(const string& value) {

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -21,6 +21,17 @@ using namespace atoms;
 using namespace commons;
 using namespace metta;
 
+namespace {
+
+bool is_transient_mork_http_status(int status) {
+    // MORK returns 401 when a path is temporarily locked by a concurrent request, and 409 for
+    // PathForbiddenTemporary. Both are expected under parallel test load and should be retried.
+    return status == httplib::StatusCode::Unauthorized_401 ||
+           status == httplib::StatusCode::Conflict_409;
+}
+
+}  // namespace
+
 // --> MorkClient
 MorkClient::MorkClient(const string& base_url)
     : base_url_(Utils::trim(base_url)), cli(httplib::Client(base_url_)) {
@@ -54,25 +65,43 @@ string MorkClient::clear(const string& pattern) {
 }
 
 httplib::Result MorkClient::send_request(const string& method, const string& path, const string& data) {
-    httplib::Result res;
+    const unsigned int max_attempts = 16;
+    unsigned int delay_ms = 5;
 
-    if (method == "GET") {
-        res = this->cli.Get(path);
-    } else if (method == "POST") {
-        if (data.empty()) {
-            RAISE_ERROR("POST request data is empty. Cannot send an empty payload to MORK server.");
+    for (unsigned int attempt = 0; attempt < max_attempts; ++attempt) {
+        httplib::Result res;
+
+        if (method == "GET") {
+            res = this->cli.Get(path);
+        } else if (method == "POST") {
+            if (data.empty()) {
+                RAISE_ERROR("POST request data is empty. Cannot send an empty payload to MORK server.");
+            }
+            res = this->cli.Post(path, data, "text/plain");
         }
-        res = this->cli.Post(path, data, "text/plain");
-    }
 
-    if (!res) {
-        RAISE_ERROR("Connection error at http://" + this->base_url_ + path + ": " +
-                    httplib::to_string(res.error()));
-    } else if (res->status != httplib::StatusCode::OK_200) {
+        if (!res) {
+            RAISE_ERROR("Connection error at http://" + this->base_url_ + path + ": " +
+                        httplib::to_string(res.error()));
+        }
+
+        if (res->status == httplib::StatusCode::OK_200) {
+            return res;
+        }
+
+        if (is_transient_mork_http_status(res->status) && attempt + 1 < max_attempts) {
+            LOG_DEBUG("MORK transient HTTP " << res->status << " at " << path << ", retrying (attempt "
+                                             << attempt + 1 << "/" << max_attempts << ")");
+            Utils::sleep(delay_ms);
+            delay_ms *= 2;
+            continue;
+        }
+
         RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": status " +
                     std::to_string(res->status));
     }
-    return res;
+
+    RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": exhausted retries");
 }
 
 string MorkClient::url_encode(const string& value) {

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -100,7 +100,7 @@ httplib::Result MorkClient::send_request(const string& method, const string& pat
                 delay_ms = static_cast<unsigned int>(delay_ms * backoff);
             }
 
-            LOG_DEBUG("MORK transient HTTP " << res->status << " at " << path << ", retrying (attempt "
+            LOG_ERROR("MORK transient HTTP " << res->status << " at " << path << ", retrying (attempt "
                                              << attempt + 1 << "/" << max_attempts << ")");
             Utils::sleep(delay_ms);
             continue;

--- a/src/scripts/docker_image_build_mork.sh
+++ b/src/scripts/docker_image_build_mork.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
 # Usage: ./docker_image_build_mork.sh <version>
-VERSION="${VERSION:-0.10.2}"
+VERSION="${VERSION:-1.1.0}"
 
 docker buildx build -t trueagi/das:mork-server-${VERSION} --load -f src/docker/mork/Dockerfile.server .
 docker buildx build -t trueagi/das:mork-loader-${VERSION} --load -f src/docker/mork/Dockerfile.loader .

--- a/src/scripts/mork_loader.sh
+++ b/src/scripts/mork_loader.sh
@@ -9,7 +9,7 @@ else
     FILE=$1
 fi
 
-IMAGE_NAME="trueagi/das:mork-loader-1.0.0"
+IMAGE_NAME="trueagi/das:mork-loader-1.1.0"
 CONTAINER_NAME="das-mork-loader-$(date +%Y%m%d%H%M%S)"
 
 docker run --rm \

--- a/src/scripts/mork_server.sh
+++ b/src/scripts/mork_server.sh
@@ -2,7 +2,7 @@
 
 set -eoux pipefail
 
-IMAGE_NAME="trueagi/das:mork-server-1.0.4"
+IMAGE_NAME="trueagi/das:mork-server-1.1.0"
 CONTAINER_NAME="das-mork-server-$(date +%Y%m%d%H%M%S)"
 
 docker run --rm \

--- a/src/scripts/mork_server.sh
+++ b/src/scripts/mork_server.sh
@@ -2,7 +2,7 @@
 
 set -eoux pipefail
 
-IMAGE_NAME="trueagi/das:mork-server-1.0.0"
+IMAGE_NAME="trueagi/das:mork-server-1.0.4"
 CONTAINER_NAME="das-mork-server-$(date +%Y%m%d%H%M%S)"
 
 docker run --rm \

--- a/src/scripts/regression_test.sh
+++ b/src/scripts/regression_test.sh
@@ -10,7 +10,7 @@ DAS_MORK_HOSTNAME=0.0.0.0
 DAS_MORK_PORT=40022
 
 MONGODB_IMAGE=mongodb/mongodb-community-server:8.2-ubuntu2204
-MORK_IMAGE=trueagi/das:mork-server-1.0.5
+MORK_IMAGE=trueagi/das:mork-server-1.1.0
 POSTGRES_IMAGE=postgres:15
 
 ARCH=$(uname -m)

--- a/src/scripts/test_all_setup.sh
+++ b/src/scripts/test_all_setup.sh
@@ -17,9 +17,9 @@ DAS_MORK_PORT=40022
 REDIS_IMAGE=redis:7.2.3-alpine
 MONGODB_IMAGE=mongodb/mongodb-community-server:8.2-ubuntu2204
 METTA_LOADER_IMAGE=trueagi/das:1.0.0-metta-parser
-MORK_IMAGE=trueagi/das:mork-server-1.0.4
-MORK_LOADER_IMAGE=trueagi/das:mork-loader-1.0.4
-MORK_SERVER_IMAGE=trueagi/das:mork-server-1.0.4
+MORK_IMAGE=trueagi/das:mork-server-1.1.0
+MORK_LOADER_IMAGE=trueagi/das:mork-loader-1.1.0
+MORK_SERVER_IMAGE=trueagi/das:mork-server-1.1.0
 POSTGRES_IMAGE=postgres:15
 
 ANIMALS_FILE=/tmp/animals.metta

--- a/src/tests/assets/adapterdb_config.json
+++ b/src/tests/assets/adapterdb_config.json
@@ -82,7 +82,7 @@
             "image": "trueagi/das:1.0.0-metta-parser"
         },
         "morkdb": {
-            "image": "trueagi/das:mork-loader-1.0.4"
+            "image": "trueagi/das:mork-loader-1.1.0"
         }
     },
     "agents": {

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -823,7 +823,6 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
-    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//tests/cpp/test_commons:mock_animals_data_lib",
@@ -990,7 +989,6 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
-    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//db_adapter:db_adapter_lib",
@@ -1021,7 +1019,6 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
-    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//db_adapter:db_adapter_lib",

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -823,6 +823,7 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
+    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//tests/cpp/test_commons:mock_animals_data_lib",
@@ -989,6 +990,7 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
+    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//db_adapter:db_adapter_lib",
@@ -1019,6 +1021,7 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
+    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//db_adapter:db_adapter_lib",

--- a/src/tests/cpp/adapterdb_test.cc
+++ b/src/tests/cpp/adapterdb_test.cc
@@ -33,14 +33,11 @@ struct AdapterTestParams {
     string test_name;
 };
 
-class AdapterDBTestEnvironment : public ::testing::Environment {
-   public:
-    void SetUp() override {
-        auto mork_client = make_shared<MorkClient>("localhost:40022");
-        mork_client->post("(Similarity \"ent\" \"human\")");
-        mork_client->post("(Inheritance \"human\" \"mammal\")");
-    }
-};
+void seed_mork_adapter_test_data() {
+    auto mork_client = make_shared<MorkClient>("localhost:40022");
+    mork_client->post("(Similarity \"ent\" \"human\")");
+    mork_client->post("(Inheritance \"human\" \"mammal\")");
+}
 
 class AdapterDBTestBase : public ::testing::Test {
    protected:
@@ -111,6 +108,10 @@ class AdapterDBTest : public AdapterDBTestBase, public ::testing::WithParamInter
         file << comment;
         file << p.mapping_file_content;
         file.close();
+
+        if (p.adapter_type == "mork") {
+            seed_mork_adapter_test_data();
+        }
     }
 
     void TearDown() override { remove(mapping_file_path.c_str()); }
@@ -525,6 +526,5 @@ TEST_F(AdapterDBConstructorFailureTest, ConstructorFailsWhenMappingFileDoesNotEx
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    ::testing::AddGlobalTestEnvironment(new AdapterDBTestEnvironment());
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/adapterdb_test.cc
+++ b/src/tests/cpp/adapterdb_test.cc
@@ -34,11 +34,27 @@ struct AdapterTestParams {
 };
 
 void seed_mork_adapter_test_data() {
+    static bool seeded = false;
+    if (seeded) {
+        return;
+    }
+
     auto mork_client = make_shared<MorkClient>("localhost:40022");
-    mork_client->clear("(Similarity \"ent\" $h)");
-    mork_client->clear("(Inheritance \"human\" $m)");
-    mork_client->post("(Similarity \"ent\" \"human\")");
-    mork_client->post("(Inheritance \"human\" \"mammal\")");
+
+    const string similarity_query = "(Similarity \"ent\" $h)";
+    const string inheritance_query = "(Inheritance \"human\" $m)";
+
+    const auto similarity_results = mork_client->get(similarity_query, similarity_query);
+    const auto inheritance_results = mork_client->get(inheritance_query, inheritance_query);
+
+    if (similarity_results.empty()) {
+        mork_client->post("(Similarity \"ent\" \"human\")");
+    }
+    if (inheritance_results.empty()) {
+        mork_client->post("(Inheritance \"human\" \"mammal\")");
+    }
+
+    seeded = true;
 }
 
 class AdapterDBTestBase : public ::testing::Test {

--- a/src/tests/cpp/adapterdb_test.cc
+++ b/src/tests/cpp/adapterdb_test.cc
@@ -48,8 +48,6 @@ void seed_mork_adapter_test_data() {
     if (inheritance_results.empty()) {
         mork_client->post(inheritance_seed);
     }
-
-    seeded = true;
 }
 
 class AdapterDBTestBase : public ::testing::Test {

--- a/src/tests/cpp/adapterdb_test.cc
+++ b/src/tests/cpp/adapterdb_test.cc
@@ -34,24 +34,19 @@ struct AdapterTestParams {
 };
 
 void seed_mork_adapter_test_data() {
-    static bool seeded = false;
-    if (seeded) {
-        return;
-    }
-
     auto mork_client = make_shared<MorkClient>("localhost:40022");
 
-    const string similarity_query = "(Similarity \"ent\" $h)";
-    const string inheritance_query = "(Inheritance \"human\" $m)";
+    const string similarity_seed = "(Similarity \"ent\" \"human\")";
+    const string inheritance_seed = "(Inheritance \"human\" \"mammal\")";
 
-    const auto similarity_results = mork_client->get(similarity_query, similarity_query);
-    const auto inheritance_results = mork_client->get(inheritance_query, inheritance_query);
+    const auto similarity_results = mork_client->get(similarity_seed, similarity_seed);
+    const auto inheritance_results = mork_client->get(inheritance_seed, inheritance_seed);
 
     if (similarity_results.empty()) {
-        mork_client->post("(Similarity \"ent\" \"human\")");
+        mork_client->post(similarity_seed);
     }
     if (inheritance_results.empty()) {
-        mork_client->post("(Inheritance \"human\" \"mammal\")");
+        mork_client->post(inheritance_seed);
     }
 
     seeded = true;

--- a/src/tests/cpp/adapterdb_test.cc
+++ b/src/tests/cpp/adapterdb_test.cc
@@ -35,6 +35,8 @@ struct AdapterTestParams {
 
 void seed_mork_adapter_test_data() {
     auto mork_client = make_shared<MorkClient>("localhost:40022");
+    mork_client->clear("(Similarity \"ent\" $h)");
+    mork_client->clear("(Inheritance \"human\" $m)");
     mork_client->post("(Similarity \"ent\" \"human\")");
     mork_client->post("(Inheritance \"human\" \"mammal\")");
 }


### PR DESCRIPTION
Fixes intermittent adapterdb_test failures in CI caused by HTTP 401 from the MORK server when tests run in parallel and contend for the same path.

- Add retry with exponential backoff to MorkClient for transient 401/409 responses
- Update MORK Docker images from 1.0.4/1.0.5 to 1.1.0 across test and setup scripts