### PR TITLE
[BUGFIX] Mark MORK and adapterDB tests as exclusive

### DIFF
--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -838,6 +838,7 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
+    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//tests/cpp/test_commons:mock_animals_data_lib",
@@ -1004,6 +1005,7 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
+    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//db_adapter:db_adapter_lib",
@@ -1034,6 +1036,7 @@ cc_test(
         "-lbsoncxx",
     ],
     linkstatic = 1,
+    tags = ["exclusive"],
     deps = [
         "//atomdb:atomdb_singleton",
         "//db_adapter:db_adapter_lib",


### PR DESCRIPTION
This change adds `tags = ["exclusive"]` to:

1. morkdb_test
2. morkwrapper_test
3. adapterdb_test