### PR TITLE
[#FIX] Disable compilation of unit tests in postgres lib

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -67,7 +67,7 @@ COPY src/assets/libpqxx-7.10.5.tar.gz /tmp
 RUN cd /tmp \
     && tar xzvf libpqxx-7.10.5.tar.gz \
     && cd /tmp/libpqxx-7.10.5 \
-    && cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POSITION_INDEPENDENT_CODE=ON\
+    && cmake -S . -B build -DSKIP_BUILD_TEST=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POSITION_INDEPENDENT_CODE=ON\
     && cmake --build build -j \
     && cmake --install build \
     && ldconfig


### PR DESCRIPTION
In MacOS this step in our Dockerfile was flaky:

```
RUN cd /tmp \
    && tar xzvf libpqxx-7.10.5.tar.gz \
    && cd /tmp/libpqxx-7.10.5 \
    && cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POSITION_INDEPENDENT_CODE=ON\
    && cmake --build build -j \
    && cmake --install build \
    && ldconfig
```

The first `cmake` commands sometimes breaks with: 

```
46.11 c++: fatal error: Killed signal terminated program cc1plus
46.12 compilation terminated.
46.18 gmake[2]: *** [test/CMakeFiles/runner.dir/build.make:678: test/CMakeFiles/runner.dir/unit/test_array.cxx.o] Error 1
46.20 gmake[2]: *** Waiting for unfinished jobs....
48.59 c++: fatal error: Killed signal terminated program cc1plus
48.59 compilation terminated.
48.67 gmake[2]: *** [test/CMakeFiles/runner.dir/build.make:1182: test/CMakeFiles/runner.dir/unit/test_test_helpers.cxx.o] Error 1
52.66 c++: fatal error: Killed signal terminated program cc1plus
52.66 compilation terminated.
52.71 gmake[2]: *** [test/CMakeFiles/runner.dir/build.make:90: test/CMakeFiles/runner.dir/test00.cxx.o] Error 1
54.32 c++: fatal error: Killed signal terminated program cc1plus
54.32 compilation terminated.
54.42 gmake[2]: *** [test/CMakeFiles/runner.dir/build.make:398: test/CMakeFiles/runner.dir/test60.cxx.o] Error 1
76.43 gmake[1]: *** [CMakeFiles/Makefile2:160: test/CMakeFiles/runner.dir/all] Error 2
76.43 gmake: *** [Makefile:156: all] Error 2
```

This flakiness were also reported to happen in our pipeline as well.

In this PR, I disable the unit tests compilation in libpqxx since this is where the error is happening and we don't really need these unit tests.
