### PR TITLE
Improve CI

### DIFF
--- a/.github/scripts/bazel_build.sh
+++ b/.github/scripts/bazel_build.sh
@@ -58,15 +58,7 @@ BAZELISK_BUILD_CMD="${BAZELISK_CMD} build --noshow_progress --strategy=CppCompil
 BAZELISK_RUN_CMD="${BAZELISK_CMD} run"
 
 BAZEL_BINARY_TARGETS=(
-  "//:word_query"
-  "//:word_query_evolution"
-  "//:attention_broker_service"
-  "//:attention_broker_client"
-  "//:das"
-  "//:db_loader"
-  "//:busnode"
-  "//:busclient"
-  "//:database_adapter"
+  "//:ci_binaries"
 )
 
 BAZEL_BINARY_OUTPUTS=(

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -54,22 +54,29 @@ jobs:
       - name: Loading Load Knowledge Base
         run: das-cli metta load /tmp/animals.metta
 
-      - name: Setup bazel
-        run: .github/scripts/setup_bazel.sh
-
-      - name: Compile Binaries
-        run: .github/scripts/bazel_build.sh
-
       - name: Starting Attention Broker
         run: das-cli attention-broker restart
 
-      - name: Starting MORK Server and Load Knowledge Base
+      - name: Starting MORK Servers
         run: |-
-          make run-mork-server > /dev/null 2>&1 &
-          
-          until curl --silent http://localhost:40022/status/-; do
-            echo "Waiting MORK…"
-            sleep 1
+          make run-mork-server &
+          DAS_MORK_PORT=40032 make run-mork-server &
+          wait
+
+          for port in 40022 40032; do
+            for attempt in $(seq 1 60); do
+              if curl --silent "http://localhost:${port}/status/-"; then
+                echo "MORK ready on port ${port}"
+                break
+              fi
+              if [[ "${attempt}" -eq 60 ]]; then
+                echo "MORK failed to start on port ${port}" >&2
+                docker ps -a --filter "name=das-mork-server-${port}" >&2
+                exit 1
+              fi
+              echo "Waiting for MORK on port ${port}…"
+              sleep 1
+            done
           done
 
       - name: Starting Postgres Server and load database
@@ -87,5 +94,13 @@ jobs:
           
           docker exec -i pg_test psql -U postgres -d postgres_wrapper_test < src/scripts/postgres_setup.sql
 
+      - name: Setup bazel
+        run: .github/scripts/setup_bazel.sh
+
       - name: Execute Unit Test Suite
-        run: make run-tests-only
+        working-directory: ./src
+        run: ./scripts/bazel_exec.sh test --show_progress --cache_test_results=no //tests/cpp/...
+
+      - name: Build production binaries
+        working-directory: ./src
+        run: ./scripts/bazel_exec.sh build --noshow_progress //:ci_binaries

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -59,19 +59,31 @@ jobs:
 
       - name: Starting MORK Servers
         run: |-
+          set -euo pipefail
+
           make run-mork-server &
+          pid_40022=$!
           DAS_MORK_PORT=40032 make run-mork-server &
-          wait
+          pid_40032=$!
+
+          launch_failed=0
+          wait "${pid_40022}" || launch_failed=1
+          wait "${pid_40032}" || launch_failed=1
+          if [[ "${launch_failed}" -ne 0 ]]; then
+            echo "MORK server launch failed" >&2
+            docker ps -a --filter "name=das-mork-server-" >&2 || true
+            exit 1
+          fi
 
           for port in 40022 40032; do
             for attempt in $(seq 1 60); do
-              if curl --silent "http://localhost:${port}/status/-"; then
+              if curl --fail --silent --show-error "http://localhost:${port}/status/-"; then
                 echo "MORK ready on port ${port}"
                 break
               fi
               if [[ "${attempt}" -eq 60 ]]; then
                 echo "MORK failed to start on port ${port}" >&2
-                docker ps -a --filter "name=das-mork-server-${port}" >&2
+                docker ps -a --filter "name=das-mork-server-${port}" >&2 || true
                 exit 1
               fi
               echo "Waiting for MORK on port ${port}…"

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,14 @@ test-agents-integration:
 run-tests-only:
 	@$(MAKE) bazel 'test --show_progress --cache_test_results=no //tests/...'
 
+build-ci-binaries:
+	@cd src && ./scripts/bazel_exec.sh build --noshow_progress //:ci_binaries
+
+run-tests-native:
+	@cd src && ./scripts/bazel_exec.sh test --show_progress --cache_test_results=no //tests/cpp/...
+
+ci-unit-tests: run-tests-native build-ci-binaries
+
 lint-all:
 	@$(MAKE) bazel lint \
 		"//... --fix --report --diff" \

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -10,7 +10,7 @@ common --curses=yes
 # common --show_timestamps
 
 # Use half of all available CPU cores
-common --jobs=HOST_CPUS*0.5
+common --jobs=HOST_CPUS*0.85
 
 # Enable bazel bzlmod (for Bazel 8+)
 common --enable_bzlmod

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -9,7 +9,7 @@ common --color=yes
 common --curses=yes
 # common --show_timestamps
 
-# Use half of all available CPU cores
+# Use 85% all available CPU cores
 common --jobs=HOST_CPUS*0.85
 
 # Enable bazel bzlmod (for Bazel 8+)
@@ -45,8 +45,8 @@ build --host_cxxopt=-w
 build --host_cxxopt=-Wno-all
 
 #################################### TEST #####################################
-# Use half of all available CPU cores
-# test --jobs=HOST_CPUS*0.5
+# Use 85% of all available CPU cores
+# test --jobs=HOST_CPUS*0.85
 
 # Other options
 test --test_output=errors

--- a/src/BUILD
+++ b/src/BUILD
@@ -215,3 +215,23 @@ cc_binary(
         "//main:bus_client_lib",
     ],
 )
+
+# Meta-target for CI: building this forces all production binaries to compile/link.
+# Used by .github/workflows/run-unit-tests.yml and bazel_build.sh.
+genrule(
+    name = "ci_binaries",
+    srcs = [
+        ":word_query",
+        ":word_query_evolution",
+        ":attention_broker_service",
+        ":attention_broker_client",
+        ":das",
+        ":db_loader",
+        ":busnode",
+        ":busclient",
+        ":database_adapter",
+    ],
+    outs = ["ci_binaries.stamp"],
+    cmd = "touch $@",
+    visibility = ["//visibility:public"],
+)

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -79,20 +79,12 @@ httplib::Result MorkClient::send_request(const string& method, const string& pat
             res = this->cli.Post(path, data, "text/plain");
         }
 
-        if (!res) {
-            RAISE_ERROR("Connection error at http://" + this->base_url_ + path + ": " +
-                        httplib::to_string(res.error()));
-        }
+        if (!res || is_transient_mork_http_status(res->status)) {
+            string status_str = res ? std::to_string(res->status) : "unknown";
 
-        if (res->status == httplib::StatusCode::OK_200) {
-            return res;
-        }
-
-        if (is_transient_mork_http_status(res->status)) {
             if (attempt + 1 >= max_attempts) {
                 RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": exhausted " +
-                            std::to_string(max_attempts) + " retries, last status " +
-                            std::to_string(res->status));
+                            std::to_string(max_attempts) + " retries, last status " + status_str);
             }
 
             unsigned int delay_ms = initial_delay_ms;
@@ -100,10 +92,14 @@ httplib::Result MorkClient::send_request(const string& method, const string& pat
                 delay_ms = static_cast<unsigned int>(delay_ms * backoff);
             }
 
-            LOG_ERROR("MORK transient HTTP " << res->status << " at " << path << ", retrying (attempt "
+            LOG_ERROR("MORK transient HTTP " << status_str << " at " << path << ", retrying (attempt "
                                              << attempt + 1 << "/" << max_attempts << ")");
             Utils::sleep(delay_ms);
             continue;
+        }
+
+        if (res->status == httplib::StatusCode::OK_200) {
+            return res;
         }
 
         RAISE_ERROR("Http error at http://" + this->base_url_ + path + ": status " +

--- a/src/scripts/mork_server.sh
+++ b/src/scripts/mork_server.sh
@@ -1,20 +1,16 @@
 #!/bin/bash
 
-set -eoux pipefail
+set -euo pipefail
 
 IMAGE_NAME="trueagi/das:mork-server-1.1.0"
-CONTAINER_NAME="das-mork-server-$(date +%Y%m%d%H%M%S)"
+MORK_PORT="${DAS_MORK_PORT:-40022}"
+CONTAINER_NAME="das-mork-server-${MORK_PORT}"
 
-docker run --rm \
+docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
+
+docker run -d --rm \
     --name="${CONTAINER_NAME}" \
     --network host \
     -e MORK_SERVER_ADDR=0.0.0.0 \
-    -e MORK_SERVER_PORT=${DAS_MORK_PORT:-40022} \
+    -e MORK_SERVER_PORT="${MORK_PORT}" \
     "${IMAGE_NAME}" "$@"
-
-sleep 1
-
-if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-  echo "Removing existing container: ${CONTAINER_NAME}"
-  _=$(docker rm -f "${CONTAINER_NAME}" 2>&1 > /dev/null || true)
-fi

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -942,7 +942,7 @@ cc_test(
 
 cc_test(
     name = "postgreswrapper_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "postgreswrapper_test.cc",
     ],
@@ -971,7 +971,7 @@ cc_test(
 
 cc_test(
     name = "morkwrapper_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "morkwrapper_test.cc",
     ],
@@ -1001,7 +1001,7 @@ cc_test(
 
 cc_test(
     name = "adapterdb_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "adapterdb_test.cc",
     ],

--- a/src/tests/cpp/adapterdb_test.cc
+++ b/src/tests/cpp/adapterdb_test.cc
@@ -34,7 +34,7 @@ struct AdapterTestParams {
 };
 
 void seed_mork_adapter_test_data() {
-    auto mork_client = make_shared<MorkClient>("localhost:40022");
+    auto mork_client = make_shared<MorkClient>("localhost:40032");
 
     const string similarity_seed = "(Similarity \"ent\" \"human\")";
     const string inheritance_seed = "(Inheritance \"human\" \"mammal\")";
@@ -192,7 +192,7 @@ static const AdapterTestParams MorkParams = {
     R"(
 (Similarity "ent" $h)
 (Inheritance "human" $m))",
-    {{"host", "localhost"}, {"port", 40022}},
+    {{"host", "localhost"}, {"port", 40032}},
     "Mork",
 };
 

--- a/src/tests/cpp/morkdb_test.cc
+++ b/src/tests/cpp/morkdb_test.cc
@@ -125,7 +125,7 @@ TEST_F(MorkDBTest, QueryForTargets) {
 }
 
 TEST_F(MorkDBTest, ConcurrentQueryForPattern) {
-    const int num_threads = 200;
+    const int num_threads = 8;
     vector<thread> threads;
     atomic<int> success_count{0};
 
@@ -301,7 +301,7 @@ TEST_F(MorkDBTest, ConcurrentAddLinks) {
     int arity = 3;
     int chunck_size = 500;
 
-    const int num_threads = 100;
+    const int num_threads = 8;
     vector<thread> threads;
     atomic<int> success_count{0};
 

--- a/src/tests/cpp/morkwrapper_test.cc
+++ b/src/tests/cpp/morkwrapper_test.cc
@@ -35,7 +35,7 @@ using namespace processor;
 class MorkWrapperTest : public ::testing::Test {
    protected:
     string TEST_HOST = "localhost";
-    int TEST_PORT = 40022;
+    int TEST_PORT = 40032;
 
     string INVALID_HOST = "invalid.host";
     int INVALID_PORT = 99999;

--- a/src/tests/integration/cpp/BUILD
+++ b/src/tests/integration/cpp/BUILD
@@ -11,6 +11,7 @@ cc_test(
         "-Iexternal/gtest/googletest",
     ],
     linkstatic = 1,
+    tags = ["integration"],
     deps = [
         "//tests/integration/cpp/helpers:process_helper",
         "//tests/integration/cpp/helpers:test_helper",


### PR DESCRIPTION
## Summary

Speeds up and stabilizes the self-hosted unit-test CI pipeline by running Bazel natively on the runner (instead of inside `das-builder` Docker), failing fast on test regressions, and fixing MORK server orchestration for parallel test workloads.

- **Native Bazel in CI** — `bazel_exec.sh` on the host after `setup_bazel.sh`; drops `bazel_build.sh` + `make run-tests-only` (Docker round-trip) from the unit-test workflow.
- **`//:ci_binaries` meta-target** — single Bazel target that forces all production binaries to compile/link; shared by CI and `bazel_build.sh` (publish workflow).
- **Fail-fast ordering** — run `//tests/cpp/...` first, then `//:ci_binaries` (reuses Bazel cache from the test build).
- **Dual MORK servers** — ports `40022` (morkdb) and `40032` (adapterdb / morkwrapper); fixed `mork_server.sh` to run detached with stable per-port container names.
- **Test scope** — unit CI runs `//tests/cpp/...` only; integration tests stay tagged and excluded (they require `/opt/das` Docker layout).

## CI workflow changes (`run-unit-tests.yml`)

| Before | After |
|--------|-------|
| `bazel_build.sh` (full packaging script) | Removed from unit-test job |
| `make run-tests-only` → Docker `das-builder` | `./scripts/bazel_exec.sh test //tests/cpp/...` on host |
| Single MORK on 40022 | MORK on 40022 + 40032 |
| Binaries built before tests | Tests first, then `//:ci_binaries` |
| Bazel setup before services | Services first, Bazel setup just before compile/test |

## Other changes

- **`src/BUILD`** — `ci_binaries` genrule listing all production `cc_binary` / shared-lib targets.
- **`Makefile`** — `build-ci-binaries`, `run-tests-native`, `ci-unit-tests` for local parity with CI.
- **`src/.bazelrc`** — `--jobs=HOST_CPUS*0.85` (was `0.5`) on dedicated baremetal runners.
- **`mork_server.sh`** — `docker run -d`, container name `das-mork-server-${PORT}`, remove stale container before start.
- **`MorkDB.cc`** — retry on connection failures alongside transient HTTP 401/409.
- **Tests** — `adapterdb_test` / `morkwrapper_test` use MORK port 40032; reduce `morkdb_test` thread counts; bump `adapterdb`, `morkwrapper`, `postgreswrapper` test size to `medium`.
- **`inference_integration_test`** — tagged `integration`.

## Why native Bazel?

`setup_bazel.sh` already installs Bazelisk (`/opt/bazel/bazelisk`) and native deps (hiredis, mongocxx, libpqxx, httplib) on self-hosted runners — the same toolchain baked into `das-builder`. Running tests through Docker duplicated compilation and required `/opt/das` bind mounts that integration tests depended on. Unit tests only need the host toolchain + service fixtures (Redis, Mongo, MORK, Postgres).
