### PR TITLE
[#1199] Minor refactory of HandleTrie to allow lookups cloning the contents of the TrieValue before returning

### DIFF
--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -566,7 +566,7 @@ size_t InMemoryDB::node_count() const { RAISE_ERROR("node_count() is not impleme
 size_t InMemoryDB::link_count() const { RAISE_ERROR("link_count() is not implemented yet"); }
 
 size_t InMemoryDB::atom_count() const {
-    auto size = this->atoms_trie_->size;
+    auto size = this->atoms_trie_->size();
     return static_cast<size_t>(size);
 }
 

--- a/src/attention_broker/HebbianNetwork.cc
+++ b/src/attention_broker/HebbianNetwork.cc
@@ -157,7 +157,7 @@ static bool visit_serialize_node(HandleTrie::TrieNode* trie_node, void* data) {
     visit_data->stream->write(reinterpret_cast<const char*>(&node->stimuli_to_spread),
                               sizeof(node->stimuli_to_spread));
     unsigned int determiners_size = node->determiners.size();
-    unsigned int neighbors_size = node->neighbors->size;
+    unsigned int neighbors_size = node->neighbors->size();
     visit_data->stream->write(reinterpret_cast<const char*>(&determiners_size),
                               sizeof(determiners_size));
     visit_data->stream->write(reinterpret_cast<const char*>(&neighbors_size), sizeof(neighbors_size));
@@ -225,7 +225,8 @@ void HebbianNetwork::deserialize_node(istream& is,
 void HebbianNetwork::serialize(ostream& os) {
     os.write(reinterpret_cast<const char*>(&this->tokens_to_distribute),
              sizeof(this->tokens_to_distribute));
-    os.write(reinterpret_cast<const char*>(&this->nodes->size), sizeof(this->nodes->size));
+    unsigned int s = this->nodes->size();
+    os.write(reinterpret_cast<const char*>(&s), sizeof(s));
     VisitData visit_data;
     visit_data.node = NULL;
     visit_data.network = this;

--- a/src/commons/HandleTrie.cc
+++ b/src/commons/HandleTrie.cc
@@ -3,7 +3,6 @@
 #include <iostream>
 #include <stack>
 
-#include "Utils.h"
 #include "expression_hasher.h"
 
 using namespace commons;
@@ -178,48 +177,8 @@ HandleTrie::TrieValue* HandleTrie::insert(const string& key, TrieValue* value) {
     }
 }
 
-HandleTrie::TrieValue* HandleTrie::lookup(const string& key) {
-    TrieNode* node = lookup_node(key);
-    return node != NULL ? node->value : NULL;
-}
-
-HandleTrie::TrieNode* HandleTrie::lookup_node(const string& key) {
-    if (key.size() != key_size) {
-        RAISE_ERROR("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
-    }
-
-    TrieNode* tree_cursor = root;
-    unsigned char key_cursor = 0;
-    tree_cursor->trie_node_mutex.lock();
-    while (tree_cursor != NULL) {
-        if (tree_cursor->suffix_start > 0) {
-            bool match = true;
-            unsigned int n = key.size();
-            for (unsigned int i = key_cursor; i < n; i++) {
-                if (key[i] != tree_cursor->suffix[i]) {
-                    match = false;
-                    break;
-                }
-            }
-            TrieNode* node = match ? tree_cursor : NULL;
-            tree_cursor->trie_node_mutex.unlock();
-            return node;
-        } else {
-            unsigned char c = TLB[(unsigned char) key[key_cursor]];
-            TrieNode* child = tree_cursor->children[c];
-            tree_cursor->trie_node_mutex.unlock();
-            tree_cursor = child;
-            key_cursor++;
-            if (tree_cursor != NULL) {
-                tree_cursor->trie_node_mutex.lock();
-            }
-        }
-    }
-    return NULL;
-}
-
 bool HandleTrie::remove(const string& key, bool delete_value) {
-    TrieNode* node = lookup_node(key);
+    TrieNode* node = fetch<TrieNode>(key);
     if (node == NULL) {
         return false;
     }
@@ -234,6 +193,15 @@ bool HandleTrie::remove(const string& key, bool delete_value) {
     this->size--;
     node->trie_node_mutex.unlock();
     return true;
+}
+
+void* HandleTrie::lookup_stored_object(const string& key, bool clone) {
+    TrieValue* trie_value = fetch<TrieValue>(key);
+    if (trie_value == NULL) {
+        return NULL;
+    } else {
+        return trie_value->get_stored_object(clone);
+    }
 }
 
 void HandleTrie::traverse(bool keep_root_locked,
@@ -275,6 +243,6 @@ void HandleTrie::traverse(bool keep_root_locked,
 }
 
 bool HandleTrie::exists(const string& key) {
-    TrieNode* node = lookup_node(key);
+    TrieNode* node = fetch<TrieNode>(key);
     return node != NULL ? true : false;
 }

--- a/src/commons/HandleTrie.cc
+++ b/src/commons/HandleTrie.cc
@@ -70,7 +70,7 @@ HandleTrie::HandleTrie(unsigned int key_size) {
         HandleTrie::TLB_INIT();
     }
     this->root = new TrieNode();
-    this->size = 0;
+    this->_size = 0;
 }
 
 HandleTrie::~HandleTrie() { delete root; }
@@ -90,7 +90,7 @@ HandleTrie::TrieValue* HandleTrie::insert(const string& key, TrieValue* value) {
     TrieNode* split;
     unsigned char key_cursor = 0;
     tree_cursor->trie_node_mutex.lock();
-    this->size++;
+    this->_size++;
     while (true) {
         unsigned char c = TLB[(unsigned char) key[key_cursor]];
         if (tree_cursor->children[c] == NULL) {
@@ -154,7 +154,7 @@ HandleTrie::TrieValue* HandleTrie::insert(const string& key, TrieValue* value) {
                 if (match) {
                     if (tree_cursor->value != NULL) {
                         tree_cursor->value->merge(value);
-                        this->size--;
+                        this->_size--;
                         delete value;
                         if (tree_cursor != parent) {
                             parent->trie_node_mutex.unlock();
@@ -178,19 +178,19 @@ HandleTrie::TrieValue* HandleTrie::insert(const string& key, TrieValue* value) {
 }
 
 bool HandleTrie::remove(const string& key, bool delete_value) {
-    TrieNode* node = fetch<TrieNode>(key);
+    TrieNode* node = fetch<TrieNode>(key, false, false);
     if (node == NULL) {
         return false;
     }
     if (node->value == NULL) {
+        node->trie_node_mutex.unlock();
         return false;
     }
-    node->trie_node_mutex.lock();
     if (delete_value) {
         delete node->value;
     }
     node->value = NULL;
-    this->size--;
+    this->_size--;
     node->trie_node_mutex.unlock();
     return true;
 }
@@ -234,6 +234,6 @@ void HandleTrie::traverse(bool keep_root_locked,
 }
 
 bool HandleTrie::exists(const string& key) {
-    TrieNode* node = fetch<TrieNode>(key);
-    return node != NULL ? true : false;
+    TrieNode* node = fetch<TrieNode>(key, true, false);
+    return (node != NULL);
 }

--- a/src/commons/HandleTrie.cc
+++ b/src/commons/HandleTrie.cc
@@ -234,6 +234,5 @@ void HandleTrie::traverse(bool keep_root_locked,
 }
 
 bool HandleTrie::exists(const string& key) {
-    TrieNode* node = fetch<TrieNode>(key, true, false);
-    return (node != NULL);
+    return (fetch<TrieNode>(key, true, false) != NULL);
 }

--- a/src/commons/HandleTrie.cc
+++ b/src/commons/HandleTrie.cc
@@ -233,6 +233,4 @@ void HandleTrie::traverse(bool keep_root_locked,
     }
 }
 
-bool HandleTrie::exists(const string& key) {
-    return (fetch<TrieNode>(key, true, false) != NULL);
-}
+bool HandleTrie::exists(const string& key) { return (fetch<TrieNode>(key, true, false) != NULL); }

--- a/src/commons/HandleTrie.cc
+++ b/src/commons/HandleTrie.cc
@@ -195,15 +195,6 @@ bool HandleTrie::remove(const string& key, bool delete_value) {
     return true;
 }
 
-void* HandleTrie::lookup_stored_object(const string& key, bool clone) {
-    TrieValue* trie_value = fetch<TrieValue>(key);
-    if (trie_value == NULL) {
-        return NULL;
-    } else {
-        return trie_value->get_stored_object(clone);
-    }
-}
-
 void HandleTrie::traverse(bool keep_root_locked,
                           bool (*visit_function)(TrieNode* node, void* data),
                           void* data) {

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -2,6 +2,7 @@
 
 #include <mutex>
 #include <string>
+#include "Utils.h"
 
 #define TRIE_ALPHABET_SIZE ((unsigned int) 16)
 
@@ -25,11 +26,14 @@ class HandleTrie {
      */
     class TrieValue {
        protected:
-        TrieValue();                               /// basic empty constructor.
+        TrieValue(); /// basic empty constructor.
        public:
-        virtual ~TrieValue();                      /// Destructor.
+        virtual ~TrieValue(); /// Destructor.
         virtual void merge(TrieValue* other) = 0;  /// Called when a repeated handle is inserted.
-        virtual string to_string();  /// Returns a string representation of the value object.
+        virtual string to_string(); /// Returns a string representation of the value object.
+        virtual void* get_stored_object(bool clone) { /// Return the actual object being stored (or a clone of it).
+            return (void*) NULL; 
+        }
     };
 
     /**
@@ -72,7 +76,17 @@ class HandleTrie {
      *
      * @return The HandleTrie::TrieValue object attached to the passed key or NULL if none.
      */
-    TrieValue* lookup(const string& key);
+    inline TrieValue* lookup(const string& key) { return fetch<TrieValue>(key); }
+
+    /**
+     * Lookup for a given handle and return the corresponding object stored in TrieValue.
+     *
+     * @param key Handle being searched.
+     * @param clone A flag indicating if a clone is supposed to be returned instead of the actual object being stored.
+     *
+     * @return The object actually being stored inside a HandleTrie::TrieValue object attached to the passed key.
+     */
+    void* lookup_stored_object(const string& key, bool clone = false);
 
     bool exists(const string& key);
 
@@ -100,15 +114,51 @@ class HandleTrie {
     unsigned int size;
 
    private:
-    /**
-     * Lookup for a node containing a given handle.
-     * Similar to lookup() but returns the node pointer instead of the value.
-     *
-     * @param key Handle being searched.
-     *
-     * @return The HandleTrie::TrieNode containing the key or NULL if none.
-     */
-    TrieNode* lookup_node(const string& key);
+
+    template <typename T>
+    T* fetch(const string& key) {
+        if (key.size() != key_size) {
+            RAISE_ERROR("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
+        }
+
+        TrieNode* tree_cursor = root;
+        unsigned char key_cursor = 0;
+        tree_cursor->trie_node_mutex.lock();
+        while (tree_cursor != NULL) {
+            if (tree_cursor->suffix_start > 0) {
+                bool match = true;
+                unsigned int n = key.size();
+                for (unsigned int i = key_cursor; i < n; i++) {
+                    if (key[i] != tree_cursor->suffix[i]) {
+                        match = false;
+                        break;
+                    }
+                }
+                TrieNode* node = match ? tree_cursor : NULL;
+                tree_cursor->trie_node_mutex.unlock();
+                if (node == NULL) {
+                    return NULL;
+                }
+                if constexpr (is_same_v<T, TrieNode>) {
+                    return node;
+                } else if constexpr (is_same_v<T, TrieValue>) {
+                    return node->value;
+                } else {
+                    RAISE_ERROR("Invalid fetch() attempt with unexpected type");
+                }
+            } else {
+                unsigned char c = TLB[(unsigned char) key[key_cursor]];
+                TrieNode* child = tree_cursor->children[c];
+                tree_cursor->trie_node_mutex.unlock();
+                tree_cursor = child;
+                key_cursor++;
+                if (tree_cursor != NULL) {
+                    tree_cursor->trie_node_mutex.lock();
+                }
+            }
+        }
+        return NULL;
+    }
 
     static unsigned char TLB[256];
     static bool TLB_INITIALIZED;

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <atomic>
 #include <string>
 #include "Utils.h"
 
@@ -32,7 +33,8 @@ class HandleTrie {
         virtual void merge(TrieValue* other) = 0;  /// Called when a repeated handle is inserted.
         virtual string to_string(); /// Returns a string representation of the value object.
         virtual void* get_stored_object(bool clone) { /// Return the actual object being stored (or a clone of it).
-            return (void*) NULL; 
+            RAISE_ERROR("get_stored_object() is not implemented for this TrieValue subclass.");
+            return NULL; // Just to avoid warnings
         }
     };
 
@@ -76,7 +78,7 @@ class HandleTrie {
      *
      * @return The HandleTrie::TrieValue object attached to the passed key or NULL if none.
      */
-    inline TrieValue* lookup(const string& key) { return fetch<TrieValue>(key); }
+    inline TrieValue* lookup(const string& key) { return fetch<TrieValue>(key, true, false); }
 
     /**
      * Lookup for a given handle and return the corresponding object stored in TrieValue.
@@ -86,7 +88,7 @@ class HandleTrie {
      *
      * @return The object actually being stored inside a HandleTrie::TrieValue object attached to the passed key.
      */
-    inline void* lookup_stored_object(const string& key, bool clone = false) { return fetch<void>(key, clone); }
+    inline void* lookup_stored_object(const string& key, bool clone = false) { return fetch<void>(key, true, clone); }
 
     bool exists(const string& key);
 
@@ -110,13 +112,19 @@ class HandleTrie {
      */
     void traverse(bool keep_root_locked, bool (*visit_function)(TrieNode* node, void* data), void* data);
 
+    /**
+     * Return the number of elements stored in this HandleTrie.
+     *
+     * @return The number of elements stored in this HandleTrie.
+     */
+    inline unsigned int size() { return (unsigned int) this->_size; }
+
     TrieNode* root;
-    unsigned int size;
 
    private:
 
     template <typename T>
-    T* fetch(const string& key, bool clone_stored_object = false) {
+    T* fetch(const string& key, bool unlock_node, bool clone_stored_object) {
         if (key.size() != key_size) {
             RAISE_ERROR("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
         }
@@ -142,12 +150,16 @@ class HandleTrie {
                     } else if constexpr (is_same_v<T, TrieValue>) {
                         answer = node->value;
                     } else if constexpr (is_same_v<T, void>) {
-                        answer = node->value->get_stored_object(clone_stored_object);
+                        if (node->value != NULL) {
+                            answer = node->value->get_stored_object(clone_stored_object);
+                        }
                     } else {
                         RAISE_ERROR("Invalid fetch() attempt with unexpected type");
                     }
                 }
-                tree_cursor->trie_node_mutex.unlock();
+                if (unlock_node) {
+                    tree_cursor->trie_node_mutex.unlock();
+                }
                 return answer;
             } else {
                 unsigned char c = TLB[(unsigned char) key[key_cursor]];
@@ -186,6 +198,7 @@ class HandleTrie {
     }
 
     unsigned int key_size;
+    atomic<unsigned int> _size;
 };
 
 /**

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -86,7 +86,7 @@ class HandleTrie {
      *
      * @return The object actually being stored inside a HandleTrie::TrieValue object attached to the passed key.
      */
-    void* lookup_stored_object(const string& key, bool clone = false);
+    void* lookup_stored_object(const string& key, bool clone = false) { return fetch<void>(key, clone); }
 
     bool exists(const string& key);
 
@@ -116,7 +116,7 @@ class HandleTrie {
    private:
 
     template <typename T>
-    T* fetch(const string& key) {
+    T* fetch(const string& key, bool clone_stored_object = false) {
         if (key.size() != key_size) {
             RAISE_ERROR("Invalid key size: " + to_string(key.size()) + " != " + to_string(key_size));
         }
@@ -143,6 +143,8 @@ class HandleTrie {
                     return node;
                 } else if constexpr (is_same_v<T, TrieValue>) {
                     return node->value;
+                } else if constexpr (is_same_v<T, void>) {
+                    return node->value->get_stored_object(clone_stored_object);
                 } else {
                     RAISE_ERROR("Invalid fetch() attempt with unexpected type");
                 }

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -135,19 +135,18 @@ class HandleTrie {
                     }
                 }
                 TrieNode* node = match ? tree_cursor : NULL;
-                tree_cursor->trie_node_mutex.unlock();
-                if (node == NULL) {
-                    return NULL;
-                }
+                T* answer = NULL;
                 if constexpr (is_same_v<T, TrieNode>) {
-                    return node;
+                    answer = node;
                 } else if constexpr (is_same_v<T, TrieValue>) {
-                    return node->value;
+                    answer = node->value;
                 } else if constexpr (is_same_v<T, void>) {
-                    return node->value->get_stored_object(clone_stored_object);
+                    answer = node->value->get_stored_object(clone_stored_object);
                 } else {
                     RAISE_ERROR("Invalid fetch() attempt with unexpected type");
                 }
+                tree_cursor->trie_node_mutex.unlock();
+                return answer;
             } else {
                 unsigned char c = TLB[(unsigned char) key[key_cursor]];
                 TrieNode* child = tree_cursor->children[c];

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -93,7 +93,7 @@ class HandleTrie {
      * @return The object actually being stored inside a HandleTrie::TrieValue object attached to the
      * passed key.
      */
-    inline void* lookup_stored_object(const string& key, bool clone=true) {
+    inline void* lookup_stored_object(const string& key, bool clone = true) {
         return fetch<void>(key, true, clone);
     }
 

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -86,13 +86,14 @@ class HandleTrie {
      * Lookup for a given handle and return the corresponding object stored in TrieValue.
      *
      * @param key Handle being searched.
-     * @param clone A flag indicating if a clone is supposed to be returned instead of the actual object
-     * being stored.
+     * @param clone A flag indicating if a clone is supposed to be returned instead of the actual
+     * object being stored. It's defaulted to "true". Use clone=false with caution as the actual
+     * raw pointer to the inner stored object inside the TrieValue is returned.
      *
      * @return The object actually being stored inside a HandleTrie::TrieValue object attached to the
      * passed key.
      */
-    inline void* lookup_stored_object(const string& key, bool clone = false) {
+    inline void* lookup_stored_object(const string& key, bool clone=true) {
         return fetch<void>(key, true, clone);
     }
 
@@ -149,20 +150,25 @@ class HandleTrie {
                 }
                 TrieNode* node = match ? tree_cursor : NULL;
                 T* answer = NULL;
+                bool forced_lock_release = false;
                 if (node != NULL) {
                     if constexpr (is_same_v<T, TrieNode>) {
                         answer = node;
                     } else if constexpr (is_same_v<T, TrieValue>) {
+                        forced_lock_release = true;
                         answer = node->value;
                     } else if constexpr (is_same_v<T, void>) {
+                        forced_lock_release = true;
                         if (node->value != NULL) {
                             answer = node->value->get_stored_object(clone_stored_object);
                         }
                     } else {
                         RAISE_ERROR("Invalid fetch() attempt with unexpected type");
                     }
+                } else {
+                    forced_lock_release = true;
                 }
-                if (unlock_node) {
+                if (unlock_node || forced_lock_release) {
                     tree_cursor->trie_node_mutex.unlock();
                 }
                 return answer;

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -136,14 +136,16 @@ class HandleTrie {
                 }
                 TrieNode* node = match ? tree_cursor : NULL;
                 T* answer = NULL;
-                if constexpr (is_same_v<T, TrieNode>) {
-                    answer = node;
-                } else if constexpr (is_same_v<T, TrieValue>) {
-                    answer = node->value;
-                } else if constexpr (is_same_v<T, void>) {
-                    answer = node->value->get_stored_object(clone_stored_object);
-                } else {
-                    RAISE_ERROR("Invalid fetch() attempt with unexpected type");
+                if (node != NULL) {
+                    if constexpr (is_same_v<T, TrieNode>) {
+                        answer = node;
+                    } else if constexpr (is_same_v<T, TrieValue>) {
+                        answer = node->value;
+                    } else if constexpr (is_same_v<T, void>) {
+                        answer = node->value->get_stored_object(clone_stored_object);
+                    } else {
+                        RAISE_ERROR("Invalid fetch() attempt with unexpected type");
+                    }
                 }
                 tree_cursor->trie_node_mutex.unlock();
                 return answer;

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <mutex>
 #include <atomic>
+#include <mutex>
 #include <string>
+
 #include "Utils.h"
 
 #define TRIE_ALPHABET_SIZE ((unsigned int) 16)
@@ -27,14 +28,15 @@ class HandleTrie {
      */
     class TrieValue {
        protected:
-        TrieValue(); /// basic empty constructor.
+        TrieValue();                               /// basic empty constructor.
        public:
-        virtual ~TrieValue(); /// Destructor.
+        virtual ~TrieValue();                      /// Destructor.
         virtual void merge(TrieValue* other) = 0;  /// Called when a repeated handle is inserted.
-        virtual string to_string(); /// Returns a string representation of the value object.
-        virtual void* get_stored_object(bool clone) { /// Return the actual object being stored (or a clone of it).
+        virtual string to_string();  /// Returns a string representation of the value object.
+        virtual void* get_stored_object(
+            bool clone) {            /// Return the actual object being stored (or a clone of it).
             RAISE_ERROR("get_stored_object() is not implemented for this TrieValue subclass.");
-            return NULL; // Just to avoid warnings
+            return NULL;             // Just to avoid warnings
         }
     };
 
@@ -84,11 +86,15 @@ class HandleTrie {
      * Lookup for a given handle and return the corresponding object stored in TrieValue.
      *
      * @param key Handle being searched.
-     * @param clone A flag indicating if a clone is supposed to be returned instead of the actual object being stored.
+     * @param clone A flag indicating if a clone is supposed to be returned instead of the actual object
+     * being stored.
      *
-     * @return The object actually being stored inside a HandleTrie::TrieValue object attached to the passed key.
+     * @return The object actually being stored inside a HandleTrie::TrieValue object attached to the
+     * passed key.
      */
-    inline void* lookup_stored_object(const string& key, bool clone = false) { return fetch<void>(key, true, clone); }
+    inline void* lookup_stored_object(const string& key, bool clone = false) {
+        return fetch<void>(key, true, clone);
+    }
 
     bool exists(const string& key);
 
@@ -122,7 +128,6 @@ class HandleTrie {
     TrieNode* root;
 
    private:
-
     template <typename T>
     T* fetch(const string& key, bool unlock_node, bool clone_stored_object) {
         if (key.size() != key_size) {

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -86,7 +86,7 @@ class HandleTrie {
      *
      * @return The object actually being stored inside a HandleTrie::TrieValue object attached to the passed key.
      */
-    void* lookup_stored_object(const string& key, bool clone = false) { return fetch<void>(key, clone); }
+    inline void* lookup_stored_object(const string& key, bool clone = false) { return fetch<void>(key, clone); }
 
     bool exists(const string& key);
 

--- a/src/db_adapter/DatabaseMapper.cc
+++ b/src/db_adapter/DatabaseMapper.cc
@@ -18,4 +18,4 @@ using namespace db_adapter;
 using namespace commons;
 using namespace atoms;
 
-unsigned int DatabaseMapper::handle_trie_size() { return this->handle_trie.size; }
+unsigned int DatabaseMapper::handle_trie_size() { return this->handle_trie.size(); }

--- a/src/tests/cpp/handle_trie_test.cc
+++ b/src/tests/cpp/handle_trie_test.cc
@@ -92,7 +92,7 @@ TEST(HandleTrieTest, basics) {
     EXPECT_TRUE(value != NULL);
     EXPECT_TRUE(value->count == 3);
     // -- begin -- test lookup_stored_object() just in this first test case
-    unsigned int* check_count = (unsigned int*) trie.lookup_stored_object("ABCD");
+    unsigned int* check_count = (unsigned int*) trie.lookup_stored_object("ABCD", false);
     EXPECT_TRUE(*check_count == 3);
     EXPECT_TRUE(check_count == &(((TestValue*) value)->count));
     check_count = (unsigned int*) trie.lookup_stored_object("ABCD", true);

--- a/src/tests/cpp/handle_trie_test.cc
+++ b/src/tests/cpp/handle_trie_test.cc
@@ -21,11 +21,11 @@ class TestValue : public HandleTrie::TrieValue {
     void merge(TrieValue* other) {}
     void* get_stored_object(bool clone) {
         if (clone) {
-            unsigned int *cloned_count = new unsigned int[1];
+            unsigned int* cloned_count = new unsigned int[1];
             cloned_count[0] = this->count;
-            return (void *) cloned_count;
+            return (void*) cloned_count;
         } else {
-            return (void *) &(this->count);
+            return (void*) &(this->count);
         }
     }
 };
@@ -37,11 +37,11 @@ class AccumulatorValue : public HandleTrie::TrieValue {
     void merge(TrieValue* other) { this->count += ((AccumulatorValue*) other)->count; }
     void* get_stored_object(bool clone) {
         if (clone) {
-            unsigned int *cloned_count = new unsigned int[1];
+            unsigned int* cloned_count = new unsigned int[1];
             cloned_count[0] = this->count;
-            return (void *) cloned_count;
+            return (void*) cloned_count;
         } else {
-            return (void *) &(this->count);
+            return (void*) &(this->count);
         }
     }
 };
@@ -92,13 +92,13 @@ TEST(HandleTrieTest, basics) {
     EXPECT_TRUE(value != NULL);
     EXPECT_TRUE(value->count == 3);
     // -- begin -- test lookup_stored_object() just in this first test case
-    unsigned int *check_count = (unsigned int *) trie.lookup_stored_object("ABCD");
+    unsigned int* check_count = (unsigned int*) trie.lookup_stored_object("ABCD");
     EXPECT_TRUE(*check_count == 3);
-    EXPECT_TRUE(check_count == &(((AccumulatorValue *) value)->count));
-    check_count = (unsigned int *) trie.lookup_stored_object("ABCD", true);
+    EXPECT_TRUE(check_count == &(((AccumulatorValue*) value)->count));
+    check_count = (unsigned int*) trie.lookup_stored_object("ABCD", true);
     EXPECT_TRUE(*check_count == 3);
-    EXPECT_TRUE(check_count != &(((AccumulatorValue *) value)->count));
-    delete [] check_count;
+    EXPECT_TRUE(check_count != &(((AccumulatorValue*) value)->count));
+    delete[] check_count;
     // -- end --
     value = (TestValue*) trie.lookup("ABCF");
     EXPECT_TRUE(value == NULL);
@@ -507,11 +507,11 @@ void visitor_stored_object(HandleTrie* trie, unsigned int n_visits, string* hand
     for (unsigned int i = 0; i < n_visits; i++) {
         string s = handles[rand() % HANDLE_SPACE_SIZE];
         LOG_DEBUG("Trying to visit: " + s);
-        unsigned int *check_count = (unsigned int *) trie->lookup_stored_object(s, true);
+        unsigned int* check_count = (unsigned int*) trie->lookup_stored_object(s, true);
         if (check_count != NULL) {
             LOG_DEBUG("Visiting: " + s);
             EXPECT_TRUE(*check_count < 1000000);
-            delete [] check_count;
+            delete[] check_count;
         }
     }
 }

--- a/src/tests/cpp/handle_trie_test.cc
+++ b/src/tests/cpp/handle_trie_test.cc
@@ -19,13 +19,31 @@ class TestValue : public HandleTrie::TrieValue {
     unsigned int count;
     TestValue(int count = 1) { this->count = count; }
     void merge(TrieValue* other) {}
+    void* get_stored_object(bool clone) {
+        if (clone) {
+            unsigned int *cloned_count = new unsigned int[1];
+            cloned_count[0] = this->count;
+            return (void *) cloned_count;
+        } else {
+            return (void *) &(this->count);
+        }
+    }
 };
 
 class AccumulatorValue : public HandleTrie::TrieValue {
    public:
     unsigned int count;
     AccumulatorValue() { this->count = 1; }
-    void merge(TrieValue* other) { count += ((AccumulatorValue*) other)->count; }
+    void merge(TrieValue* other) { this->count += ((AccumulatorValue*) other)->count; }
+    void* get_stored_object(bool clone) {
+        if (clone) {
+            unsigned int *cloned_count = new unsigned int[1];
+            cloned_count[0] = this->count;
+            return (void *) cloned_count;
+        } else {
+            return (void *) &(this->count);
+        }
+    }
 };
 
 char R_TLB[16] = {
@@ -73,6 +91,15 @@ TEST(HandleTrieTest, basics) {
     value = (TestValue*) trie.lookup("ABCD");
     EXPECT_TRUE(value != NULL);
     EXPECT_TRUE(value->count == 3);
+    // -- begin -- test lookup_stored_object() just in this first test case
+    unsigned int *check_count = (unsigned int *) trie.lookup_stored_object("ABCD");
+    EXPECT_TRUE(*check_count == 3);
+    EXPECT_TRUE(check_count == &(((AccumulatorValue *) value)->count));
+    check_count = (unsigned int *) trie.lookup_stored_object("ABCD", true);
+    EXPECT_TRUE(*check_count == 3);
+    EXPECT_TRUE(check_count != &(((AccumulatorValue *) value)->count));
+    delete [] check_count;
+    // -- end --
     value = (TestValue*) trie.lookup("ABCF");
     EXPECT_TRUE(value == NULL);
 
@@ -464,6 +491,7 @@ void producer2(HandleTrie* trie, unsigned int n_insertions, string* handles) {
     for (unsigned int i = 0; i < n_insertions; i++) {
         string s = handles[rand() % HANDLE_SPACE_SIZE];
         value = new AccumulatorValue();
+        LOG_DEBUG("Producing: " + s);
         trie->insert(s, value);
     }
 }
@@ -472,6 +500,30 @@ void visitor2(HandleTrie* trie, unsigned int n_visits, string* handles) {
     for (unsigned int i = 0; i < n_visits; i++) {
         string s = handles[rand() % HANDLE_SPACE_SIZE];
         trie->lookup(s);
+    }
+}
+
+void visitor_stored_object(HandleTrie* trie, unsigned int n_visits, string* handles) {
+    for (unsigned int i = 0; i < n_visits; i++) {
+        string s = handles[rand() % HANDLE_SPACE_SIZE];
+        LOG_DEBUG("Trying to visit: " + s);
+        unsigned int *check_count = (unsigned int *) trie->lookup_stored_object(s, true);
+        if (check_count != NULL) {
+            LOG_DEBUG("Visiting: " + s);
+            EXPECT_TRUE(*check_count < 1000000);
+            delete [] check_count;
+        }
+    }
+}
+
+void remover(HandleTrie* trie, unsigned int n_removals, string* handles) {
+    for (unsigned int i = 0; i < n_removals; i++) {
+        string s = handles[rand() % HANDLE_SPACE_SIZE];
+        LOG_DEBUG("Checking existence of: " + s);
+        if (trie->exists(s)) {
+            LOG_DEBUG("Removing: " + s);
+            trie->remove(s);
+        }
     }
 }
 
@@ -538,11 +590,53 @@ TEST(HandleTrieTest, multithread_limited_handle_set) {
     }
 }
 
+TEST(HandleTrieTest, multithread_limited_handle_set_with_deletion) {
+    string handles[HANDLE_SPACE_SIZE];
+    for (unsigned int i = 0; i < HANDLE_SPACE_SIZE; i++) {
+        handles[i] = random_handle();
+    }
+    vector<thread*> producers;
+    vector<thread*> visitors;
+    vector<thread*> removers;
+    unsigned int n_insertions = 100000;
+    unsigned int n_visits = 100000;
+    unsigned int n_removals = 10000;
+    int n_removers = 10;
+    for (int n_producers : {2, 10, 100}) {
+        for (int n_visitors : {2, 10, 100}) {
+            unsigned int key_size = HANDLE_HASH_SIZE - 1;
+            HandleTrie* trie = new HandleTrie(key_size);
+            for (int i = 0; i < n_producers; i++) {
+                producers.push_back(new thread(&producer2, trie, n_insertions, handles));
+            }
+            for (int i = 0; i < n_visitors; i++) {
+                visitors.push_back(new thread(&visitor_stored_object, trie, n_visits, handles));
+            }
+            for (int i = 0; i < n_removers; i++) {
+                removers.push_back(new thread(&remover, trie, n_removals, handles));
+            }
+            for (thread* t : producers) {
+                t->join();
+            }
+            for (thread* t : visitors) {
+                t->join();
+            }
+            for (thread* t : removers) {
+                t->join();
+            }
+            delete trie;
+            producers.clear();
+            visitors.clear();
+            removers.clear();
+        }
+    }
+}
+
 TEST(HandleTrieTest, remove_basic) {
     HandleTrie trie(4);
     TestValue* value;
 
-    unsigned int initial_size = trie.size;
+    unsigned int initial_size = trie.size();
     EXPECT_EQ(initial_size, 0);
 
     // Insert some values
@@ -552,7 +646,7 @@ TEST(HandleTrieTest, remove_basic) {
     trie.insert("FBCD", new TestValue(6));
     trie.insert("AFCD", new TestValue(7));
 
-    EXPECT_EQ(trie.size, initial_size + 5);
+    EXPECT_EQ(trie.size(), initial_size + 5);
 
     // Verify they exist
     value = (TestValue*) trie.lookup("ABCD");
@@ -570,7 +664,7 @@ TEST(HandleTrieTest, remove_basic) {
     value = (TestValue*) trie.lookup("ABCD");
     EXPECT_TRUE(value == NULL);
 
-    EXPECT_EQ(trie.size, initial_size + 4);
+    EXPECT_EQ(trie.size(), initial_size + 4);
 
     // Verify others still exist
     value = (TestValue*) trie.lookup("ABCF");
@@ -590,7 +684,7 @@ TEST(HandleTrieTest, remove_basic) {
     removed = trie.remove("XXXX");
     EXPECT_FALSE(removed);
 
-    EXPECT_EQ(trie.size, initial_size + 4);
+    EXPECT_EQ(trie.size(), initial_size + 4);
 }
 
 TEST(HandleTrieTest, remove_and_reinsert) {

--- a/src/tests/cpp/handle_trie_test.cc
+++ b/src/tests/cpp/handle_trie_test.cc
@@ -94,10 +94,10 @@ TEST(HandleTrieTest, basics) {
     // -- begin -- test lookup_stored_object() just in this first test case
     unsigned int* check_count = (unsigned int*) trie.lookup_stored_object("ABCD");
     EXPECT_TRUE(*check_count == 3);
-    EXPECT_TRUE(check_count == &(((AccumulatorValue*) value)->count));
+    EXPECT_TRUE(check_count == &(((TestValue*) value)->count));
     check_count = (unsigned int*) trie.lookup_stored_object("ABCD", true);
     EXPECT_TRUE(*check_count == 3);
-    EXPECT_TRUE(check_count != &(((AccumulatorValue*) value)->count));
+    EXPECT_TRUE(check_count != &(((TestValue*) value)->count));
     delete[] check_count;
     // -- end --
     value = (TestValue*) trie.lookup("ABCF");


### PR DESCRIPTION
Resolves #1199

We rewrote lookup() (which is in the public API) and wrote a new public lookup_stored_object() both using the same private method fetch() which is basically the old lookup() but rewritten to be a templated function so we can use it to return either the TrieNode, the TrieValue within it or whatever user object which is stored inside the TrieValue (optionally cloning this object instead of returning it directly). We also added an optional flag to fetch() to allow returning whiteout unlocking the corresponding TrieNode.

In addition to the new features, we added a couple of use cases to test the new functionalities and adapted pre-existing code to use the new public elements in HandleTrie. We also fixed a pre-existing bug related to the class variable HandleTrie::size, which was renamed to HandleTrie::_size and has been made atomic with a new public access method named size().