### PR TITLE
Add `AtomDB::composite_type_enabled()`

### DIFF
--- a/config/das.json
+++ b/config/das.json
@@ -1,6 +1,7 @@
 {
     "atomdb": {
         "type": "redismongodb",
+        "composite_type_enabled": true,
         "redis": {
             "image": "redis:7.2.3-alpine",
             "endpoint": "localhost:40020",
@@ -51,6 +52,7 @@
             },
             "atomdb_backend": {
                 "type": "morkdb",
+                "composite_type_enabled": true,
                 "mongodb": {
                     "endpoint": "localhost:40021",
                     "username": "admin",
@@ -78,6 +80,7 @@
             {
                 "uid": "peer1",
                 "type": "redismongodb",
+                "composite_type_enabled": true,
                 "context": "remotedb_test_peer1_",
                 "mongodb": {
                     "endpoint": "localhost:40021",
@@ -90,6 +93,7 @@
                 },
                 "local_persistence": {
                     "type": "morkdb",
+                    "composite_type_enabled": true,
                     "context": "remotedb_test_peer1_local_",
                     "mongodb": {
                         "endpoint": "localhost:40021",

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -21,6 +21,7 @@ class AtomDB : public HandleDecoder {
     virtual ~AtomDB() = default;
 
     virtual bool allow_nested_indexing() = 0;
+    virtual bool composite_type_enabled() const = 0;
 
     virtual shared_ptr<Atom> get_atom(const string& handle) = 0;  // HandleDecoder interface
     virtual shared_ptr<Node> get_node(const string& handle) = 0;

--- a/src/atomdb/adapterdb/AdapterDB.cc
+++ b/src/atomdb/adapterdb/AdapterDB.cc
@@ -67,6 +67,11 @@ bool AdapterDB::allow_nested_indexing() {
     return this->atomdb_backend->allow_nested_indexing();
 }
 
+bool AdapterDB::composite_type_enabled() const {
+    this->ensure_backend_ready();
+    return this->atomdb_backend->composite_type_enabled();
+}
+
 shared_ptr<Atom> AdapterDB::get_atom(const string& handle) {
     this->ensure_backend_ready();
     return this->atomdb_backend->get_atom(handle);

--- a/src/atomdb/adapterdb/AdapterDB.h
+++ b/src/atomdb/adapterdb/AdapterDB.h
@@ -56,6 +56,7 @@ class AdapterDB : public AtomDB {
     // ------------------------------------------------------------------
 
     bool allow_nested_indexing() override;
+    bool composite_type_enabled() const override;
 
     shared_ptr<Atom> get_atom(const string& handle) override;
     shared_ptr<Node> get_node(const string& handle) override;

--- a/src/atomdb/inmemorydb/InMemoryDB.h
+++ b/src/atomdb/inmemorydb/InMemoryDB.h
@@ -22,6 +22,7 @@ class InMemoryDB : public AtomDB {
     ~InMemoryDB();
 
     bool allow_nested_indexing() override;
+    bool composite_type_enabled() const override { return false; }
 
     shared_ptr<Atom> get_atom(const string& handle) override;
     shared_ptr<Node> get_node(const string& handle) override;

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -217,7 +217,7 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
                                  bool throw_if_exists,
                                  bool is_transactional) {
     if (links.empty()) {
-        if (is_transactional) {
+        if (this->composite_type_enabled() && is_transactional) {
             lock_guard<mutex> composite_type_hashes_map_lock(this->composite_type_hashes_map_mutex);
             this->composite_type_hashes_map.clear();
         }
@@ -240,11 +240,11 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
 
     map<string, vector<string>> composite_type_entries_map;
     map<string, string> composite_type_hashes_map_copy;
-    if (is_transactional) {
+    if (this->composite_type_enabled() && is_transactional) {
         this->build_composite_type_entries_map(links, composite_type_entries_map);
         lock_guard<mutex> composite_type_hashes_map_lock(this->composite_type_hashes_map_mutex);
         composite_type_hashes_map_copy = this->composite_type_hashes_map;
-    } else {
+    } else if (!is_transactional) {
         this->check_existing_targets(links);
     }
 
@@ -270,7 +270,11 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
         }
 
         shared_ptr<atomdb_api_types::MongodbDocument> mongodb_doc;
-        if (is_transactional) {
+        if (!this->composite_type_enabled()) {
+            static const vector<string> empty_composite_type;
+            mongodb_doc =
+                make_shared<atomdb_api_types::MongodbDocument>(link, "", empty_composite_type, false);
+        } else if (is_transactional) {
             mongodb_doc = make_shared<atomdb_api_types::MongodbDocument>(
                 link,
                 composite_type_hashes_map_copy[link_handle],
@@ -292,7 +296,7 @@ vector<string> MorkDB::add_links(const vector<atoms::Link*>& links,
         this->mork_client->post(metta_expressions, "$x", "$x");
     }
 
-    if (is_transactional) {
+    if (this->composite_type_enabled() && is_transactional) {
         lock_guard<mutex> composite_type_hashes_map_lock(this->composite_type_hashes_map_mutex);
         this->composite_type_hashes_map.clear();
     }

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -33,7 +33,10 @@ string RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::size];
 uint RedisMongoDB::MONGODB_CHUNK_SIZE;
 
 RedisMongoDB::RedisMongoDB(const string& context, bool skip_redis, const JsonConfig& config)
-    : context(context), skip_redis_(skip_redis), cluster_flag(false) {
+    : context(context),
+      skip_redis_(skip_redis),
+      composite_type_enabled_(config.at_path("composite_type_enabled").get_or<bool>(true)),
+      cluster_flag(false) {
     initialize_statics(context);
     mongodb_setup(config);
     load_pattern_index_schema();
@@ -855,7 +858,7 @@ vector<string> RedisMongoDB::add_nodes(const vector<atoms::Node*>& nodes,
         auto mongodb_doc = atomdb_api_types::MongodbDocument(node);
         documents.push_back(mongodb_doc.value());
         handles.push_back(node->handle());
-        if (is_transactional) {
+        if (this->composite_type_enabled_ && is_transactional) {
             lock_guard<mutex> composite_type_hashes_map_lock(this->composite_type_hashes_map_mutex);
             this->composite_type_hashes_map[node->handle()] = node->named_type_hash();
         }
@@ -880,7 +883,7 @@ vector<string> RedisMongoDB::add_links(const vector<atoms::Link*>& links,
                                        bool throw_if_exists,
                                        bool is_transactional) {
     if (links.empty()) {
-        if (is_transactional) {
+        if (this->composite_type_enabled_ && is_transactional) {
             lock_guard<mutex> composite_type_hashes_map_lock(this->composite_type_hashes_map_mutex);
             this->composite_type_hashes_map.clear();
         }
@@ -902,9 +905,9 @@ vector<string> RedisMongoDB::add_links(const vector<atoms::Link*>& links,
     }
 
     map<string, vector<string>> composite_type_entries_map;
-    if (is_transactional) {
+    if (this->composite_type_enabled_ && is_transactional) {
         this->build_composite_type_entries_map(links, composite_type_entries_map);
-    } else {
+    } else if (!is_transactional) {
         this->check_existing_targets(links);
     }
 
@@ -940,7 +943,11 @@ vector<string> RedisMongoDB::add_links(const vector<atoms::Link*>& links,
         }
 
         shared_ptr<atomdb_api_types::MongodbDocument> mongodb_doc;
-        if (is_transactional) {
+        if (!this->composite_type_enabled_) {
+            static const vector<string> empty_composite_type;
+            mongodb_doc =
+                make_shared<atomdb_api_types::MongodbDocument>(link, "", empty_composite_type, false);
+        } else if (is_transactional) {
             string composite_type_hash =
                 Hasher::composite_handle(composite_type_entries_map[link_handle]);
             mongodb_doc = make_shared<atomdb_api_types::MongodbDocument>(
@@ -978,7 +985,7 @@ vector<string> RedisMongoDB::add_links(const vector<atoms::Link*>& links,
     set_next_score_with_context(
         ctx, REDIS_INCOMING_PREFIX + ":next_score", this->incoming_set_next_score.load());
 
-    if (is_transactional) {
+    if (this->composite_type_enabled_ && is_transactional) {
         lock_guard<mutex> composite_type_hashes_map_lock(this->composite_type_hashes_map_mutex);
         this->composite_type_hashes_map.clear();
     }

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -32,7 +32,7 @@ class RedisMongoDB : public AtomDB {
     ~RedisMongoDB();
 
     bool allow_nested_indexing() override;
-    bool composite_type_enabled() const { return composite_type_enabled_; }
+    bool composite_type_enabled() const override { return composite_type_enabled_; }
 
     static string REDIS_PATTERNS_PREFIX;
     static string REDIS_OUTGOING_PREFIX;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -32,6 +32,7 @@ class RedisMongoDB : public AtomDB {
     ~RedisMongoDB();
 
     bool allow_nested_indexing() override;
+    bool composite_type_enabled() const { return composite_type_enabled_; }
 
     static string REDIS_PATTERNS_PREFIX;
     static string REDIS_OUTGOING_PREFIX;
@@ -147,6 +148,7 @@ class RedisMongoDB : public AtomDB {
    private:
     string context;
     bool skip_redis_;
+    bool composite_type_enabled_;
     bool cluster_flag;
     RedisContextPool* redis_pool;
     mongocxx::pool* mongodb_pool;

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
@@ -245,12 +245,8 @@ MongodbDocument::MongodbDocument(const atoms::Link* link, HandleDecoder& db) {
 
 MongodbDocument::MongodbDocument(const atoms::Link* link,
                                  const string& composite_type_hash,
-                                 const vector<string>& composite_type) {
-    bsoncxx::builder::basic::array composite_type_array;
-    for (const auto& entry : composite_type) {
-        composite_type_array.append(entry);
-    }
-
+                                 const vector<string>& composite_type,
+                                 bool include_composite_type) {
     bsoncxx::builder::basic::array targets_array;
     for (const auto& target : link->targets) {
         targets_array.append(target);
@@ -259,8 +255,14 @@ MongodbDocument::MongodbDocument(const atoms::Link* link,
     bsoncxx::builder::basic::document doc;
     doc.append(bsoncxx::builder::basic::kvp("_id", link->handle()));
     doc.append(bsoncxx::builder::basic::kvp("is_toplevel", link->is_toplevel));
-    doc.append(bsoncxx::builder::basic::kvp("composite_type_hash", composite_type_hash));
-    doc.append(bsoncxx::builder::basic::kvp("composite_type", composite_type_array));
+    if (include_composite_type) {
+        bsoncxx::builder::basic::array composite_type_array;
+        for (const auto& entry : composite_type) {
+            composite_type_array.append(entry);
+        }
+        doc.append(bsoncxx::builder::basic::kvp("composite_type_hash", composite_type_hash));
+        doc.append(bsoncxx::builder::basic::kvp("composite_type", composite_type_array));
+    }
     doc.append(bsoncxx::builder::basic::kvp("named_type", link->type));
     doc.append(bsoncxx::builder::basic::kvp("named_type_hash", link->named_type_hash()));
     doc.append(bsoncxx::builder::basic::kvp("targets", targets_array));

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
@@ -80,7 +80,8 @@ class MongodbDocument : public AtomDocument {
     MongodbDocument(const atoms::Link* link, HandleDecoder& db);
     MongodbDocument(const atoms::Link* link,
                     const string& composite_type_hash,
-                    const vector<string>& composite_type);
+                    const vector<string>& composite_type,
+                    bool include_composite_type = true);
     ~MongodbDocument();
 
     const char* get(const string& key);

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -76,6 +76,11 @@ RemoteAtomDB::RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers)
 
 RemoteAtomDB::~RemoteAtomDB() = default;
 
+bool RemoteAtomDB::composite_type_enabled() const {
+    RAISE_ERROR("composite_type_enabled() is not supported in RemoteAtomDB");
+    return true;
+}
+
 void RemoteAtomDB::derive_nested_indexing() {
     // Derive the aggregated nested-indexing capability from the peers. A single global boolean
     // cannot describe a heterogeneous result set, so mixed configurations are normalized to the

--- a/src/atomdb/remotedb/RemoteAtomDB.h
+++ b/src/atomdb/remotedb/RemoteAtomDB.h
@@ -28,6 +28,7 @@ class RemoteAtomDB : public AtomDB {
     ~RemoteAtomDB();
 
     bool allow_nested_indexing() override;
+    bool composite_type_enabled() const override;
 
     shared_ptr<Atom> get_atom(const string& handle) override;
     shared_ptr<Node> get_node(const string& handle) override;

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -36,6 +36,10 @@ bool RemoteAtomDBPeer::allow_nested_indexing() {
     return atomdb_ ? atomdb_->allow_nested_indexing() : false;
 }
 
+bool RemoteAtomDBPeer::composite_type_enabled() const {
+    return local_persistence_ && local_persistence_->composite_type_enabled();
+}
+
 shared_ptr<Atom> RemoteAtomDBPeer::get_atom(const string& handle) {
     auto atom = cache_.get_atom(handle);
     if (atom) return atom;

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -29,6 +29,7 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
     ~RemoteAtomDBPeer();
 
     bool allow_nested_indexing() override;
+    bool composite_type_enabled() const override;
 
     shared_ptr<Atom> get_atom(const string& handle) override;
     shared_ptr<Node> get_node(const string& handle) override;
@@ -95,6 +96,8 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
     bool thread_one_step() override;
 
     const string& get_uid() const { return uid_; }
+
+    bool is_readonly() const { return local_persistence_ == nullptr; }
 
    private:
     void feed_cache_from_handle_set(shared_ptr<atomdb_api_types::HandleSet> handle_set);

--- a/src/tests/assets/adapterdb_config.json
+++ b/src/tests/assets/adapterdb_config.json
@@ -20,6 +20,7 @@
             },
             "atomdb_backend": {
                 "type": "morkdb",
+                "composite_type_enabled": true,
                 "mongodb": {
                     "endpoint": "localhost:40021",
                     "username": "admin",
@@ -43,6 +44,7 @@
             {
                 "uid": "peer1",
                 "type": "redismongodb",
+                "composite_type_enabled": true,
                 "context": "remotedb_test_peer1_",
                 "mongodb": {
                     "endpoint": "localhost:40021",
@@ -55,6 +57,7 @@
                 },
                 "local_persistence": {
                     "type": "morkdb",
+                    "composite_type_enabled": true,
                     "context": "remotedb_test_peer1_local_",
                     "mongodb": {
                         "endpoint": "localhost:40021",

--- a/src/tests/assets/remotedb_config_single.json
+++ b/src/tests/assets/remotedb_config_single.json
@@ -3,6 +3,7 @@
         {
             "uid": "single_peer",
             "type": "redismongodb",
+            "composite_type_enabled": true,
             "context": "remotedb_test_single_peer_",
             "redis": {
                 "endpoint": "localhost:40020",

--- a/src/tests/cpp/config_parser_test.cc
+++ b/src/tests/cpp/config_parser_test.cc
@@ -14,6 +14,7 @@ namespace {
 const char* kValidConfigV1 = R"({
   "atomdb": {
     "type": "redismongodb",
+    "composite_type_enabled": true,
     "redis": {
       "port": 40020,
       "hostname": "localhost",
@@ -50,6 +51,8 @@ TEST(ConfigParserTest, GetNestedStructure) {
     auto atomdb = config.at_path("atomdb").get_or<JsonConfig>(JsonConfig());
     string type = atomdb.at_path("type").get_or<string>("");
     EXPECT_EQ(type, "redismongodb");
+    bool composite_type_enabled = atomdb.at_path("composite_type_enabled").get_or<bool>(false);
+    EXPECT_TRUE(composite_type_enabled);
 
     auto redis = atomdb.at_path("redis").get_or<JsonConfig>(JsonConfig());
     long port = redis.at_path("port").get_or<long>(0);

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -1023,6 +1023,71 @@ TEST_F(RedisMongoDBTest, AtomsCount) {
     EXPECT_EQ(db->empty(), false);
 }
 
+TEST_F(RedisMongoDBTest, CompositeTypeEnabledFlag) {
+    EXPECT_TRUE(db->composite_type_enabled());
+
+    auto config_default = test_atomdb_json_config();
+    config_default.erase("composite_type_enabled");
+    auto db_default = make_shared<RedisMongoDB>("test_", false, config_default);
+    EXPECT_TRUE(db_default->composite_type_enabled());
+
+    vector<Node*> enabled_nodes = {new Node("Symbol", "CompositeTypeEnabled-A"),
+                                   new Node("Symbol", "CompositeTypeEnabled-B"),
+                                   new Node("Symbol", "CompositeTypeEnabled-C")};
+    ASSERT_EQ(db->add_nodes(enabled_nodes).size(), 3);
+    auto enabled_link =
+        new Link("Expression",
+                 {enabled_nodes[0]->handle(), enabled_nodes[1]->handle(), enabled_nodes[2]->handle()});
+    string enabled_link_handle = db->add_link(enabled_link);
+    ASSERT_FALSE(enabled_link_handle.empty());
+
+    auto enabled_doc = db->get_atom_document(enabled_link_handle);
+    ASSERT_NE(enabled_doc, nullptr);
+    EXPECT_TRUE(enabled_doc->contains("composite_type_hash"));
+    EXPECT_TRUE(enabled_doc->contains("composite_type"));
+    EXPECT_EQ(string(enabled_doc->get("composite_type_hash")), enabled_link->composite_type_hash(*db));
+    EXPECT_EQ(enabled_doc->get_size("composite_type"), 4);
+
+    auto config_disabled = test_atomdb_json_config();
+    config_disabled["composite_type_enabled"] = false;
+    auto db_disabled = make_shared<RedisMongoDB>("test_", false, config_disabled);
+    EXPECT_FALSE(db_disabled->composite_type_enabled());
+
+    vector<Node*> disabled_nodes = {new Node("Symbol", "CompositeTypeDisabled-A"),
+                                    new Node("Symbol", "CompositeTypeDisabled-B"),
+                                    new Node("Symbol", "CompositeTypeDisabled-C")};
+    ASSERT_EQ(db_disabled->add_nodes(disabled_nodes).size(), 3);
+    auto disabled_link = new Link(
+        "Expression",
+        {disabled_nodes[0]->handle(), disabled_nodes[1]->handle(), disabled_nodes[2]->handle()});
+    string disabled_link_handle = db_disabled->add_link(disabled_link);
+    ASSERT_FALSE(disabled_link_handle.empty());
+
+    auto disabled_doc = db_disabled->get_atom_document(disabled_link_handle);
+    ASSERT_NE(disabled_doc, nullptr);
+    EXPECT_FALSE(disabled_doc->contains("composite_type_hash"));
+    EXPECT_FALSE(disabled_doc->contains("composite_type"));
+
+    vector<Node*> transactional_nodes = {new Node("Symbol", "CompositeTypeDisabledTx-A"),
+                                         new Node("Symbol", "CompositeTypeDisabledTx-B"),
+                                         new Node("Symbol", "CompositeTypeDisabledTx-C")};
+    auto transactional_link = new Link("Expression",
+                                       {transactional_nodes[0]->handle(),
+                                        transactional_nodes[1]->handle(),
+                                        transactional_nodes[2]->handle()});
+    ASSERT_EQ(db_disabled->add_nodes(transactional_nodes, false, true).size(), 3);
+    ASSERT_EQ(db_disabled->add_links({transactional_link}, false, true).size(), 1);
+
+    auto transactional_doc = db_disabled->get_atom_document(transactional_link->handle());
+    ASSERT_NE(transactional_doc, nullptr);
+    EXPECT_FALSE(transactional_doc->contains("composite_type_hash"));
+    EXPECT_FALSE(transactional_doc->contains("composite_type"));
+
+    EXPECT_TRUE(db->delete_atom(enabled_link_handle, true));
+    EXPECT_TRUE(db_disabled->delete_atom(disabled_link_handle, true));
+    EXPECT_TRUE(db_disabled->delete_atom(transactional_link->handle(), true));
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(new RedisMongoDBTestEnvironment());

--- a/src/tests/cpp/test_commons/TestAtomDBJsonConfig.h
+++ b/src/tests/cpp/test_commons/TestAtomDBJsonConfig.h
@@ -11,6 +11,7 @@ namespace atomdb {
 inline commons::JsonConfig test_atomdb_json_config(const string& atomdb_type = "redismongodb") {
     auto json = nlohmann::json();
     json["type"] = atomdb_type;
+    json["composite_type_enabled"] = true;
     json["redis"] = {{"endpoint", "localhost:40020"}, {"cluster", false}};
     json["mongodb"] = {{"endpoint", "localhost:40021"}, {"username", "admin"}, {"password", "admin"}};
     json["morkdb"] = {{"endpoint", "localhost:40022"}};


### PR DESCRIPTION
## Summary

- Add `composite_type_enabled` (default `true`) to AtomDB config and expose it via `AtomDB::composite_type_enabled()`.
- When disabled, RedisMongoDB/MorkDB skip composite-type map/hash logic on add and omit `composite_type` / `composite_type_hash` from link documents.
- Wire the flag through AdapterDB, RemoteAtomDBPeer, and InMemoryDB; cover with unit tests and config fixtures.

## Test plan

- [ ] `bazel test //tests/cpp:redis_mongodb_test --test_filter=RedisMongoDBTest.CompositeTypeEnabledFlag`
- [ ] `bazel test //tests/cpp:config_parser_test --test_filter=ConfigParserTest.GetNestedStructure`
