### PR TITLE
[#1196] Stream query answers as JSON over the Command Router HTTP API

### DIFF
--- a/src/agents/command_router/http_api/BusCommandRouterProxyStreamPoller.cc
+++ b/src/agents/command_router/http_api/BusCommandRouterProxyStreamPoller.cc
@@ -26,7 +26,10 @@ void append_answer_chunk(const shared_ptr<BusCommandRouterProxy>& router_proxy,
                          json& chunk_data) {
     shared_ptr<QueryAnswer> answer;
     while ((answer = router_proxy->pop()) != nullptr) {
-        bool use_metta_output = !answer->metta_expression.empty() || populate_metta_mapping;
+        if (populate_metta_mapping && answer->metta_expression.empty()) {
+            router_proxy->populate_metta_mapping(answer.get());
+        }
+        bool use_metta_output = populate_metta_mapping || !answer->metta_expression.empty();
         chunk_data.push_back(answer->to_json(use_metta_output));
         if (chunk_data.size() >= items_per_chunk) {
             emit_chunk(on_chunk, chunk_data);

--- a/src/agents/command_router/http_api/BusCommandRouterProxyStreamPoller.cc
+++ b/src/agents/command_router/http_api/BusCommandRouterProxyStreamPoller.cc
@@ -9,23 +9,25 @@ using namespace agents;
 
 namespace {
 
-void emit_chunk(const function<void(const vector<string>& chunk)>& on_chunk,
-                vector<string>& chunk_data) {
-    if (!chunk_data.empty() && on_chunk) {
-        on_chunk(chunk_data);
-        chunk_data.clear();
+void emit_chunk(const function<void(const json& chunk)>& on_chunk, json& chunk_data) {
+    if (chunk_data.empty()) {
+        return;
     }
+    if (on_chunk) {
+        on_chunk(chunk_data);
+    }
+    chunk_data = json::array();
 }
 
 void append_answer_chunk(const shared_ptr<BusCommandRouterProxy>& router_proxy,
                          bool populate_metta_mapping,
                          size_t items_per_chunk,
-                         const function<void(const vector<string>& chunk)>& on_chunk,
-                         vector<string>& chunk_data) {
+                         const function<void(const json& chunk)>& on_chunk,
+                         json& chunk_data) {
     shared_ptr<QueryAnswer> answer;
     while ((answer = router_proxy->pop()) != nullptr) {
         bool use_metta_output = !answer->metta_expression.empty() || populate_metta_mapping;
-        chunk_data.push_back(answer->to_string(use_metta_output));
+        chunk_data.push_back(answer->to_json(use_metta_output));
         if (chunk_data.size() >= items_per_chunk) {
             emit_chunk(on_chunk, chunk_data);
         }
@@ -44,7 +46,7 @@ PollStreamResult BusCommandRouterProxyStreamPoller::poll_stream(
     const string& command_type,
     size_t items_per_chunk,
     const function<bool()>& should_abort,
-    const function<void(const vector<string>& chunk)>& on_chunk,
+    const function<void(const json& chunk)>& on_chunk,
     const function<void(const string& error)>& on_error,
     const function<void()>& on_aborted) {
     if (items_per_chunk == 0) {
@@ -94,7 +96,7 @@ PollStreamResult BusCommandRouterProxyStreamPoller::poll_stream(
             return {};
         }
         if (on_chunk) {
-            on_chunk({router_proxy->params_response});
+            on_chunk(json::array({json(router_proxy->params_response)}));
         }
         return poll_succeeded();
     }
@@ -119,7 +121,7 @@ PollStreamResult BusCommandRouterProxyStreamPoller::poll_stream(
             return {};
         }
         if (on_chunk) {
-            on_chunk({router_proxy->set_param_ack});
+            on_chunk(json::array({json(router_proxy->set_param_ack)}));
         }
         return poll_succeeded();
     }
@@ -147,9 +149,9 @@ PollStreamResult BusCommandRouterProxyStreamPoller::poll_stream(
         const bool populate_metta_mapping =
             router_proxy->parameters.get_or<bool>(BaseQueryProxy::POPULATE_METTA_MAPPING, false);
 
-        vector<string> chunk_data;
+        json chunk_data = json::array();
         size_t streamed_item_count = 0;
-        auto emit_answer_chunk = [&](const vector<string>& chunk) {
+        auto emit_answer_chunk = [&](const json& chunk) {
             streamed_item_count += chunk.size();
             if (on_chunk) {
                 on_chunk(chunk);

--- a/src/agents/command_router/http_api/BusCommandRouterProxyStreamPoller.h
+++ b/src/agents/command_router/http_api/BusCommandRouterProxyStreamPoller.h
@@ -6,8 +6,11 @@
 #include <vector>
 
 #include "BusCommandRouterProxy.h"
+#include "nlohmann/json.hpp"
 
 using namespace std;
+
+using json = nlohmann::json;
 
 namespace command_router {
 
@@ -29,7 +32,7 @@ class BusCommandRouterProxyStreamPoller {
      * Poll router_proxy until the command finishes, is aborted, or fails.
      *
      * For command_type "query" and "evolution", answers are popped from the proxy
-     * and forwarded in batches of at most items_per_chunk strings. For "get" and
+     * and forwarded in batches of at most items_per_chunk JSON values. For "get" and
      * "set", a single chunk is emitted once the proxy response is ready.
      *
      * @param router_proxy Proxy already issued on the service bus.
@@ -38,7 +41,7 @@ class BusCommandRouterProxyStreamPoller {
      *                        Must be at least 1.
      * @param should_abort Optional callback; when it returns true, the proxy is aborted
      *                     and on_aborted is invoked.
-     * @param on_chunk Called with each batch of serialized answers or response payload.
+     * @param on_chunk Called with a JSON array of QueryAnswer objects or response payload.
      * @param on_error Called with an error message on validation, proxy, or unknown
      *                 command failures.
      * @param on_aborted Called when polling stops because should_abort returned true.
@@ -48,7 +51,7 @@ class BusCommandRouterProxyStreamPoller {
                                         const string& command_type,
                                         size_t items_per_chunk,
                                         const function<bool()>& should_abort,
-                                        const function<void(const vector<string>& chunk)>& on_chunk,
+                                        const function<void(const json& chunk)>& on_chunk,
                                         const function<void(const string& error)>& on_error,
                                         const function<void()>& on_aborted);
 

--- a/src/agents/command_router/http_api/CommandExecution.cc
+++ b/src/agents/command_router/http_api/CommandExecution.cc
@@ -141,8 +141,11 @@ void CommandExecution::mark_running() {
     this->publish_event_locked(this->lifecycle_event_locked());
 }
 
-void CommandExecution::publish_chunk(int seq, const vector<string>& data) {
+void CommandExecution::publish_chunk(int seq, const json& data) {
     lock_guard<mutex> lock(this->mtx_);
+    if (!data.is_array()) {
+        RAISE_ERROR("Chunk data must be a JSON array");
+    }
     this->received_count_ += static_cast<int>(data.size());
     this->publish_event_locked({{"execution_id", this->execution_id},
                                 {"type", "chunk"},

--- a/src/agents/command_router/http_api/CommandExecution.h
+++ b/src/agents/command_router/http_api/CommandExecution.h
@@ -75,8 +75,8 @@ class CommandExecution {
     /** @brief True when terminal and finished_at_ms is older than retention_ms. */
     bool is_retention_expired(unsigned long now_ms, unsigned long retention_ms) const;
 
-    /** @brief Append a chunk event and update received_count. */
-    void publish_chunk(int seq, const vector<string>& data);
+    /** @brief Append a chunk event and update received_count. @p data must be a JSON array. */
+    void publish_chunk(int seq, const json& data);
 
     /** @brief PENDING -> RUNNING; emits a lifecycle event. */
     void mark_running();

--- a/src/agents/command_router/http_api/CommandRouterHttpAPI.cc
+++ b/src/agents/command_router/http_api/CommandRouterHttpAPI.cc
@@ -37,9 +37,9 @@ CommandRouterHttpAPI::CommandRouterHttpAPI(const string& host,
       port(port),
       thread_pool(thread_pool),
       router_processor(router_processor),
-      settings(settings),
       bus_host(bus_host),
-      http_requestor_id(bus_host + ":http-api:" + std::to_string(port)) {
+      http_requestor_id(bus_host + ":http-api:" + std::to_string(port)),
+      settings(settings) {
     if (this->thread_pool == nullptr) {
         RAISE_ERROR("CommandRouterHttpAPI requires a non-null thread pool");
     }
@@ -153,14 +153,16 @@ void CommandRouterHttpAPI::setup_routes() {
             if (this->is_sync_command_type(command_type)) {
                 LOG_INFO("CommandRouter HTTP API sync execution type=" << command_type);
 
-                vector<string> chunks;
+                json results = json::array();
                 string error_message;
                 const PollStreamResult poll_result = this->execute_router_command(
                     command_type,
                     command_text,
                     nullptr,
-                    [&](const vector<string>& chunk) {
-                        chunks.insert(chunks.end(), chunk.begin(), chunk.end());
+                    [&](const json& chunk) {
+                        for (const auto& item : chunk) {
+                            results.push_back(item);
+                        }
                     },
                     [&](const string& message) { error_message = message; },
                     nullptr);
@@ -172,14 +174,14 @@ void CommandRouterHttpAPI::setup_routes() {
                     return;
                 }
 
-                if (chunks.empty()) {
+                if (results.empty()) {
                     this->set_json_response(
                         response, 500, {{"error", "Command finished without a response"}});
                     return;
                 }
 
                 this->set_json_response(
-                    response, 200, {{"command_type", command_type}, {"result", chunks.front()}});
+                    response, 200, {{"command_type", command_type}, {"result", results.front()}});
                 return;
             }
 
@@ -334,7 +336,7 @@ void CommandRouterHttpAPI::run_execution_inner(const shared_ptr<CommandExecution
     int seq = 0;
 
     auto should_abort = [&]() { return exec->is_cancel_requested() || this->shutting_down.load(); };
-    auto on_chunk = [&](const vector<string>& chunk) { exec->publish_chunk(++seq, chunk); };
+    auto on_chunk = [&](const json& chunk) { exec->publish_chunk(++seq, chunk); };
     auto on_error = [&](const string& message) { exec->mark_error(message); };
     auto on_aborted = [&]() {
         exec->mark_aborted();
@@ -367,7 +369,7 @@ PollStreamResult CommandRouterHttpAPI::execute_router_command(
     const string& command_type,
     const string& command_text,
     const function<bool()>& should_abort,
-    const function<void(const vector<string>& chunk)>& on_chunk,
+    const function<void(const json& chunk)>& on_chunk,
     const function<void(const string& error)>& on_error,
     const function<void()>& on_aborted) {
     if (this->router_processor == nullptr) {

--- a/src/agents/command_router/http_api/CommandRouterHttpAPI.h
+++ b/src/agents/command_router/http_api/CommandRouterHttpAPI.h
@@ -113,7 +113,7 @@ class CommandRouterHttpAPI : public processor::Processor, public processor::Thre
     PollStreamResult execute_router_command(const string& command_type,
                                             const string& command_text,
                                             const function<bool()>& should_abort,
-                                            const function<void(const vector<string>& chunk)>& on_chunk,
+                                            const function<void(const json& chunk)>& on_chunk,
                                             const function<void(const string& error)>& on_error,
                                             const function<void()>& on_aborted);
 

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -144,39 +144,135 @@ json QueryAnswer::to_json(bool metta_flag) {
     json answer = json::object();
 
     json handles_json = json::array();
-    string key = metta_flag ? "metta" : "handles";
+    json metta_handles_json = json::array();
     for (const vector<string>& group : this->handles) {
         json group_json = json::array();
+        json metta_group_json = json::array();
         for (const string& handle : group) {
+            group_json.push_back(handle);
             if (metta_flag) {
                 auto it = this->metta_expression.find(handle);
-                group_json.push_back(
+                metta_group_json.push_back(
                     (it != this->metta_expression.end() && !it->second.empty()) ? it->second : handle);
-            } else {
-                group_json.push_back(handle);
             }
         }
         handles_json.push_back(group_json);
-    }
-    answer[key] = handles_json;
-
-    json assignment_json = json::object();
-    for (const auto& pair : this->assignment.table) {
-        const string& value = pair.second;
         if (metta_flag) {
-            auto it = this->metta_expression.find(value);
-            assignment_json[pair.first] =
-                (it != this->metta_expression.end() && !it->second.empty()) ? it->second : value;
-        } else {
-            assignment_json[pair.first] = value;
+            metta_handles_json.push_back(metta_group_json);
         }
     }
+
+    json assignment_json = json::object();
+    json assignment_metta_json = json::object();
+    for (const auto& pair : this->assignment.table) {
+        assignment_json[pair.first] = pair.second;
+        if (metta_flag) {
+            auto it = this->metta_expression.find(pair.second);
+            assignment_metta_json[pair.first] =
+                (it != this->metta_expression.end() && !it->second.empty()) ? it->second : pair.second;
+        }
+    }
+
+    answer["handles"] = handles_json;
     answer["assignment"] = assignment_json;
+    answer["metta_expression"] = this->metta_expression;
+
+    if (metta_flag) {
+        answer["metta_expressions"] = metta_handles_json;
+        answer["assignment_metta"] = assignment_metta_json;
+    } else {
+        answer["metta_expressions"] = json::array();
+        answer["assignment_metta"] = json::object();
+    }
 
     answer["importance"] = this->importance;
     answer["strength"] = this->strength;
 
     return answer;
+}
+
+void QueryAnswer::from_json(const json& json_data) {
+    if (!json_data.is_object()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: expected object");
+    }
+
+    this->handles.clear();
+    this->handles.push_back({});
+    this->assignment.clear();
+    this->metta_expression.clear();
+    this->token_representation.clear();
+    this->strength = 0.0;
+    this->importance = 0.0;
+
+    if (!json_data.contains("strength") || !json_data["strength"].is_number()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid strength");
+    }
+    if (!json_data.contains("importance") || !json_data["importance"].is_number()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid importance");
+    }
+    this->strength = json_data["strength"].get<double>();
+    this->importance = json_data["importance"].get<double>();
+
+    if (!json_data.contains("handles") || !json_data["handles"].is_array()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid handles");
+    }
+    const json& handles_json = json_data["handles"];
+    if (handles_json.size() >= MAX_NUMBER_OF_OPERATION_CLAUSES) {
+        RAISE_ERROR("Invalid handles_size: " + std::to_string(handles_json.size()) +
+                    " loading QueryAnswer from JSON");
+    }
+    for (size_t i = 0; i < handles_json.size(); i++) {
+        if (!handles_json[i].is_array()) {
+            RAISE_ERROR("Invalid QueryAnswer JSON: handles[" + std::to_string(i) + "] must be an array");
+        }
+        unsigned int path_index = 0;
+        if (i > 0) {
+            path_index = this->add_path();
+        }
+        for (size_t j = 0; j < handles_json[i].size(); j++) {
+            const json& handle_json = handles_json[i][j];
+            if (!handle_json.is_string()) {
+                RAISE_ERROR("Invalid QueryAnswer JSON: handle at [" + std::to_string(i) + "][" +
+                            std::to_string(j) + "] must be a string");
+            }
+            const string handle = handle_json.get<string>();
+            if (i == 0) {
+                this->add_handle(handle);
+            } else {
+                this->add_path_element(path_index, handle);
+            }
+        }
+    }
+
+    if (!json_data.contains("assignment") || !json_data["assignment"].is_object()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid assignment");
+    }
+    const json& assignment_json = json_data["assignment"];
+    if (assignment_json.size() > MAX_NUMBER_OF_VARIABLES_IN_QUERY) {
+        RAISE_ERROR("Invalid number of assignments: " + std::to_string(assignment_json.size()) +
+                    " loading QueryAnswer from JSON");
+    }
+    for (auto it = assignment_json.begin(); it != assignment_json.end(); ++it) {
+        if (!it.value().is_string()) {
+            RAISE_ERROR("Invalid QueryAnswer JSON: assignment value for '" + it.key() +
+                        "' must be a string");
+        }
+        if (!this->assignment.assign(it.key(), it.value().get<string>())) {
+            RAISE_ERROR("Invalid QueryAnswer JSON: conflicting assignment for '" + it.key() + "'");
+        }
+    }
+
+    if (!json_data.contains("metta_expression") || !json_data["metta_expression"].is_object()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid metta_expression");
+    }
+    const json& metta_json = json_data["metta_expression"];
+    for (auto it = metta_json.begin(); it != metta_json.end(); ++it) {
+        if (!it.value().is_string()) {
+            RAISE_ERROR("Invalid QueryAnswer JSON: metta_expression value for '" + it.key() +
+                        "' must be a string");
+        }
+        this->metta_expression[it.key()] = it.value().get<string>();
+    }
 }
 
 const string& QueryAnswer::tokenize() {

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -140,6 +140,45 @@ string QueryAnswer::to_string(bool metta_flag) {
     return answer;
 }
 
+json QueryAnswer::to_json(bool metta_flag) {
+    json answer = json::object();
+
+    json handles_json = json::array();
+    string key = metta_flag ? "metta" : "handles";
+    for (const vector<string>& group : this->handles) {
+        json group_json = json::array();
+        for (const string& handle : group) {
+            if (metta_flag) {
+                auto it = this->metta_expression.find(handle);
+                group_json.push_back(
+                    (it != this->metta_expression.end() && !it->second.empty()) ? it->second : handle);
+            } else {
+                group_json.push_back(handle);
+            }
+        }
+        handles_json.push_back(group_json);
+    }
+    answer[key] = handles_json;
+
+    json assignment_json = json::object();
+    for (const auto& pair : this->assignment.table) {
+        const string& value = pair.second;
+        if (metta_flag) {
+            auto it = this->metta_expression.find(value);
+            assignment_json[pair.first] =
+                (it != this->metta_expression.end() && !it->second.empty()) ? it->second : value;
+        } else {
+            assignment_json[pair.first] = value;
+        }
+    }
+    answer["assignment"] = assignment_json;
+
+    answer["importance"] = this->importance;
+    answer["strength"] = this->strength;
+
+    return answer;
+}
+
 const string& QueryAnswer::tokenize() {
     // char_count is computed to be slightly larger than actually required by assuming
     // e.g. 3 digits to represent sizes

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -196,83 +196,85 @@ void QueryAnswer::from_json(const json& json_data) {
         RAISE_ERROR("Invalid QueryAnswer JSON: expected object");
     }
 
-    this->handles.clear();
-    this->handles.push_back({});
-    this->assignment.clear();
-    this->metta_expression.clear();
-    this->token_representation.clear();
-    this->strength = 0.0;
-    this->importance = 0.0;
-
     if (!json_data.contains("strength") || !json_data["strength"].is_number()) {
         RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid strength");
     }
     if (!json_data.contains("importance") || !json_data["importance"].is_number()) {
         RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid importance");
     }
-    this->strength = json_data["strength"].get<double>();
-    this->importance = json_data["importance"].get<double>();
-
     if (!json_data.contains("handles") || !json_data["handles"].is_array()) {
         RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid handles");
     }
+    if (!json_data.contains("assignment") || !json_data["assignment"].is_object()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid assignment");
+    }
+    if (!json_data.contains("handle_to_metta") || !json_data["handle_to_metta"].is_object()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid handle_to_metta");
+    }
+
+    const double strength = json_data["strength"].get<double>();
+    const double importance = json_data["importance"].get<double>();
+
     const json& handles_json = json_data["handles"];
     if (handles_json.size() >= MAX_NUMBER_OF_OPERATION_CLAUSES) {
         RAISE_ERROR("Invalid handles_size: " + std::to_string(handles_json.size()) +
                     " loading QueryAnswer from JSON");
     }
-    for (size_t i = 0; i < handles_json.size(); i++) {
-        if (!handles_json[i].is_array()) {
-            RAISE_ERROR("Invalid QueryAnswer JSON: handles[" + std::to_string(i) + "] must be an array");
-        }
-        unsigned int path_index = 0;
-        if (i > 0) {
-            path_index = this->add_path();
-        }
-        for (size_t j = 0; j < handles_json[i].size(); j++) {
-            const json& handle_json = handles_json[i][j];
-            if (!handle_json.is_string()) {
-                RAISE_ERROR("Invalid QueryAnswer JSON: handle at [" + std::to_string(i) + "][" +
-                            std::to_string(j) + "] must be a string");
+    vector<vector<string>> handles;
+    if (handles_json.empty()) {
+        handles.push_back({});
+    } else {
+        for (size_t i = 0; i < handles_json.size(); i++) {
+            if (!handles_json[i].is_array()) {
+                RAISE_ERROR("Invalid QueryAnswer JSON: handles[" + std::to_string(i) +
+                            "] must be an array");
             }
-            const string handle = handle_json.get<string>();
-            if (i == 0) {
-                this->add_handle(handle);
-            } else {
-                this->add_path_element(path_index, handle);
+            vector<string> group;
+            group.reserve(handles_json[i].size());
+            for (size_t j = 0; j < handles_json[i].size(); j++) {
+                const json& handle_json = handles_json[i][j];
+                if (!handle_json.is_string()) {
+                    RAISE_ERROR("Invalid QueryAnswer JSON: handle at [" + std::to_string(i) + "][" +
+                                std::to_string(j) + "] must be a string");
+                }
+                group.push_back(handle_json.get<string>());
             }
+            handles.push_back(std::move(group));
         }
     }
 
-    if (!json_data.contains("assignment") || !json_data["assignment"].is_object()) {
-        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid assignment");
-    }
     const json& assignment_json = json_data["assignment"];
     if (assignment_json.size() > MAX_NUMBER_OF_VARIABLES_IN_QUERY) {
         RAISE_ERROR("Invalid number of assignments: " + std::to_string(assignment_json.size()) +
                     " loading QueryAnswer from JSON");
     }
+    Assignment assignment;
     for (auto it = assignment_json.begin(); it != assignment_json.end(); ++it) {
         if (!it.value().is_string()) {
             RAISE_ERROR("Invalid QueryAnswer JSON: assignment value for '" + it.key() +
                         "' must be a string");
         }
-        if (!this->assignment.assign(it.key(), it.value().get<string>())) {
+        if (!assignment.assign(it.key(), it.value().get<string>())) {
             RAISE_ERROR("Invalid QueryAnswer JSON: conflicting assignment for '" + it.key() + "'");
         }
     }
 
-    if (!json_data.contains("handle_to_metta") || !json_data["handle_to_metta"].is_object()) {
-        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid handle_to_metta");
-    }
     const json& metta_json = json_data["handle_to_metta"];
+    map<string, string> metta_expression;
     for (auto it = metta_json.begin(); it != metta_json.end(); ++it) {
         if (!it.value().is_string()) {
             RAISE_ERROR("Invalid QueryAnswer JSON: handle_to_metta value for '" + it.key() +
                         "' must be a string");
         }
-        this->metta_expression[it.key()] = it.value().get<string>();
+        metta_expression[it.key()] = it.value().get<string>();
     }
+
+    this->strength = strength;
+    this->importance = importance;
+    this->handles = std::move(handles);
+    this->assignment = assignment;
+    this->metta_expression = std::move(metta_expression);
+    this->token_representation.clear();
 }
 
 const string& QueryAnswer::tokenize() {

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -201,17 +201,18 @@ void QueryAnswer::from_json(const json& json_data) {
         RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid assignment");
     }
 
-    const double strength = json_data["strength"].get<double>();
-    const double importance = json_data["importance"].get<double>();
+    this->strength = json_data["strength"].get<double>();
+    this->importance = json_data["importance"].get<double>();
 
     const json& handles_json = json_data["handles"];
     if (handles_json.size() >= MAX_NUMBER_OF_OPERATION_CLAUSES) {
         RAISE_ERROR("Invalid handles_size: " + std::to_string(handles_json.size()) +
                     " loading QueryAnswer from JSON");
     }
-    vector<vector<string>> handles;
+
+    this->handles.clear();
     if (handles_json.empty()) {
-        handles.push_back({});
+        this->handles.push_back({});
     } else {
         for (size_t i = 0; i < handles_json.size(); i++) {
             if (!handles_json[i].is_array()) {
@@ -228,7 +229,7 @@ void QueryAnswer::from_json(const json& json_data) {
                 }
                 group.push_back(handle_json.get<string>());
             }
-            handles.push_back(std::move(group));
+            this->handles.push_back(std::move(group));
         }
     }
 
@@ -237,21 +238,18 @@ void QueryAnswer::from_json(const json& json_data) {
         RAISE_ERROR("Invalid number of assignments: " + std::to_string(assignment_json.size()) +
                     " loading QueryAnswer from JSON");
     }
-    Assignment assignment;
+
+    this->assignment.clear();
     for (auto it = assignment_json.begin(); it != assignment_json.end(); ++it) {
         if (!it.value().is_string()) {
             RAISE_ERROR("Invalid QueryAnswer JSON: assignment value for '" + it.key() +
                         "' must be a string");
         }
-        if (!assignment.assign(it.key(), it.value().get<string>())) {
+        if (!this->assignment.assign(it.key(), it.value().get<string>())) {
             RAISE_ERROR("Invalid QueryAnswer JSON: conflicting assignment for '" + it.key() + "'");
         }
     }
 
-    this->strength = strength;
-    this->importance = importance;
-    this->handles = std::move(handles);
-    this->assignment = assignment;
     this->metta_expression.clear();
     this->token_representation.clear();
 }

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -144,7 +144,7 @@ json QueryAnswer::to_json(bool metta_flag) {
     json answer = json::object();
 
     json handles_json = json::array();
-    json metta_handles_json = json::array();
+    json metta_expressions_json = json::array();
     for (const vector<string>& group : this->handles) {
         json group_json = json::array();
         json metta_group_json = json::array();
@@ -152,14 +152,13 @@ json QueryAnswer::to_json(bool metta_flag) {
             group_json.push_back(handle);
             if (metta_flag) {
                 auto it = this->metta_expression.find(handle);
-                metta_group_json.push_back(
-                    (it != this->metta_expression.end() && !it->second.empty()) ? it->second : handle);
+                if (it != this->metta_expression.end() && !it->second.empty()) {
+                    metta_group_json.push_back(it->second);
+                }
             }
         }
         handles_json.push_back(group_json);
-        if (metta_flag) {
-            metta_handles_json.push_back(metta_group_json);
-        }
+        metta_expressions_json.push_back(metta_group_json);
     }
 
     json assignment_json = json::object();
@@ -168,23 +167,16 @@ json QueryAnswer::to_json(bool metta_flag) {
         assignment_json[pair.first] = pair.second;
         if (metta_flag) {
             auto it = this->metta_expression.find(pair.second);
-            assignment_metta_json[pair.first] =
-                (it != this->metta_expression.end() && !it->second.empty()) ? it->second : pair.second;
+            if (it != this->metta_expression.end() && !it->second.empty()) {
+                assignment_metta_json[pair.first] = it->second;
+            }
         }
     }
 
     answer["handles"] = handles_json;
     answer["assignment"] = assignment_json;
-    answer["handle_to_metta"] = this->metta_expression;
-
-    if (metta_flag) {
-        answer["handles_metta"] = metta_handles_json;
-        answer["assignment_metta"] = assignment_metta_json;
-    } else {
-        answer["handles_metta"] = json::array();
-        answer["assignment_metta"] = json::object();
-    }
-
+    answer["metta_expressions"] = metta_expressions_json;
+    answer["assignment_metta"] = assignment_metta_json;
     answer["importance"] = this->importance;
     answer["strength"] = this->strength;
 
@@ -207,9 +199,6 @@ void QueryAnswer::from_json(const json& json_data) {
     }
     if (!json_data.contains("assignment") || !json_data["assignment"].is_object()) {
         RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid assignment");
-    }
-    if (!json_data.contains("handle_to_metta") || !json_data["handle_to_metta"].is_object()) {
-        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid handle_to_metta");
     }
 
     const double strength = json_data["strength"].get<double>();
@@ -259,21 +248,11 @@ void QueryAnswer::from_json(const json& json_data) {
         }
     }
 
-    const json& metta_json = json_data["handle_to_metta"];
-    map<string, string> metta_expression;
-    for (auto it = metta_json.begin(); it != metta_json.end(); ++it) {
-        if (!it.value().is_string()) {
-            RAISE_ERROR("Invalid QueryAnswer JSON: handle_to_metta value for '" + it.key() +
-                        "' must be a string");
-        }
-        metta_expression[it.key()] = it.value().get<string>();
-    }
-
     this->strength = strength;
     this->importance = importance;
     this->handles = std::move(handles);
     this->assignment = assignment;
-    this->metta_expression = std::move(metta_expression);
+    this->metta_expression.clear();
     this->token_representation.clear();
 }
 

--- a/src/agents/query_engine/QueryAnswer.cc
+++ b/src/agents/query_engine/QueryAnswer.cc
@@ -175,13 +175,13 @@ json QueryAnswer::to_json(bool metta_flag) {
 
     answer["handles"] = handles_json;
     answer["assignment"] = assignment_json;
-    answer["metta_expression"] = this->metta_expression;
+    answer["handle_to_metta"] = this->metta_expression;
 
     if (metta_flag) {
-        answer["metta_expressions"] = metta_handles_json;
+        answer["handles_metta"] = metta_handles_json;
         answer["assignment_metta"] = assignment_metta_json;
     } else {
-        answer["metta_expressions"] = json::array();
+        answer["handles_metta"] = json::array();
         answer["assignment_metta"] = json::object();
     }
 
@@ -262,13 +262,13 @@ void QueryAnswer::from_json(const json& json_data) {
         }
     }
 
-    if (!json_data.contains("metta_expression") || !json_data["metta_expression"].is_object()) {
-        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid metta_expression");
+    if (!json_data.contains("handle_to_metta") || !json_data["handle_to_metta"].is_object()) {
+        RAISE_ERROR("Invalid QueryAnswer JSON: missing or invalid handle_to_metta");
     }
-    const json& metta_json = json_data["metta_expression"];
+    const json& metta_json = json_data["handle_to_metta"];
     for (auto it = metta_json.begin(); it != metta_json.end(); ++it) {
         if (!it.value().is_string()) {
-            RAISE_ERROR("Invalid QueryAnswer JSON: metta_expression value for '" + it.key() +
+            RAISE_ERROR("Invalid QueryAnswer JSON: handle_to_metta value for '" + it.key() +
                         "' must be a string");
         }
         this->metta_expression[it.key()] = it.value().get<string>();

--- a/src/agents/query_engine/QueryAnswer.h
+++ b/src/agents/query_engine/QueryAnswer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
@@ -12,6 +13,8 @@
 using namespace std;
 using namespace atoms;
 using namespace commons;
+
+using nlohmann::json;
 
 // If this constant is set to numbers greater than 999, we need
 // to fix QueryAnswer.tokenize() properly
@@ -445,6 +448,11 @@ class QueryAnswer {
      * production environment).
      */
     string to_string(bool metta_flag = false);
+
+    /**
+     * Returns a json representation of this QueryAnswer
+     */
+    json to_json(bool metta_flag = false);
 
     /**
      * Returns the element indicated by the passed QueryAnswerElement key, it can be either one

--- a/src/agents/query_engine/QueryAnswer.h
+++ b/src/agents/query_engine/QueryAnswer.h
@@ -450,9 +450,24 @@ class QueryAnswer {
     string to_string(bool metta_flag = false);
 
     /**
-     * Returns a json representation of this QueryAnswer
+     * Returns a json representation of this QueryAnswer.
+     *
+     * Always includes the full internal state so from_json() can rebuild the
+     * same QueryAnswer: handles, assignment, metta_expression (handle -> MeTTa
+     * map), importance and strength. When metta_flag is true, also fills
+     * metta_expressions and assignment_metta with MeTTa values substituted
+     * where available.
      */
     json to_json(bool metta_flag = false);
+
+    /**
+     * Rebuilds this QueryAnswer from a json representation produced by to_json().
+     * Resets the current object before loading. Uses handles, assignment,
+     * metta_expression, importance and strength.
+     *
+     * @param json_data A json object representing a QueryAnswer.
+     */
+    void from_json(const json& json_data);
 
     /**
      * Returns the element indicated by the passed QueryAnswerElement key, it can be either one

--- a/src/agents/query_engine/QueryAnswer.h
+++ b/src/agents/query_engine/QueryAnswer.h
@@ -452,18 +452,17 @@ class QueryAnswer {
     /**
      * Returns a json representation of this QueryAnswer.
      *
-     * Always includes the full internal state so from_json() can rebuild the
-     * same QueryAnswer: handles, assignment, handle_to_metta (handle -> MeTTa
-     * map), importance and strength. When metta_flag is true, also fills
-     * handles_metta and assignment_metta with MeTTa values substituted where
-     * available.
+     * Always includes handles, assignment, metta_expressions, assignment_metta,
+     * importance and strength. When metta_flag is true, metta_expressions and
+     * assignment_metta are filled with MeTTa values where available; otherwise
+     * they are present but empty.
      */
     json to_json(bool metta_flag = false);
 
     /**
      * Rebuilds this QueryAnswer from a json representation produced by to_json().
-     * Resets the current object before loading. Uses handles, assignment,
-     * handle_to_metta, importance and strength.
+     * Loads handles, assignment, importance and strength. Does not restore the
+     * internal metta_expression map. Clears metta_expression on success.
      *
      * @param json_data A json object representing a QueryAnswer.
      */

--- a/src/agents/query_engine/QueryAnswer.h
+++ b/src/agents/query_engine/QueryAnswer.h
@@ -453,17 +453,17 @@ class QueryAnswer {
      * Returns a json representation of this QueryAnswer.
      *
      * Always includes the full internal state so from_json() can rebuild the
-     * same QueryAnswer: handles, assignment, metta_expression (handle -> MeTTa
+     * same QueryAnswer: handles, assignment, handle_to_metta (handle -> MeTTa
      * map), importance and strength. When metta_flag is true, also fills
-     * metta_expressions and assignment_metta with MeTTa values substituted
-     * where available.
+     * handles_metta and assignment_metta with MeTTa values substituted where
+     * available.
      */
     json to_json(bool metta_flag = false);
 
     /**
      * Rebuilds this QueryAnswer from a json representation produced by to_json().
      * Resets the current object before loading. Uses handles, assignment,
-     * metta_expression, importance and strength.
+     * handle_to_metta, importance and strength.
      *
      * @param json_data A json object representing a QueryAnswer.
      */

--- a/src/tests/cpp/command_router_http_api_test.cc
+++ b/src/tests/cpp/command_router_http_api_test.cc
@@ -154,7 +154,7 @@ class StreamTestProxy : public BusCommandRouterProxy {
     void mark_finished() { this->from_remote_peer(BaseProxy::FINISHED, {}); }
 };
 
-size_t total_items(const vector<vector<string>>& chunks) {
+size_t total_items(const vector<json>& chunks) {
     size_t count = 0;
     for (const auto& chunk : chunks) {
         count += chunk.size();
@@ -162,7 +162,7 @@ size_t total_items(const vector<vector<string>>& chunks) {
     return count;
 }
 
-vector<size_t> chunk_sizes(const vector<vector<string>>& chunks) {
+vector<size_t> chunk_sizes(const vector<json>& chunks) {
     vector<size_t> sizes;
     for (const auto& chunk : chunks) {
         sizes.push_back(chunk.size());
@@ -258,8 +258,8 @@ TEST(CommandExecutionTest, event_buffer_overflow_raises) {
     CommandExecution exec("exec-abc", "query", "(Similarity %V1 %V2)", 2);
 
     exec.mark_running();
-    exec.publish_chunk(1, {"a"});
-    EXPECT_THROW(exec.publish_chunk(2, {"b", "c"}), runtime_error);
+    exec.publish_chunk(1, json::array({json("a")}));
+    EXPECT_THROW(exec.publish_chunk(2, json::array({json("b"), json("c")})), runtime_error);
 }
 
 // -----------------------------------------------------------------------------
@@ -356,8 +356,8 @@ TEST(BusCommandRouterProxyStreamPollerTest, stream_emits_one_item_per_chunk_by_d
     proxy->enqueue_answers(5);
     proxy->mark_finished();
 
-    vector<vector<string>> chunks;
-    auto on_chunk = [&](const vector<string>& chunk) { chunks.push_back(chunk); };
+    vector<json> chunks;
+    auto on_chunk = [&](const json& chunk) { chunks.push_back(chunk); };
 
     const auto poll_result = BusCommandRouterProxyStreamPoller::poll_stream(
         proxy, "query", 1, nullptr, on_chunk, nullptr, nullptr);
@@ -366,7 +366,7 @@ TEST(BusCommandRouterProxyStreamPollerTest, stream_emits_one_item_per_chunk_by_d
     EXPECT_EQ(chunks.size(), 5u);
     EXPECT_EQ(chunk_sizes(chunks), (vector<size_t>{1, 1, 1, 1, 1}));
     EXPECT_EQ(total_items(chunks), 5u);
-    EXPECT_NE(chunks.front().front().find("answer-0"), string::npos);
+    EXPECT_EQ(chunks.front()[0]["handles"][0][0], "answer-0");
 }
 
 TEST(BusCommandRouterProxyStreamPollerTest,
@@ -382,20 +382,19 @@ TEST(BusCommandRouterProxyStreamPollerTest,
     proxy->from_remote_peer(BaseQueryProxy::ANSWER_BUNDLE, bundle);
     proxy->mark_finished();
 
-    vector<vector<string>> chunks;
+    vector<json> chunks;
     const auto poll_result = BusCommandRouterProxyStreamPoller::poll_stream(
         proxy,
         "query",
         1,
         nullptr,
-        [&](const vector<string>& chunk) { chunks.push_back(chunk); },
+        [&](const json& chunk) { chunks.push_back(chunk); },
         nullptr,
         nullptr);
     ASSERT_TRUE(poll_result.ok);
     ASSERT_EQ(chunks.size(), 1u);
-    EXPECT_NE(chunks[0].front().find("7ec8526b8c8f15a6ac55273fedbf694f"), string::npos);
-    EXPECT_NE(chunks[0].front().find("181a19436acef495c8039a610be59603"), string::npos);
-    EXPECT_EQ(chunks[0].front().find("[[]]"), string::npos);
+    EXPECT_EQ(chunks[0][0]["handles"][0][0], "7ec8526b8c8f15a6ac55273fedbf694f");
+    EXPECT_EQ(chunks[0][0]["assignment"]["C"], "181a19436acef495c8039a610be59603");
 }
 
 TEST(BusCommandRouterProxyTest, count_command_sets_total_and_marks_count_received) {
@@ -422,20 +421,20 @@ TEST(BusCommandRouterProxyStreamPollerTest, count_only_emits_total) {
     proxy->from_remote_peer(PatternMatchingQueryProxy::COUNT, {"14"});
     proxy->mark_finished();
 
-    vector<vector<string>> chunks;
+    vector<json> chunks;
     const auto poll_result = BusCommandRouterProxyStreamPoller::poll_stream(
         proxy,
         "query",
         1,
         nullptr,
-        [&](const vector<string>& chunk) { chunks.push_back(chunk); },
+        [&](const json& chunk) { chunks.push_back(chunk); },
         nullptr,
         nullptr);
     ASSERT_TRUE(poll_result.ok);
     EXPECT_TRUE(poll_result.is_count_only);
     EXPECT_EQ(poll_result.count_only_total, 14);
     ASSERT_EQ(chunks.size(), 1u);
-    EXPECT_EQ(chunks[0], vector<string>{"14"});
+    EXPECT_EQ(chunks[0], json::array({json("14")}));
 }
 
 TEST(BusCommandRouterProxyStreamPollerTest, streams_answers_when_count_flag_true_but_answers_arrive) {
@@ -445,13 +444,13 @@ TEST(BusCommandRouterProxyStreamPollerTest, streams_answers_when_count_flag_true
     proxy->enqueue_answers(3);
     proxy->mark_finished();
 
-    vector<vector<string>> chunks;
+    vector<json> chunks;
     const auto poll_result = BusCommandRouterProxyStreamPoller::poll_stream(
         proxy,
         "query",
         1,
         nullptr,
-        [&](const vector<string>& chunk) { chunks.push_back(chunk); },
+        [&](const json& chunk) { chunks.push_back(chunk); },
         nullptr,
         nullptr);
     ASSERT_TRUE(poll_result.ok);
@@ -466,8 +465,8 @@ TEST(BusCommandRouterProxyStreamPollerTest, stream_groups_items_per_chunk) {
     proxy->enqueue_answers(7);
     proxy->mark_finished();
 
-    vector<vector<string>> chunks;
-    auto on_chunk = [&](const vector<string>& chunk) { chunks.push_back(chunk); };
+    vector<json> chunks;
+    auto on_chunk = [&](const json& chunk) { chunks.push_back(chunk); };
 
     const auto poll_result = BusCommandRouterProxyStreamPoller::poll_stream(
         proxy, "query", 3, nullptr, on_chunk, nullptr, nullptr);
@@ -497,36 +496,36 @@ TEST(BusCommandRouterProxyStreamPollerTest, get_and_set_emit_single_chunk) {
     auto get_proxy = make_shared<StreamTestProxy>();
     get_proxy->from_remote_peer(BusCommandRouterProxy::PARAMS_RESPONSE, {"params-body"});
 
-    vector<vector<string>> get_chunks;
+    vector<json> get_chunks;
     const auto get_result = BusCommandRouterProxyStreamPoller::poll_stream(
         get_proxy,
         "get",
         1,
         nullptr,
-        [&](const vector<string>& chunk) { get_chunks.push_back(chunk); },
+        [&](const json& chunk) { get_chunks.push_back(chunk); },
         nullptr,
         nullptr);
     ASSERT_TRUE(get_result.ok);
     EXPECT_FALSE(get_result.is_count_only);
     ASSERT_EQ(get_chunks.size(), 1u);
-    EXPECT_EQ(get_chunks[0], vector<string>{"params-body"});
+    EXPECT_EQ(get_chunks[0], json::array({json("params-body")}));
 
     auto set_proxy = make_shared<StreamTestProxy>();
     set_proxy->from_remote_peer(BusCommandRouterProxy::SET_PARAM_ACK, {"ack-body"});
 
-    vector<vector<string>> set_chunks;
+    vector<json> set_chunks;
     const auto set_result = BusCommandRouterProxyStreamPoller::poll_stream(
         set_proxy,
         "set",
         1,
         nullptr,
-        [&](const vector<string>& chunk) { set_chunks.push_back(chunk); },
+        [&](const json& chunk) { set_chunks.push_back(chunk); },
         nullptr,
         nullptr);
     ASSERT_TRUE(set_result.ok);
     EXPECT_FALSE(set_result.is_count_only);
     ASSERT_EQ(set_chunks.size(), 1u);
-    EXPECT_EQ(set_chunks[0], vector<string>{"ack-body"});
+    EXPECT_EQ(set_chunks[0], json::array({json("ack-body")}));
 }
 
 TEST(BusCommandRouterProxyStreamPollerTest, get_and_set_reject_empty_response) {

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -466,8 +466,8 @@ TEST(QueryAnswer, json_rebuild) {
     json dumped = input.to_json(false);
     EXPECT_EQ(dumped["handles"][0][0], h1);
     EXPECT_EQ(dumped["assignment"]["v1"], h2);
-    EXPECT_EQ(dumped["metta_expression"][h1], input.metta_expression[h1]);
-    EXPECT_TRUE(dumped["metta_expressions"].empty());
+    EXPECT_EQ(dumped["handle_to_metta"][h1], input.metta_expression[h1]);
+    EXPECT_TRUE(dumped["handles_metta"].empty());
     EXPECT_TRUE(dumped["assignment_metta"].empty());
 
     QueryAnswer output(0.0);
@@ -480,8 +480,8 @@ TEST(QueryAnswer, json_rebuild) {
     json dumped_metta = input.to_json(true);
     EXPECT_EQ(dumped_metta["handles"][0][0], h1);
     EXPECT_EQ(dumped_metta["assignment"]["v1"], h2);
-    EXPECT_EQ(dumped_metta["metta_expression"][h1], input.metta_expression[h1]);
-    EXPECT_EQ(dumped_metta["metta_expressions"][0][0], input.metta_expression[h1]);
+    EXPECT_EQ(dumped_metta["handle_to_metta"][h1], input.metta_expression[h1]);
+    EXPECT_EQ(dumped_metta["handles_metta"][0][0], input.metta_expression[h1]);
     EXPECT_EQ(dumped_metta["assignment_metta"]["v1"], input.metta_expression[h2]);
 
     QueryAnswer output_from_metta_flag(0.0);
@@ -511,28 +511,28 @@ TEST(QueryAnswer, from_json_edge_cases) {
     json missing_handles = {{"strength", 0.0},
                             {"importance", 0.0},
                             {"assignment", json::object()},
-                            {"metta_expression", json::object()}};
+                            {"handle_to_metta", json::object()}};
     EXPECT_THROW(QueryAnswer().from_json(missing_handles), runtime_error);
 
     json bad_handle_type = {{"strength", 0.0},
                             {"importance", 0.0},
                             {"handles", json::array({json::array({1})})},
                             {"assignment", json::object()},
-                            {"metta_expression", json::object()}};
+                            {"handle_to_metta", json::object()}};
     EXPECT_THROW(QueryAnswer().from_json(bad_handle_type), runtime_error);
 
     json bad_assignment_value = {{"strength", 0.0},
                                  {"importance", 0.0},
                                  {"handles", json::array({json::array()})},
                                  {"assignment", {{"v1", 123}}},
-                                 {"metta_expression", json::object()}};
+                                 {"handle_to_metta", json::object()}};
     EXPECT_THROW(QueryAnswer().from_json(bad_assignment_value), runtime_error);
 
     json bad_metta_value = {{"strength", 0.0},
                             {"importance", 0.0},
                             {"handles", json::array({json::array()})},
                             {"assignment", json::object()},
-                            {"metta_expression", {{"h1", true}}}};
+                            {"handle_to_metta", {{"h1", true}}}};
     EXPECT_THROW(QueryAnswer().from_json(bad_metta_value), runtime_error);
 }
 

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -438,6 +438,104 @@ TEST(QueryAnswer, tokenization) {
     }
 }
 
+void query_answers_equal_including_metta(QueryAnswer* qa1, QueryAnswer* qa2) {
+    query_answers_equal(qa1, qa2);
+    EXPECT_EQ(qa1->metta_expression, qa2->metta_expression);
+}
+
+TEST(QueryAnswer, json_rebuild) {
+    QueryAnswer input(0.75);
+    input.strength = 0.25;
+    string h1 = random_handle();
+    string h2 = random_handle();
+    string h3 = random_handle();
+    string path_h1 = random_handle();
+    string path_h2 = random_handle();
+
+    input.add_handle(h1);
+    input.add_handle(h2);
+    input.assignment.assign("v1", h2);
+    input.assignment.assign("v2", h3);
+    unsigned int path_index = input.add_path();
+    input.add_path_element(path_index, path_h1);
+    input.add_path_element(path_index, path_h2);
+    input.metta_expression[h1] = "(Evaluation (Predicate \"p\") (Concept \"a\"))";
+    input.metta_expression[h2] = "\"human\"";
+    input.metta_expression[h3] = "(Concept \"x\")";
+
+    json dumped = input.to_json(false);
+    EXPECT_EQ(dumped["handles"][0][0], h1);
+    EXPECT_EQ(dumped["assignment"]["v1"], h2);
+    EXPECT_EQ(dumped["metta_expression"][h1], input.metta_expression[h1]);
+    EXPECT_TRUE(dumped["metta_expressions"].empty());
+    EXPECT_TRUE(dumped["assignment_metta"].empty());
+
+    QueryAnswer output(0.0);
+    output.add_handle("should-be-cleared");
+    output.assignment.assign("old", "value");
+    output.metta_expression["old"] = "expr";
+    output.from_json(dumped);
+    query_answers_equal_including_metta(&input, &output);
+
+    json dumped_metta = input.to_json(true);
+    EXPECT_EQ(dumped_metta["handles"][0][0], h1);
+    EXPECT_EQ(dumped_metta["assignment"]["v1"], h2);
+    EXPECT_EQ(dumped_metta["metta_expression"][h1], input.metta_expression[h1]);
+    EXPECT_EQ(dumped_metta["metta_expressions"][0][0], input.metta_expression[h1]);
+    EXPECT_EQ(dumped_metta["assignment_metta"]["v1"], input.metta_expression[h2]);
+
+    QueryAnswer output_from_metta_flag(0.0);
+    output_from_metta_flag.from_json(dumped_metta);
+    query_answers_equal_including_metta(&input, &output_from_metta_flag);
+}
+
+TEST(QueryAnswer, json_rebuild_empty) {
+    QueryAnswer input(0.0);
+    input.strength = 0.0;
+    json dumped = input.to_json();
+    QueryAnswer output(1.0);
+    output.strength = 1.0;
+    output.add_handle(random_handle());
+    output.from_json(dumped);
+    query_answers_equal_including_metta(&input, &output);
+    EXPECT_EQ(output.get_handles_size(), 0u);
+    EXPECT_EQ(output.get_paths_size(), 0u);
+    EXPECT_EQ(output.assignment.variable_count(), 0u);
+    EXPECT_TRUE(output.metta_expression.empty());
+}
+
+TEST(QueryAnswer, from_json_edge_cases) {
+    EXPECT_THROW(QueryAnswer().from_json(json::array()), runtime_error);
+    EXPECT_THROW(QueryAnswer().from_json(json::object()), runtime_error);
+
+    json missing_handles = {{"strength", 0.0},
+                            {"importance", 0.0},
+                            {"assignment", json::object()},
+                            {"metta_expression", json::object()}};
+    EXPECT_THROW(QueryAnswer().from_json(missing_handles), runtime_error);
+
+    json bad_handle_type = {{"strength", 0.0},
+                            {"importance", 0.0},
+                            {"handles", json::array({json::array({1})})},
+                            {"assignment", json::object()},
+                            {"metta_expression", json::object()}};
+    EXPECT_THROW(QueryAnswer().from_json(bad_handle_type), runtime_error);
+
+    json bad_assignment_value = {{"strength", 0.0},
+                                 {"importance", 0.0},
+                                 {"handles", json::array({json::array()})},
+                                 {"assignment", {{"v1", 123}}},
+                                 {"metta_expression", json::object()}};
+    EXPECT_THROW(QueryAnswer().from_json(bad_assignment_value), runtime_error);
+
+    json bad_metta_value = {{"strength", 0.0},
+                            {"importance", 0.0},
+                            {"handles", json::array({json::array()})},
+                            {"assignment", json::object()},
+                            {"metta_expression", {{"h1", true}}}};
+    EXPECT_THROW(QueryAnswer().from_json(bad_metta_value), runtime_error);
+}
+
 TEST(QueryAnswer, get_query_answer_element) {
     QueryAnswer answer;
     answer.get_handles_vector().push_back("h1");

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -435,6 +435,11 @@ TEST(QueryAnswer, tokenization) {
         QueryAnswer output(0.0);
         output.untokenize(token_string);
         query_answers_equal(&input, &output);
+
+        json json_data = input.to_json(false);
+        QueryAnswer json_output(0.0);
+        json_output.from_json(json_data);
+        query_answers_equal(&input, &json_output);
     }
 }
 
@@ -466,8 +471,8 @@ TEST(QueryAnswer, json_rebuild) {
     json dumped = input.to_json(false);
     EXPECT_EQ(dumped["handles"][0][0], h1);
     EXPECT_EQ(dumped["assignment"]["v1"], h2);
-    EXPECT_EQ(dumped["handle_to_metta"][h1], input.metta_expression[h1]);
-    EXPECT_TRUE(dumped["handles_metta"].empty());
+    EXPECT_FALSE(dumped.contains("handle_to_metta"));
+    EXPECT_TRUE(dumped["metta_expressions"][0].empty());
     EXPECT_TRUE(dumped["assignment_metta"].empty());
 
     QueryAnswer output(0.0);
@@ -475,18 +480,20 @@ TEST(QueryAnswer, json_rebuild) {
     output.assignment.assign("old", "value");
     output.metta_expression["old"] = "expr";
     output.from_json(dumped);
-    query_answers_equal_including_metta(&input, &output);
+    query_answers_equal(&input, &output);
+    EXPECT_TRUE(output.metta_expression.empty());
 
     json dumped_metta = input.to_json(true);
     EXPECT_EQ(dumped_metta["handles"][0][0], h1);
     EXPECT_EQ(dumped_metta["assignment"]["v1"], h2);
-    EXPECT_EQ(dumped_metta["handle_to_metta"][h1], input.metta_expression[h1]);
-    EXPECT_EQ(dumped_metta["handles_metta"][0][0], input.metta_expression[h1]);
+    EXPECT_EQ(dumped_metta["metta_expressions"][0][0], input.metta_expression[h1]);
+    EXPECT_EQ(dumped_metta["metta_expressions"][0][1], input.metta_expression[h2]);
     EXPECT_EQ(dumped_metta["assignment_metta"]["v1"], input.metta_expression[h2]);
 
     QueryAnswer output_from_metta_flag(0.0);
     output_from_metta_flag.from_json(dumped_metta);
-    query_answers_equal_including_metta(&input, &output_from_metta_flag);
+    query_answers_equal(&input, &output_from_metta_flag);
+    EXPECT_TRUE(output_from_metta_flag.metta_expression.empty());
 }
 
 TEST(QueryAnswer, json_rebuild_empty) {
@@ -497,7 +504,7 @@ TEST(QueryAnswer, json_rebuild_empty) {
     output.strength = 1.0;
     output.add_handle(random_handle());
     output.from_json(dumped);
-    query_answers_equal_including_metta(&input, &output);
+    query_answers_equal(&input, &output);
     EXPECT_EQ(output.get_handles_size(), 0u);
     EXPECT_EQ(output.get_paths_size(), 0u);
     EXPECT_EQ(output.assignment.variable_count(), 0u);
@@ -508,32 +515,20 @@ TEST(QueryAnswer, from_json_edge_cases) {
     EXPECT_THROW(QueryAnswer().from_json(json::array()), runtime_error);
     EXPECT_THROW(QueryAnswer().from_json(json::object()), runtime_error);
 
-    json missing_handles = {{"strength", 0.0},
-                            {"importance", 0.0},
-                            {"assignment", json::object()},
-                            {"handle_to_metta", json::object()}};
+    json missing_handles = {{"strength", 0.0}, {"importance", 0.0}, {"assignment", json::object()}};
     EXPECT_THROW(QueryAnswer().from_json(missing_handles), runtime_error);
 
     json bad_handle_type = {{"strength", 0.0},
                             {"importance", 0.0},
                             {"handles", json::array({json::array({1})})},
-                            {"assignment", json::object()},
-                            {"handle_to_metta", json::object()}};
+                            {"assignment", json::object()}};
     EXPECT_THROW(QueryAnswer().from_json(bad_handle_type), runtime_error);
 
     json bad_assignment_value = {{"strength", 0.0},
                                  {"importance", 0.0},
                                  {"handles", json::array({json::array()})},
-                                 {"assignment", {{"v1", 123}}},
-                                 {"handle_to_metta", json::object()}};
+                                 {"assignment", {{"v1", 123}}}};
     EXPECT_THROW(QueryAnswer().from_json(bad_assignment_value), runtime_error);
-
-    json bad_metta_value = {{"strength", 0.0},
-                            {"importance", 0.0},
-                            {"handles", json::array({json::array()})},
-                            {"assignment", json::object()},
-                            {"handle_to_metta", {{"h1", true}}}};
-    EXPECT_THROW(QueryAnswer().from_json(bad_metta_value), runtime_error);
 }
 
 TEST(QueryAnswer, from_json_preserves_state_on_error) {
@@ -546,8 +541,7 @@ TEST(QueryAnswer, from_json_preserves_state_on_error) {
     json bad = {{"strength", 0.0},
                 {"importance", 0.0},
                 {"handles", json::array({json::array({1})})},
-                {"assignment", json::object()},
-                {"handle_to_metta", json::object()}};
+                {"assignment", json::object()}};
     EXPECT_THROW(answer.from_json(bad), runtime_error);
 
     EXPECT_EQ(answer.strength, 0.25);

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -536,6 +536,27 @@ TEST(QueryAnswer, from_json_edge_cases) {
     EXPECT_THROW(QueryAnswer().from_json(bad_metta_value), runtime_error);
 }
 
+TEST(QueryAnswer, from_json_preserves_state_on_error) {
+    QueryAnswer answer(0.5);
+    answer.strength = 0.25;
+    answer.add_handle("h1");
+    answer.assignment.assign("v1", "h2");
+    answer.metta_expression["h1"] = "(Concept \"x\")";
+
+    json bad = {{"strength", 0.0},
+                {"importance", 0.0},
+                {"handles", json::array({json::array({1})})},
+                {"assignment", json::object()},
+                {"handle_to_metta", json::object()}};
+    EXPECT_THROW(answer.from_json(bad), runtime_error);
+
+    EXPECT_EQ(answer.strength, 0.25);
+    EXPECT_EQ(answer.importance, 0.5);
+    EXPECT_EQ(answer.get_handles_vector()[0], "h1");
+    EXPECT_EQ(answer.assignment.get("v1"), "h2");
+    EXPECT_EQ(answer.metta_expression["h1"], "(Concept \"x\")");
+}
+
 TEST(QueryAnswer, get_query_answer_element) {
     QueryAnswer answer;
     answer.get_handles_vector().push_back("h1");

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -531,24 +531,16 @@ TEST(QueryAnswer, from_json_edge_cases) {
     EXPECT_THROW(QueryAnswer().from_json(bad_assignment_value), runtime_error);
 }
 
-TEST(QueryAnswer, from_json_preserves_state_on_error) {
+TEST(QueryAnswer, from_json_throws_on_invalid_handle) {
     QueryAnswer answer(0.5);
     answer.strength = 0.25;
     answer.add_handle("h1");
-    answer.assignment.assign("v1", "h2");
-    answer.metta_expression["h1"] = "(Concept \"x\")";
 
     json bad = {{"strength", 0.0},
                 {"importance", 0.0},
                 {"handles", json::array({json::array({1})})},
                 {"assignment", json::object()}};
     EXPECT_THROW(answer.from_json(bad), runtime_error);
-
-    EXPECT_EQ(answer.strength, 0.25);
-    EXPECT_EQ(answer.importance, 0.5);
-    EXPECT_EQ(answer.get_handles_vector()[0], "h1");
-    EXPECT_EQ(answer.assignment.get("v1"), "h2");
-    EXPECT_EQ(answer.metta_expression["h1"], "(Concept \"x\")");
 }
 
 TEST(QueryAnswer, get_query_answer_element) {


### PR DESCRIPTION
Summary

- Adds `QueryAnswer::to_json()` to serialize QueryAnswers as structured JSON objects.
- Adds `QueryAnswer::from_json()` to rebuild a QueryAnswer from a JSON object.
- Updates the Command Router HTTP API WebSocket stream to send JSON answers instead of debug strings from to_string().
- Changes the chunk pipeline to use JSON arrays end-to-end (**BusCommandRouterProxyStreamPoller**, **CommandExecution**, **CommandRouterHttpAPI**).

`to_json()` with `metta_flag=false`.

```json
{
  "handles":[["289476dbf62faffc149e3658bc368b6b"]],
  "assignment":{"X":"a408f6dd446cdd4fa56f82e77fe6c870"},
  "metta_expressions":[],
  "assignment_metta":{},
  "importance":0.0,
  "strength":0.0
}
```

`to_json()`  with `metta_flag=true`.

```json
{
  "handles":[["289476dbf62faffc149e3658bc368b6b"]],
  "assignment": {"X":"a408f6dd446cdd4fa56f82e77fe6c870"},
  "metta_expressions": [["(Similarity \"human\" \"ent\")"]],
  "assignment_metta":{"X":"\"ent\""},
  "strength":0.0,
  "importance":0.0
}
```

Resolves #1196 