### PR TITLE
[#1226] Force all Utils methods to use the same statically initialized seed

### DIFF
--- a/src/agents/query_engine/query_element/LinkTemplate.cc
+++ b/src/agents/query_engine/query_element/LinkTemplate.cc
@@ -47,8 +47,6 @@ LinkTemplate::LinkTemplate(const string& type,
     this->inner_flag = true;
     this->arity = targets.size();
     this->processor = nullptr;
-    this->random_generator =
-        new std::mt19937(std::chrono::system_clock::now().time_since_epoch().count());
     unsigned int max_reverse_nesting = 0;
     this->attention_focus_strategy = PERCENTAGE;
     for (auto element : targets) {
@@ -64,7 +62,6 @@ LinkTemplate::~LinkTemplate() {
     if (this->processor != nullptr) {
         this->processor->stop();
     }
-    delete this->random_generator;
     LOG_LOCAL_DEBUG("Deleting LinkTemplate: " + std::to_string((unsigned long) this) + "... Done");
 }
 
@@ -132,7 +129,9 @@ void LinkTemplate::compute_importance(vector<pair<char*, float>>& handles) {
     }
     // Sort decreasing by importance value
 
-    std::shuffle(handles.begin(), handles.end(), *this->random_generator);
+    Random::lock_random_generator();
+    std::shuffle(handles.begin(), handles.end(), *Random::get_random_generator());
+    Random::unlock_random_generator();
     std::sort(handles.begin(),
               handles.end(),
               [](const std::pair<char*, float>& left, const std::pair<char*, float>& right) {

--- a/src/agents/query_engine/query_element/LinkTemplate.h
+++ b/src/agents/query_engine/query_element/LinkTemplate.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <mutex>
-#include <random>
 #include <string>
 #include <vector>
 
@@ -82,7 +81,6 @@ class LinkTemplate : public QueryElement {
     LinkSchema link_schema;
     shared_ptr<SourceElement> source_element;
     shared_ptr<StoppableThread> processor;
-    std::mt19937* random_generator;
     AttentionFocusStrategy attention_focus_strategy;
     static ThreadSafeHashmap<string, shared_ptr<atomdb_api_types::HandleSet>> cache;
 

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -37,12 +37,20 @@ void Utils::error(string msg, bool throw_flag, bool log_flag) {
 }
 
 bool Utils::flip_coin(double true_probability) {
-    long f = 1000;
-    std::uniform_int_distribution<unsigned int> distribution(0, f);
-    Random::lock_random_generator();
-    unsigned int number = distribution(*Random::get_random_generator());
-    Random::unlock_random_generator();
-    return (number < lround(true_probability * f));
+    bool answer = false;
+    if ((true_probability > 1.0) || (true_probability < 0.0)) {
+        RAISE_ERROR("true_probability is supposed to be in [0, 1]");
+    } else {
+        if (true_probability > 0.0) {
+            long f = 1000;
+            std::uniform_int_distribution<unsigned int> distribution(0, f - 1);
+            Random::lock_random_generator();
+            unsigned int number = distribution(*Random::get_random_generator());
+            Random::unlock_random_generator();
+            answer = (number < lround(true_probability * f));
+        }
+    }
+    return answer;
 }
 
 unsigned int Utils::uint_rand(unsigned int closed_lower_bound, unsigned int open_upper_bound) {
@@ -50,7 +58,7 @@ unsigned int Utils::uint_rand(unsigned int closed_lower_bound, unsigned int open
         RAISE_ERROR("Invalid bounds: [" + std::to_string(closed_lower_bound) + ", " +
                     std::to_string(open_upper_bound) + ")");
     }
-    int delta = open_upper_bound - closed_lower_bound;
+    unsigned int delta = open_upper_bound - closed_lower_bound;
     std::uniform_int_distribution<unsigned int> distribution(0, delta - 1);
     Random::lock_random_generator();
     unsigned int number = distribution(*Random::get_random_generator());
@@ -516,11 +524,12 @@ void Random::init(unsigned int seed) {
         } else {
             random_generator = new std::mt19937(seed);
         }
+        random_generator_mutex.unlock();
     } else {
+        random_generator_mutex.unlock();
         RAISE_ERROR(
             "commons::Random already initialized. commons::Random::init() should be called only once.");
     }
-    random_generator_mutex.unlock();
 }
 
 void Random::lock_random_generator() {

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -38,18 +38,41 @@ void Utils::error(string msg, bool throw_flag, bool log_flag) {
 
 bool Utils::flip_coin(double true_probability) {
     long f = 1000;
-    return (rand() % f) < lround(true_probability * f);
+    std::uniform_int_distribution<unsigned int> distribution(0, f);
+    Random::lock_random_generator();
+    unsigned int number = distribution(*Random::get_random_generator());
+    Random::unlock_random_generator();
+    return (number < lround(true_probability * f));
 }
 
 unsigned int Utils::uint_rand(unsigned int closed_lower_bound, unsigned int open_upper_bound) {
     if (open_upper_bound <= closed_lower_bound) {
-        RAISE_ERROR("Invalid bounds");
+        RAISE_ERROR("Invalid bounds: [" + std::to_string(closed_lower_bound) + ", " + std::to_string(open_upper_bound) + ")");
     }
-    return (rand() % (open_upper_bound - closed_lower_bound)) + closed_lower_bound;
+    int delta = open_upper_bound - closed_lower_bound;
+    std::uniform_int_distribution<unsigned int> distribution(0, delta - 1);
+    Random::lock_random_generator();
+    unsigned int number = distribution(*Random::get_random_generator());
+    Random::unlock_random_generator();
+    return closed_lower_bound + number;
 }
 
 unsigned int Utils::uint_rand(unsigned int open_upper_bound) {
     return Utils::uint_rand(0, open_upper_bound);
+}
+
+string Utils::random_string(size_t length, const string& charset) {
+    const size_t size = charset.size();
+    string result;
+    for (size_t i = 0; i < length; i++) {
+        result += charset[Utils::uint_rand(size)];
+    }
+    return result;
+}
+
+string Utils::random_string(size_t length) {
+    string charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    return random_string(length, charset);
 }
 
 void Utils::sleep(unsigned int milliseconds) {
@@ -139,20 +162,6 @@ string Utils::join(const vector<string>& tokens, char delimiter) {
             result += delimiter;
         }
         result += tokens[i];
-    }
-    return result;
-}
-
-string Utils::random_string(size_t length) {
-    string charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    return random_string(length, charset);
-}
-
-string Utils::random_string(size_t length, const string& charset) {
-    const size_t size = charset.size();
-    string result;
-    for (size_t i = 0; i < length; i++) {
-        result += charset[rand() % size];
     }
     return result;
 }
@@ -489,6 +498,49 @@ string MemoryFootprint::to_string() {
     }
     answer += "]}";
     return answer;
+}
+
+// --------------------------------------------------------------------------------
+// Random
+
+std::mt19937* Random::random_generator = NULL;
+mutex Random::random_generator_mutex;
+
+void Random::init(unsigned int seed) {
+    random_generator_mutex.lock();
+    if (Random::random_generator == NULL) {
+        if (seed == 0) {
+            random_generator = new std::mt19937(std::chrono::system_clock::now().time_since_epoch().count());
+        } else {
+            random_generator = new std::mt19937(seed);
+        }
+    } else {
+        RAISE_ERROR("commons::Random already initialized. commons::Random::init() should be called only once.");
+    }
+    random_generator_mutex.unlock();
+}
+
+void Random::lock_random_generator() {
+    if (Random::random_generator == NULL) {
+        RAISE_ERROR("commons::Random is not initialized. Call commons::Random::init(seed) before using random numbers.");
+    } else {
+        random_generator_mutex.lock();
+    }
+}
+
+void Random::unlock_random_generator() {
+    if (Random::random_generator == NULL) {
+        RAISE_ERROR("commons::Random is not initialized. Call commons::Random::init(seed) before using random numbers.");
+    } else {
+        random_generator_mutex.unlock();
+    }
+}
+
+std::mt19937* Random::get_random_generator() {
+    if (Random::random_generator == NULL) {
+        RAISE_ERROR("commons::Random is not initialized. Call commons::Random::init(seed) before using random numbers.");
+    }
+    return random_generator;
 }
 
 // --------------------------------------------------------------------------------

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -47,7 +47,8 @@ bool Utils::flip_coin(double true_probability) {
 
 unsigned int Utils::uint_rand(unsigned int closed_lower_bound, unsigned int open_upper_bound) {
     if (open_upper_bound <= closed_lower_bound) {
-        RAISE_ERROR("Invalid bounds: [" + std::to_string(closed_lower_bound) + ", " + std::to_string(open_upper_bound) + ")");
+        RAISE_ERROR("Invalid bounds: [" + std::to_string(closed_lower_bound) + ", " +
+                    std::to_string(open_upper_bound) + ")");
     }
     int delta = open_upper_bound - closed_lower_bound;
     std::uniform_int_distribution<unsigned int> distribution(0, delta - 1);
@@ -510,19 +511,23 @@ void Random::init(unsigned int seed) {
     random_generator_mutex.lock();
     if (Random::random_generator == NULL) {
         if (seed == 0) {
-            random_generator = new std::mt19937(std::chrono::system_clock::now().time_since_epoch().count());
+            random_generator =
+                new std::mt19937(std::chrono::system_clock::now().time_since_epoch().count());
         } else {
             random_generator = new std::mt19937(seed);
         }
     } else {
-        RAISE_ERROR("commons::Random already initialized. commons::Random::init() should be called only once.");
+        RAISE_ERROR(
+            "commons::Random already initialized. commons::Random::init() should be called only once.");
     }
     random_generator_mutex.unlock();
 }
 
 void Random::lock_random_generator() {
     if (Random::random_generator == NULL) {
-        RAISE_ERROR("commons::Random is not initialized. Call commons::Random::init(seed) before using random numbers.");
+        RAISE_ERROR(
+            "commons::Random is not initialized. Call commons::Random::init(seed) before using random "
+            "numbers.");
     } else {
         random_generator_mutex.lock();
     }
@@ -530,7 +535,9 @@ void Random::lock_random_generator() {
 
 void Random::unlock_random_generator() {
     if (Random::random_generator == NULL) {
-        RAISE_ERROR("commons::Random is not initialized. Call commons::Random::init(seed) before using random numbers.");
+        RAISE_ERROR(
+            "commons::Random is not initialized. Call commons::Random::init(seed) before using random "
+            "numbers.");
     } else {
         random_generator_mutex.unlock();
     }
@@ -538,7 +545,9 @@ void Random::unlock_random_generator() {
 
 std::mt19937* Random::get_random_generator() {
     if (Random::random_generator == NULL) {
-        RAISE_ERROR("commons::Random is not initialized. Call commons::Random::init(seed) before using random numbers.");
+        RAISE_ERROR(
+            "commons::Random is not initialized. Call commons::Random::init(seed) before using random "
+            "numbers.");
     }
     return random_generator;
 }

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-
 #include "Logger.h"
 
 using namespace std;
@@ -111,20 +110,17 @@ class StackTrace {
 };
 
 class Random {
-
    public:
-
-   /**
-    * Use p[assed seed to initialize a pseudo-rando number generator used  in all Utils'
-    * methods with random behavior.* If seed == 0, the machine clock is used instead.
-    */
+    /**
+     * Use p[assed seed to initialize a pseudo-rando number generator used  in all Utils'
+     * methods with random behavior.* If seed == 0, the machine clock is used instead.
+     */
     static void init(unsigned int seed);
     static void lock_random_generator();
     static void unlock_random_generator();
     static std::mt19937* get_random_generator();
 
    private:
-
     static std::mt19937* random_generator;
     static mutex random_generator_mutex;
 };

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -7,9 +7,11 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <random>
 #include <stack>
 #include <string>
 #include <vector>
+
 
 #include "Logger.h"
 
@@ -108,6 +110,25 @@ class StackTrace {
     }
 };
 
+class Random {
+
+   public:
+
+   /**
+    * Use p[assed seed to initialize a pseudo-rando number generator used  in all Utils'
+    * methods with random behavior.* If seed == 0, the machine clock is used instead.
+    */
+    static void init(unsigned int seed);
+    static void lock_random_generator();
+    static void unlock_random_generator();
+    static std::mt19937* get_random_generator();
+
+   private:
+
+    static std::mt19937* random_generator;
+    static mutex random_generator_mutex;
+};
+
 class Utils {
    public:
     Utils() {}
@@ -117,14 +138,14 @@ class Utils {
     static bool flip_coin(double true_probability = 0.5);
     static unsigned int uint_rand(unsigned int open_upper_bound);
     static unsigned int uint_rand(unsigned int closed_lower_bound, unsigned int open_upper_bound);
+    static string random_string(size_t length);
+    static string random_string(size_t length, const string& charset);
     static void sleep(unsigned int milliseconds = 100);
     static string get_environment(string const& key);
     static map<string, string> parse_config(string const& config_path);
     static vector<string> split(string const& str, char delimiter = ' ');
     static pair<size_t, size_t> parse_ports_range(string const& str, char delimiter = ':');
     static string join(vector<string> const& tokens, char delimiter = ' ');
-    static string random_string(size_t length);
-    static string random_string(size_t length, const string& charset);
     static bool is_number(const string& s);
     static int string_to_int(const string& s);
     static unsigned int string_to_uint(const string& s);

--- a/src/main/bus_client.cc
+++ b/src/main/bus_client.cc
@@ -45,6 +45,7 @@ int main(int argc, char* argv[]) {
 
         JsonConfig json_config = JsonConfigParser::load(cmd_args[Helper::CONFIG]);
         SystemParametersSingleton::init(json_config);
+        Random::init(0);
 
         if (cmd_args.find(Helper::ENDPOINT) == cmd_args.end()) {
             cmd_args[Helper::ENDPOINT] = "localhost:40000";

--- a/src/main/bus_node.cc
+++ b/src/main/bus_node.cc
@@ -79,6 +79,7 @@ int main(int argc, char* argv[]) {
                 cmd_args[Helper::PORTS_RANGE] = ports_val.get<string>();
             }
         }
+        Random::init(0);
 
         // Peers join the query-engine bus mesh (agents.query.endpoint) unless overridden.
         if (cmd_args.find(Helper::BUS_ENDPOINT) == cmd_args.end() && service_name != "query-engine") {

--- a/src/tests/cpp/and_operator_test.cc
+++ b/src/tests/cpp/and_operator_test.cc
@@ -65,7 +65,6 @@ void check_query_answer(string tag,
 }
 
 TEST(AndOperator, basics) {
-    Random::init(0);
     auto source1 = make_shared<TestSource>();
     auto source2 = make_shared<TestSource>();
     auto and_operator = make_shared<And<2>>(array<shared_ptr<QueryElement>, 2>({source1, source2}));
@@ -484,4 +483,10 @@ TEST(AndOperator, not_operator_5) {
     Utils::sleep(SLEEP_DURATION);
     EXPECT_TRUE(sink.empty());
     EXPECT_TRUE(sink.finished());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/and_operator_test.cc
+++ b/src/tests/cpp/and_operator_test.cc
@@ -65,6 +65,7 @@ void check_query_answer(string tag,
 }
 
 TEST(AndOperator, basics) {
+    Random::init(0);
     auto source1 = make_shared<TestSource>();
     auto source2 = make_shared<TestSource>();
     auto and_operator = make_shared<And<2>>(array<shared_ptr<QueryElement>, 2>({source1, source2}));

--- a/src/tests/cpp/chain_operator_test.cc
+++ b/src/tests/cpp/chain_operator_test.cc
@@ -219,7 +219,6 @@ static string answer_path_to_string(QueryAnswer* query_answer) {
 }
 
 TEST(ChainOperatorTest, allow_concatenation) {
-    Random::init(0);
     if (!RUN_allow_concatenation) return;
 
     shared_ptr<Link> ab_link(new Link(LINK_TYPE, {" ", "a", "b"}));
@@ -690,5 +689,6 @@ TEST(ChainOperatorTest, basics) {
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(new ChainOperatorTestEnvironment());
+    Random::init(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/chain_operator_test.cc
+++ b/src/tests/cpp/chain_operator_test.cc
@@ -219,6 +219,7 @@ static string answer_path_to_string(QueryAnswer* query_answer) {
 }
 
 TEST(ChainOperatorTest, allow_concatenation) {
+    Random::init(0);
     if (!RUN_allow_concatenation) return;
 
     shared_ptr<Link> ab_link(new Link(LINK_TYPE, {" ", "a", "b"}));

--- a/src/tests/cpp/handle_trie_test.cc
+++ b/src/tests/cpp/handle_trie_test.cc
@@ -84,6 +84,7 @@ void visitor3(HandleTrie* trie, unsigned int n) {
 }
 
 TEST(HandleTrieTest, basics) {
+    Random::init(0);
     HandleTrie trie(4);
     TestValue* value;
 

--- a/src/tests/cpp/handle_trie_test.cc
+++ b/src/tests/cpp/handle_trie_test.cc
@@ -84,7 +84,6 @@ void visitor3(HandleTrie* trie, unsigned int n) {
 }
 
 TEST(HandleTrieTest, basics) {
-    Random::init(0);
     HandleTrie trie(4);
     TestValue* value;
 
@@ -769,4 +768,10 @@ TEST(HandleTrieTest, remove_after_merge) {
     // Verify it's gone
     value = (AccumulatorValue*) trie.lookup("ABCD");
     EXPECT_TRUE(value == NULL);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/iterator_test.cc
+++ b/src/tests/cpp/iterator_test.cc
@@ -25,7 +25,6 @@ class TestQueryElement : public QueryElement {
 };
 
 TEST(Iterator, basics) {
-    Random::init(0);
     string client_id = "no_query_element";
     auto dummy = make_shared<TestQueryElement>(client_id);
     Iterator query_answer_iterator(dummy);
@@ -118,4 +117,10 @@ TEST(Iterator, link_template_integration) {
     EXPECT_TRUE(monkey_flag);
     EXPECT_TRUE(chimp_flag);
     EXPECT_TRUE(ent_flag);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/iterator_test.cc
+++ b/src/tests/cpp/iterator_test.cc
@@ -25,6 +25,7 @@ class TestQueryElement : public QueryElement {
 };
 
 TEST(Iterator, basics) {
+    Random::init(0);
     string client_id = "no_query_element";
     auto dummy = make_shared<TestQueryElement>(client_id);
     Iterator query_answer_iterator(dummy);

--- a/src/tests/cpp/link_template_test.cc
+++ b/src/tests/cpp/link_template_test.cc
@@ -16,6 +16,7 @@ using namespace query_engine;
 using namespace query_element;
 
 TEST(LinkTemplate, basics) {
+    Random::init(0);
     string server_node_id = "SERVER";
     QueryNodeServer server_node(server_node_id);
 

--- a/src/tests/cpp/link_template_test.cc
+++ b/src/tests/cpp/link_template_test.cc
@@ -16,7 +16,6 @@ using namespace query_engine;
 using namespace query_element;
 
 TEST(LinkTemplate, basics) {
-    Random::init(0);
     string server_node_id = "SERVER";
     QueryNodeServer server_node(server_node_id);
 
@@ -72,4 +71,10 @@ TEST(LinkTemplate, basics) {
     EXPECT_TRUE(monkey_flag);
     EXPECT_TRUE(chimp_flag);
     EXPECT_TRUE(ent_flag);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/nested_link_template_test.cc
+++ b/src/tests/cpp/nested_link_template_test.cc
@@ -17,6 +17,7 @@ using namespace query_engine;
 using namespace query_element;
 
 TEST(LinkTemplate, basics) {
+    Random::init(0);
     AtomDBSingleton::init(test_atomdb_json_config());
 
     const string expression = "Expression";

--- a/src/tests/cpp/nested_link_template_test.cc
+++ b/src/tests/cpp/nested_link_template_test.cc
@@ -17,7 +17,6 @@ using namespace query_engine;
 using namespace query_element;
 
 TEST(LinkTemplate, basics) {
-    Random::init(0);
     AtomDBSingleton::init(test_atomdb_json_config());
 
     const string expression = "Expression";
@@ -83,4 +82,10 @@ TEST(LinkTemplate, nested_variables) {
         }
     }
     EXPECT_EQ(count, 1);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -267,6 +267,7 @@ void check_query_chain(const string& query_tag,
 }
 
 TEST(PatternMatchingQuery, queries) {
+    Random::init(0);
     AtomDBSingleton::init(test_atomdb_json_config());
     init_test_system_parameters_singleton();
     ServiceBus::initialize_statics({}, 40200, 40299);

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -267,7 +267,6 @@ void check_query_chain(const string& query_tag,
 }
 
 TEST(PatternMatchingQuery, queries) {
-    Random::init(0);
     AtomDBSingleton::init(test_atomdb_json_config());
     init_test_system_parameters_singleton();
     ServiceBus::initialize_statics({}, 40200, 40299);
@@ -607,4 +606,10 @@ TEST(PatternMatchingQuery, queries) {
     EXPECT_EQ(count, 1U);
 
     // clang-format on
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/processor_test.cc
+++ b/src/tests/cpp/processor_test.cc
@@ -12,6 +12,8 @@ using namespace processor;
 using namespace commons;
 
 TEST(ProcessorTest, basics) {
+    Random::init(0);
+
     Processor p1("blah");
     EXPECT_THROW(Processor p2(""), runtime_error);
     EXPECT_EQ(p1.to_string(), "blah");

--- a/src/tests/cpp/processor_test.cc
+++ b/src/tests/cpp/processor_test.cc
@@ -12,8 +12,6 @@ using namespace processor;
 using namespace commons;
 
 TEST(ProcessorTest, basics) {
-    Random::init(0);
-
     Processor p1("blah");
     EXPECT_THROW(Processor p2(""), runtime_error);
     EXPECT_EQ(p1.to_string(), "blah");
@@ -217,4 +215,10 @@ TEST(ProcessorTest, thread_pool) {
             }
         }
     }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -24,7 +24,6 @@ class TestDecoder : public HandleDecoder {
 };
 
 TEST(QueryAnswer, assignments_basics) {
-    Random::init(0);
     Assignment mapping0;
 
     // Tests assign()
@@ -689,4 +688,10 @@ TEST(QueryAnswer, rewrite_query) {
     map<string, QueryAnswerElement> replacements = {{"v1", element1}, {"v3", element2}};
     answer.rewrite_query(original_query, replacements, new_query);
     EXPECT_EQ(expected, new_query);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -24,6 +24,7 @@ class TestDecoder : public HandleDecoder {
 };
 
 TEST(QueryAnswer, assignments_basics) {
+    Random::init(0);
     Assignment mapping0;
 
     // Tests assign()

--- a/src/tests/cpp/request_selector_test.cc
+++ b/src/tests/cpp/request_selector_test.cc
@@ -12,7 +12,6 @@ class TestMessage {
 };
 
 TEST(RequestSelectorTest, even_thread_count) {
-    Random::init(0);
     SharedQueue* stimulus = new SharedQueue(1);
     SharedQueue* correlation = new SharedQueue(1);
 
@@ -34,4 +33,10 @@ TEST(RequestSelectorTest, even_thread_count) {
 
     delete stimulus;
     delete correlation;
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/request_selector_test.cc
+++ b/src/tests/cpp/request_selector_test.cc
@@ -12,6 +12,7 @@ class TestMessage {
 };
 
 TEST(RequestSelectorTest, even_thread_count) {
+    Random::init(0);
     SharedQueue* stimulus = new SharedQueue(1);
     SharedQueue* correlation = new SharedQueue(1);
 

--- a/src/tests/cpp/stoppable_thread_test.cc
+++ b/src/tests/cpp/stoppable_thread_test.cc
@@ -17,7 +17,6 @@ using namespace commons;
 // burst of workers completes, the map must drain to empty WITHOUT any external/non-worker reaping
 // trigger.
 TEST(StoppableThread, self_reap_burst_then_idle) {
-    Random::init(0);
     map<string, shared_ptr<StoppableThread>> threads;
     mutex threads_mutex;
     atomic<int> completed{0};

--- a/src/tests/cpp/stoppable_thread_test.cc
+++ b/src/tests/cpp/stoppable_thread_test.cc
@@ -17,6 +17,7 @@ using namespace commons;
 // burst of workers completes, the map must drain to empty WITHOUT any external/non-worker reaping
 // trigger.
 TEST(StoppableThread, self_reap_burst_then_idle) {
+    Random::init(0);
     map<string, shared_ptr<StoppableThread>> threads;
     mutex threads_mutex;
     atomic<int> completed{0};

--- a/src/tests/cpp/utils_test.cc
+++ b/src/tests/cpp/utils_test.cc
@@ -12,6 +12,7 @@
 using namespace std;
 using namespace commons;
 
+
 void f1() {
     STACK_TRACE();
     RAISE_ERROR("Error in f1()");
@@ -31,6 +32,7 @@ void f3() {
 }
 
 TEST(UtilsTest, read_and_split) {
+    Random::init(0);
     string fname = "UtilsTest_read_and_aplit.txt";
     string test_file = "c1 1 2 3\nc2 1 2  4\nc3 \nc4\n c5 1 2\n \n\nc6 1 2 34\nc7,111,22,3\n\n";
     make_tmp_file(fname, test_file);
@@ -80,4 +82,43 @@ TEST(UtilsTest, stack_trace) {
     EXPECT_THROW(f2(), runtime_error);
     EXPECT_THROW(f1(), runtime_error);
     // FAIL();
+}
+
+TEST(UtilsTest, flip_coin) {
+    unsigned int N = 10000;
+    float tolerance = 0.05;
+    for (float prob : {0.20, 0.50, 0.80}) {
+        unsigned int count_true = 0;
+        unsigned int count_false = 0;
+        unsigned int expected_true = lround(prob * N);
+        unsigned int expected_false = N - expected_true;
+        unsigned int delta_true = lround(tolerance * expected_true);
+        unsigned int delta_false = lround(tolerance * expected_false);
+        for (unsigned int i = 0; i < N; i++) {
+            if (Utils::flip_coin(prob)) {
+                count_true++;
+            } else {
+                count_false++;
+            }
+        }
+        EXPECT_TRUE(count_true >= (expected_true - delta_true));
+        EXPECT_TRUE(count_true <= (expected_true + delta_true));
+        EXPECT_TRUE(count_false >= (expected_false - delta_false));
+        EXPECT_TRUE(count_false <= (expected_false + delta_false));
+    }
+}
+
+TEST(UtilsTest, uint_rand) {
+    for (pair<unsigned int, unsigned int> p : vector<pair<unsigned int, unsigned int>>({{0, 1} , {0, 2}, {0, 3}, {2, 3}, {2, 4}, {2, 5}, {105, 1200}})) {
+        for (unsigned int i = 0; i < 10000; i++) {
+            unsigned int closed_lower = p.first;
+            unsigned int open_upper = p.second;
+            unsigned int number = Utils::uint_rand(closed_lower, open_upper);
+            EXPECT_TRUE(number >= closed_lower);
+            EXPECT_TRUE(number < open_upper);
+        }
+    }
+    EXPECT_THROW(Utils::uint_rand(0, 0), runtime_error);
+    EXPECT_THROW(Utils::uint_rand(2, 2), runtime_error);
+    EXPECT_THROW(Utils::uint_rand(2, 1), runtime_error);
 }

--- a/src/tests/cpp/utils_test.cc
+++ b/src/tests/cpp/utils_test.cc
@@ -12,7 +12,6 @@
 using namespace std;
 using namespace commons;
 
-
 void f1() {
     STACK_TRACE();
     RAISE_ERROR("Error in f1()");
@@ -109,7 +108,8 @@ TEST(UtilsTest, flip_coin) {
 }
 
 TEST(UtilsTest, uint_rand) {
-    for (pair<unsigned int, unsigned int> p : vector<pair<unsigned int, unsigned int>>({{0, 1} , {0, 2}, {0, 3}, {2, 3}, {2, 4}, {2, 5}, {105, 1200}})) {
+    for (pair<unsigned int, unsigned int> p : vector<pair<unsigned int, unsigned int>>(
+             {{0, 1}, {0, 2}, {0, 3}, {2, 3}, {2, 4}, {2, 5}, {105, 1200}})) {
         for (unsigned int i = 0; i < 10000; i++) {
             unsigned int closed_lower = p.first;
             unsigned int open_upper = p.second;

--- a/src/tests/cpp/utils_test.cc
+++ b/src/tests/cpp/utils_test.cc
@@ -30,8 +30,7 @@ void f3() {
     return;
 }
 
-TEST(UtilsTest, read_and_split) {
-    Random::init(0);
+TEST(LocalFileTestSuite, read_and_split) {
     string fname = "UtilsTest_read_and_aplit.txt";
     string test_file = "c1 1 2 3\nc2 1 2  4\nc3 \nc4\n c5 1 2\n \n\nc6 1 2 34\nc7,111,22,3\n\n";
     make_tmp_file(fname, test_file);
@@ -74,7 +73,7 @@ TEST(UtilsTest, read_and_split) {
     EXPECT_EQ(line, vector<string>({"blah"}));
 }
 
-TEST(UtilsTest, stack_trace) {
+TEST(LocalFileTestSuite, stack_trace) {
     STACK_TRACE();
     EXPECT_THROW(RAISE_ERROR("Error on toplevel"), runtime_error);
     EXPECT_THROW(f3(), runtime_error);
@@ -83,9 +82,9 @@ TEST(UtilsTest, stack_trace) {
     // FAIL();
 }
 
-TEST(UtilsTest, flip_coin) {
-    unsigned int N = 10000;
-    float tolerance = 0.05;
+TEST(LocalFileTestSuite, flip_coin) {
+    unsigned int N = 20000;
+    float tolerance = 0.07;
     for (float prob : {0.20, 0.50, 0.80}) {
         unsigned int count_true = 0;
         unsigned int count_false = 0;
@@ -105,9 +104,15 @@ TEST(UtilsTest, flip_coin) {
         EXPECT_TRUE(count_false >= (expected_false - delta_false));
         EXPECT_TRUE(count_false <= (expected_false + delta_false));
     }
+    for (unsigned int i = 0; i < N; i++) {
+        EXPECT_TRUE(Utils::flip_coin(1.0));
+        EXPECT_FALSE(Utils::flip_coin(0.0));
+    }
+    EXPECT_THROW(Utils::flip_coin(1.1), runtime_error);
+    EXPECT_THROW(Utils::flip_coin(-0.5), runtime_error);
 }
 
-TEST(UtilsTest, uint_rand) {
+TEST(LocalFileTestSuite, uint_rand) {
     for (pair<unsigned int, unsigned int> p : vector<pair<unsigned int, unsigned int>>(
              {{0, 1}, {0, 2}, {0, 3}, {2, 3}, {2, 4}, {2, 5}, {105, 1200}})) {
         for (unsigned int i = 0; i < 10000; i++) {
@@ -121,4 +126,10 @@ TEST(UtilsTest, uint_rand) {
     EXPECT_THROW(Utils::uint_rand(0, 0), runtime_error);
     EXPECT_THROW(Utils::uint_rand(2, 2), runtime_error);
     EXPECT_THROW(Utils::uint_rand(2, 1), runtime_error);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/worker_threads_test.cc
+++ b/src/tests/cpp/worker_threads_test.cc
@@ -20,6 +20,7 @@ class TestSharedQueue : public SharedQueue {
 };
 
 TEST(WorkerThreads, basics) {
+    Random::init(0);
     dasproto::HandleCount* handle_count;
     dasproto::HandleList* handle_list;
 

--- a/src/tests/cpp/worker_threads_test.cc
+++ b/src/tests/cpp/worker_threads_test.cc
@@ -20,7 +20,6 @@ class TestSharedQueue : public SharedQueue {
 };
 
 TEST(WorkerThreads, basics) {
-    Random::init(0);
     dasproto::HandleCount* handle_count;
     dasproto::HandleList* handle_list;
 
@@ -210,4 +209,10 @@ TEST(WorkerThreads, hebbian_network_updater_stress) {
     delete pool;
     delete stimulus;
     delete correlation;
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    Random::init(0);
+    return RUN_ALL_TESTS();
 }

--- a/src/tests/main/database_adapter_main.cc
+++ b/src/tests/main/database_adapter_main.cc
@@ -44,6 +44,7 @@ int main(int argc, char* argv[]) {
 
     auto atomdb_config = json_config.at_path("atomdb").get_or<JsonConfig>(JsonConfig());
 
+    Random::init(0);
     AtomDBSingleton::init(atomdb_config);
 
     // auto adapter = AtomDBSingleton::get_instance();;

--- a/src/tests/main/evaluation_evolution.cc
+++ b/src/tests/main/evaluation_evolution.cc
@@ -1470,6 +1470,7 @@ int main(int argc, char* argv[]) {
     SystemParametersSingleton::init(json_config);
     AtomDBSingleton::init(atomdb_config);
 
+    Random::init(0);
     db = AtomDBSingleton::get_instance();
     DECODER = static_pointer_cast<HandleDecoder>(db).get();
     ServiceBusSingleton::init(client_endpoint, server_endpoint, ports_range.first, ports_range.second);

--- a/src/tests/main/link_creation_engine_main.cc
+++ b/src/tests/main/link_creation_engine_main.cc
@@ -330,6 +330,7 @@ int main(int argc, char* argv[]) {
         RAISE_ERROR("Invalid link_type_tag: " + link_type_tag);
     }
 
+    Random::init(0);
     string atomdb_type = string(argv[3]) == string("--use-mork") ? "morkdb" : "redismongodb";
 
     set<string> highlighted;

--- a/src/tests/main/word_query_evolution_main.cc
+++ b/src/tests/main/word_query_evolution_main.cc
@@ -363,6 +363,7 @@ int main(int argc, char* argv[]) {
     string server_id = argv[2];
     auto ports_range = Utils::parse_ports_range(argv[3]);
     string atomdb_type_str = argv[4];
+    Random::init(0);
     AtomDBSingleton::init(test_atomdb_json_config(atomdb_type_str));
 
     string context_tag = argv[5];

--- a/src/tests/main/word_query_main.cc
+++ b/src/tests/main/word_query_main.cc
@@ -195,6 +195,7 @@ int main(int argc, char* argv[]) {
     string context = argv[4];
     string word_tag = argv[5];
     string atomdb_type_str = argv[6];
+    Random::init(0);
     AtomDBSingleton::init(test_atomdb_json_config(atomdb_type_str));
 
     run(client_id, server_id, ports_range.first, ports_range.second, context, word_tag);


### PR DESCRIPTION
WIP towards #1226 

Utils methods with "random" behavior, namely flip_coin(), uint_random() and random_string() now share the same random generator object which is explicitly initialized by a static method Random::init(unsigned int seed). If seed == 0, the machine clock is used as seed number. 

We also changed LinkTemplate to use Utils methods instead of its own random generator.

We are still missing a way to actually pass a given seed to executables (bus nodes/clients). The proper way to do this is yet to be discussed and will be implemented in a follow-up PR.