### PR TITLE
[#1226] Add command line parameters to initialize random seed

### DIFF
--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -244,8 +244,8 @@ void QueryEvolutionProcessor::select_one_by_tournament(
     vector<std::pair<shared_ptr<QueryAnswer>, float>>& population,
     vector<std::pair<shared_ptr<QueryAnswer>, float>>& selected) {
     unsigned int size = population.size();
-    unsigned int cursor1 = std::rand() % size;
-    unsigned int cursor2 = std::rand() % size;
+    unsigned int cursor1 = Utils::uint_rand(size);
+    unsigned int cursor2 = Utils::uint_rand(size);
     if (cursor2 == cursor1) {
         cursor2 = (cursor2 + 1) % size;
     }

--- a/src/agents/query_engine/query_element/LinkTemplate.cc
+++ b/src/agents/query_engine/query_element/LinkTemplate.cc
@@ -129,9 +129,7 @@ void LinkTemplate::compute_importance(vector<pair<char*, float>>& handles) {
     }
     // Sort decreasing by importance value
 
-    Random::lock_random_generator();
-    std::shuffle(handles.begin(), handles.end(), *Random::get_random_generator());
-    Random::unlock_random_generator();
+    Utils::shuffle(handles.begin(), handles.end());
     std::sort(handles.begin(),
               handles.end(),
               [](const std::pair<char*, float>& left, const std::pair<char*, float>& right) {

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -36,6 +36,10 @@ void Utils::error(string msg, bool throw_flag, bool log_flag) {
     }
 }
 
+void Utils::init_random(unsigned int seed) {
+    Random::init(seed);
+}
+
 bool Utils::flip_coin(double true_probability) {
     bool answer = false;
     if ((true_probability > 1.0) || (true_probability < 0.0)) {
@@ -512,10 +516,10 @@ string MemoryFootprint::to_string() {
 // --------------------------------------------------------------------------------
 // Random
 
-std::mt19937* Random::random_generator = NULL;
-mutex Random::random_generator_mutex;
+std::mt19937* Utils::Random::random_generator = NULL;
+mutex Utils::Random::random_generator_mutex;
 
-void Random::init(unsigned int seed) {
+void Utils::Random::init(unsigned int seed) {
     random_generator_mutex.lock();
     if (Random::random_generator == NULL) {
         if (seed == 0) {
@@ -532,7 +536,7 @@ void Random::init(unsigned int seed) {
     }
 }
 
-void Random::lock_random_generator() {
+void Utils::Random::lock_random_generator() {
     if (Random::random_generator == NULL) {
         RAISE_ERROR(
             "commons::Random is not initialized. Call commons::Random::init(seed) before using random "
@@ -542,7 +546,7 @@ void Random::lock_random_generator() {
     }
 }
 
-void Random::unlock_random_generator() {
+void Utils::Random::unlock_random_generator() {
     if (Random::random_generator == NULL) {
         RAISE_ERROR(
             "commons::Random is not initialized. Call commons::Random::init(seed) before using random "
@@ -552,7 +556,7 @@ void Random::unlock_random_generator() {
     }
 }
 
-std::mt19937* Random::get_random_generator() {
+std::mt19937* Utils::Random::get_random_generator() {
     if (Random::random_generator == NULL) {
         RAISE_ERROR(
             "commons::Random is not initialized. Call commons::Random::init(seed) before using random "

--- a/src/commons/Utils.cc
+++ b/src/commons/Utils.cc
@@ -36,9 +36,7 @@ void Utils::error(string msg, bool throw_flag, bool log_flag) {
     }
 }
 
-void Utils::init_random(unsigned int seed) {
-    Random::init(seed);
-}
+void Utils::init_random(unsigned int seed) { Random::init(seed); }
 
 bool Utils::flip_coin(double true_probability) {
     bool answer = false;

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -109,33 +109,43 @@ class StackTrace {
     }
 };
 
-class Random {
-   public:
-    /**
-     * Use p[assed seed to initialize a pseudo-rando number generator used  in all Utils'
-     * methods with random behavior.* If seed == 0, the machine clock is used instead.
-     */
-    static void init(unsigned int seed);
-    static void lock_random_generator();
-    static void unlock_random_generator();
-    static std::mt19937* get_random_generator();
-
-   private:
-    static std::mt19937* random_generator;
-    static mutex random_generator_mutex;
-};
-
 class Utils {
+   private:
+    class Random {
+       public:
+        /**
+         * Use p[assed seed to initialize a pseudo-rando number generator used  in all Utils'
+         * methods with random behavior.* If seed == 0, the machine clock is used instead.
+         */
+        static void init(unsigned int seed);
+        static void lock_random_generator();
+        static void unlock_random_generator();
+        static std::mt19937* get_random_generator();
+
+       private:
+        static std::mt19937* random_generator;
+        static mutex random_generator_mutex;
+    };
+
    public:
     Utils() {}
     ~Utils() {}
 
     static void error(string msg, bool throw_flag, bool log_flag = true);
+
+    static void init_random(unsigned int seed);
     static bool flip_coin(double true_probability = 0.5);
     static unsigned int uint_rand(unsigned int open_upper_bound);
     static unsigned int uint_rand(unsigned int closed_lower_bound, unsigned int open_upper_bound);
     static string random_string(size_t length);
     static string random_string(size_t length, const string& charset);
+    template<class IteratorType>
+    static void shuffle(IteratorType it1, IteratorType it2) {
+        Random::lock_random_generator();
+        std::shuffle(it1, it2, *Random::get_random_generator());
+        Random::unlock_random_generator();
+    }
+
     static void sleep(unsigned int milliseconds = 100);
     static string get_environment(string const& key);
     static map<string, string> parse_config(string const& config_path);

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -113,10 +113,6 @@ class Utils {
    private:
     class Random {
        public:
-        /**
-         * Use p[assed seed to initialize a pseudo-rando number generator used  in all Utils'
-         * methods with random behavior.* If seed == 0, the machine clock is used instead.
-         */
         static void init(unsigned int seed);
         static void lock_random_generator();
         static void unlock_random_generator();
@@ -133,6 +129,10 @@ class Utils {
 
     static void error(string msg, bool throw_flag, bool log_flag = true);
 
+    /**
+     * Use passed seed to initialize a pseudo-rando number generator used in all Utils'
+     * methods with random behavior. If seed == 0, the machine clock is used instead.
+     */
     static void init_random(unsigned int seed);
     static bool flip_coin(double true_probability = 0.5);
     static unsigned int uint_rand(unsigned int open_upper_bound);
@@ -142,7 +142,12 @@ class Utils {
     template <class IteratorType>
     static void shuffle(IteratorType it1, IteratorType it2) {
         Random::lock_random_generator();
-        std::shuffle(it1, it2, *Random::get_random_generator());
+        try {
+            std::shuffle(it1, it2, *Random::get_random_generator());
+        } catch (...) {
+            Random::unlock_random_generator();
+            throw;
+        }
         Random::unlock_random_generator();
     }
 

--- a/src/commons/Utils.h
+++ b/src/commons/Utils.h
@@ -139,7 +139,7 @@ class Utils {
     static unsigned int uint_rand(unsigned int closed_lower_bound, unsigned int open_upper_bound);
     static string random_string(size_t length);
     static string random_string(size_t length, const string& charset);
-    template<class IteratorType>
+    template <class IteratorType>
     static void shuffle(IteratorType it1, IteratorType it2) {
         Random::lock_random_generator();
         std::shuffle(it1, it2, *Random::get_random_generator());

--- a/src/main/bus_client.cc
+++ b/src/main/bus_client.cc
@@ -45,8 +45,6 @@ int main(int argc, char* argv[]) {
 
         JsonConfig json_config = JsonConfigParser::load(cmd_args[Helper::CONFIG]);
         SystemParametersSingleton::init(json_config);
-        Random::init(0);
-
         if (cmd_args.find(Helper::ENDPOINT) == cmd_args.end()) {
             cmd_args[Helper::ENDPOINT] = "localhost:40000";
         }
@@ -70,6 +68,12 @@ int main(int argc, char* argv[]) {
                 cmd_args[Helper::ATTENTION_BROKER_ENDPOINT] = attention.get<string>();
             }
         }
+
+        unsigned int seed = 0;
+        if (cmd_args.find(Helper::SEED) != cmd_args.end()) {
+            seed = Utils::string_to_uint(cmd_args[Helper::SEED]);
+        }
+        Utils::init_random(seed);
 
         Helper::merge_params_from_config(cmd_args, json_config);
 

--- a/src/main/bus_node.cc
+++ b/src/main/bus_node.cc
@@ -79,7 +79,11 @@ int main(int argc, char* argv[]) {
                 cmd_args[Helper::PORTS_RANGE] = ports_val.get<string>();
             }
         }
-        Random::init(0);
+        unsigned int seed = 0;
+        if (cmd_args.find(Helper::SEED) != cmd_args.end()) {
+            seed = Utils::string_to_uint(cmd_args[Helper::SEED]);
+        }
+        Utils::init_random(seed);
 
         // Peers join the query-engine bus mesh (agents.query.endpoint) unless overridden.
         if (cmd_args.find(Helper::BUS_ENDPOINT) == cmd_args.end() && service_name != "query-engine") {

--- a/src/main/helpers/Helper.cc
+++ b/src/main/helpers/Helper.cc
@@ -15,6 +15,7 @@ bool Helper::is_running = true;
 // Args names
 string Helper::CONFIG = "config";
 string Helper::SERVICE = "service";
+string Helper::SEED = "seed";
 string Helper::CLIENT = "client";
 string Helper::ENDPOINT = "endpoint";
 string Helper::BUS_ENDPOINT = "bus-endpoint";

--- a/src/main/helpers/Helper.h
+++ b/src/main/helpers/Helper.h
@@ -32,6 +32,8 @@ class Helper {
     static string SERVICE;
     /** Agent/broker key in `das.json` (e.g. query -> agents.query.endpoint). */
     static string CLIENT;
+    // Seed value used to initialize Utils::Random
+    static string SEED;
     /** bus_node: this node's listen address. bus_client: remote bus peer id (ServiceBus known_peer). */
     static string ENDPOINT;
     /** bus_client: this client's listen address on the bus (ServiceBus host_id). bus_node: optional

--- a/src/tests/cpp/and_operator_test.cc
+++ b/src/tests/cpp/and_operator_test.cc
@@ -487,6 +487,6 @@ TEST(AndOperator, not_operator_5) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/chain_operator_test.cc
+++ b/src/tests/cpp/chain_operator_test.cc
@@ -689,6 +689,6 @@ TEST(ChainOperatorTest, basics) {
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(new ChainOperatorTestEnvironment());
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/handle_trie_test.cc
+++ b/src/tests/cpp/handle_trie_test.cc
@@ -772,6 +772,6 @@ TEST(HandleTrieTest, remove_after_merge) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/iterator_test.cc
+++ b/src/tests/cpp/iterator_test.cc
@@ -121,6 +121,6 @@ TEST(Iterator, link_template_integration) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/link_template_test.cc
+++ b/src/tests/cpp/link_template_test.cc
@@ -75,6 +75,6 @@ TEST(LinkTemplate, basics) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/nested_link_template_test.cc
+++ b/src/tests/cpp/nested_link_template_test.cc
@@ -86,6 +86,6 @@ TEST(LinkTemplate, nested_variables) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/pattern_matching_query_test.cc
+++ b/src/tests/cpp/pattern_matching_query_test.cc
@@ -610,6 +610,6 @@ TEST(PatternMatchingQuery, queries) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/processor_test.cc
+++ b/src/tests/cpp/processor_test.cc
@@ -219,6 +219,6 @@ TEST(ProcessorTest, thread_pool) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/query_answer_test.cc
+++ b/src/tests/cpp/query_answer_test.cc
@@ -692,6 +692,6 @@ TEST(QueryAnswer, rewrite_query) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/request_selector_test.cc
+++ b/src/tests/cpp/request_selector_test.cc
@@ -37,6 +37,6 @@ TEST(RequestSelectorTest, even_thread_count) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/utils_test.cc
+++ b/src/tests/cpp/utils_test.cc
@@ -130,6 +130,6 @@ TEST(LocalFileTestSuite, uint_rand) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/cpp/worker_threads_test.cc
+++ b/src/tests/cpp/worker_threads_test.cc
@@ -213,6 +213,6 @@ TEST(WorkerThreads, hebbian_network_updater_stress) {
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
-    Random::init(0);
+    Utils::init_random(0);
     return RUN_ALL_TESTS();
 }

--- a/src/tests/main/database_adapter_main.cc
+++ b/src/tests/main/database_adapter_main.cc
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
 
     auto atomdb_config = json_config.at_path("atomdb").get_or<JsonConfig>(JsonConfig());
 
-    Random::init(0);
+    Utils::init_random(0);
     AtomDBSingleton::init(atomdb_config);
 
     // auto adapter = AtomDBSingleton::get_instance();;

--- a/src/tests/main/evaluation_evolution.cc
+++ b/src/tests/main/evaluation_evolution.cc
@@ -87,6 +87,7 @@ static unsigned int LINK_CREATION_COUNT = 10;
 static unsigned int LINK_CREATION_MAX_VISIT_ATTEMPTS = LINK_CREATION_COUNT;
 static unsigned int LINK_CREATION_MAX_ATTEMPTS = 500;
 static double ATTENTION_FOCUS_STRICTNESS = 0.30;
+static unsigned int RANDOM_SEED = 1235;
 
 static string PRESET_LINKS_FILE_PREFIX = "/opt/das/_PRESET_LINKS_";
 static string PRESET_LINKS_FILE = PRESET_LINKS_FILE_PREFIX;
@@ -1470,7 +1471,7 @@ int main(int argc, char* argv[]) {
     SystemParametersSingleton::init(json_config);
     AtomDBSingleton::init(atomdb_config);
 
-    Random::init(0);
+    Utils::init_random(RANDOM_SEED);
     db = AtomDBSingleton::get_instance();
     DECODER = static_pointer_cast<HandleDecoder>(db).get();
     ServiceBusSingleton::init(client_endpoint, server_endpoint, ports_range.first, ports_range.second);

--- a/src/tests/main/evaluation_evolution.cc
+++ b/src/tests/main/evaluation_evolution.cc
@@ -87,7 +87,7 @@ static unsigned int LINK_CREATION_COUNT = 10;
 static unsigned int LINK_CREATION_MAX_VISIT_ATTEMPTS = LINK_CREATION_COUNT;
 static unsigned int LINK_CREATION_MAX_ATTEMPTS = 500;
 static double ATTENTION_FOCUS_STRICTNESS = 0.30;
-static unsigned int RANDOM_SEED = 1235;
+static unsigned int RANDOM_SEED = 1236;
 
 static string PRESET_LINKS_FILE_PREFIX = "/opt/das/_PRESET_LINKS_";
 static string PRESET_LINKS_FILE = PRESET_LINKS_FILE_PREFIX;

--- a/src/tests/main/link_creation_engine_main.cc
+++ b/src/tests/main/link_creation_engine_main.cc
@@ -330,7 +330,7 @@ int main(int argc, char* argv[]) {
         RAISE_ERROR("Invalid link_type_tag: " + link_type_tag);
     }
 
-    Random::init(0);
+    Utils::init_random(0);
     string atomdb_type = string(argv[3]) == string("--use-mork") ? "morkdb" : "redismongodb";
 
     set<string> highlighted;

--- a/src/tests/main/word_query_evolution_main.cc
+++ b/src/tests/main/word_query_evolution_main.cc
@@ -363,7 +363,7 @@ int main(int argc, char* argv[]) {
     string server_id = argv[2];
     auto ports_range = Utils::parse_ports_range(argv[3]);
     string atomdb_type_str = argv[4];
-    Random::init(0);
+    Utils::init_random(0);
     AtomDBSingleton::init(test_atomdb_json_config(atomdb_type_str));
 
     string context_tag = argv[5];

--- a/src/tests/main/word_query_main.cc
+++ b/src/tests/main/word_query_main.cc
@@ -195,7 +195,7 @@ int main(int argc, char* argv[]) {
     string context = argv[4];
     string word_tag = argv[5];
     string atomdb_type_str = argv[6];
-    Random::init(0);
+    Utils::init_random(0);
     AtomDBSingleton::init(test_atomdb_json_config(atomdb_type_str));
 
     run(client_id, server_id, ports_range.first, ports_range.second, context, word_tag);

--- a/src/tests/scripts/run_toy.sh
+++ b/src/tests/scripts/run_toy.sh
@@ -16,6 +16,8 @@ POPULATION_SIZE=100
 NUM_GENERATIONS=5
 NUM_ITERATIONS=5
 
+SEED=1235
+
 echo "--------------------------------------------------"
 echo "Cleaning docker containers"
 echo
@@ -35,9 +37,9 @@ echo "Stating agents"
 echo
 make run-attention-broker &>> /tmp/ab.log &
 sleep 2
-make run-busnode OPTIONS="--service=query-engine --config=/opt/das/config/das.json" &>> /tmp/qa.log &
+make run-busnode OPTIONS="--service=query-engine --config=/opt/das/config/das.json --seed=$SEED" &>> /tmp/qa.log &
 sleep 2
-make run-busnode OPTIONS="--service=evolution-agent --bus-endpoint=localhost:40002 --config=/opt/das/config/das.json" &>> /tmp/ev.log &
+make run-busnode OPTIONS="--service=evolution-agent --bus-endpoint=localhost:40002 --config=/opt/das/config/das.json --seed=$SEED" &>> /tmp/ev.log &
 sleep 2
 docker update -m $AVAIABLE_RAM --memory-swap $AVAIABLE_RAM $(docker ps -q)
 echo "Done. Logs are in /tmp/ab.log /tmp/qa.log /tmp/ev.log"


### PR DESCRIPTION
WIP towards #1226 

In addition to adding a command line parameter to initialize random seed in bus node/client, we also fix a couple of issues raised in the previous PR on this same issue. The main one being the exposition of Random mutex to callers. We fixed it by making Random a private class in Utils and creating new methods (in Utils) to expose initialization and to shuffle vectors. 

Still missing a change in the building of QueryElements when a query is transformed into a query tree in such a way that each QueryElement receives a random generator which is based in the current state of global one but generates its own numbers independently.