### PR TITLE
[FIX] Pipeline being triggered by individual commits

### DIFF
--- a/.github/workflows/run-code-quality-and-tests.yml
+++ b/.github/workflows/run-code-quality-and-tests.yml
@@ -17,14 +17,6 @@ on:
 
   workflow_dispatch:
 
-  push:
-
-    paths:
-      - '**/*.h'
-      - '**/*.cc'
-      - '**/*.bazel'
-      - '**/BUILD'
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
- Removed 'on push' section from workflow, was causing pipelines to be triggered by individual commits