### PR TITLE
 `InMemoryDB` lock-free reads, atomic trie snapshots, and `HandleTrie` concurrency fixes

### DIFF
--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <utility>
 
 #include "Hasher.h"
 #include "InMemoryDBAPITypes.h"
@@ -19,38 +20,48 @@ using namespace atomdb_api_types;
 using namespace atoms;
 using namespace commons;
 
-// Helper class to wrap Atom in HandleTrie
+// Wraps an Atom in HandleTrie. The atom is held via shared_ptr and handed out with a
+// refcount bump taken under the trie node lock (get_stored_object), so readers keep it
+// alive while concurrent upserts/deletes replace or drop the trie's own reference.
+// Stored atoms are never mutated in place: merge() swaps the pointer wholesale.
 class AtomTrieValue : public HandleTrie::TrieValue {
    public:
     AtomTrieValue(Atom* atom) : atom_(atom) {}
-    ~AtomTrieValue() override { delete atom_; }
+    ~AtomTrieValue() override = default;
+    // Runs under the node lock (HandleTrie::insert on a duplicate key): replace the
+    // stored atom. Readers holding a reference keep the previous atom alive.
     void merge(HandleTrie::TrieValue* other) override {
-        // For now, just replace (could be enhanced later)
-        delete atom_;
-        atom_ = dynamic_cast<AtomTrieValue*>(other)->atom_;
-        dynamic_cast<AtomTrieValue*>(other)->atom_ = NULL;  // Prevent double delete
+        atom_ = std::move(dynamic_cast<AtomTrieValue*>(other)->atom_);
     }
-    Atom* get_atom() { return atom_; }
+    // Runs under the node lock (HandleTrie::lookup_stored_object): hand out an owning
+    // reference. The caller takes ownership of the returned shared_ptr wrapper.
+    void* get_stored_object(bool /*clone*/) override { return new shared_ptr<Atom>(atom_); }
+    // Writer-side accessor — safe only under InMemoryDB::write_mutex_ or the node lock.
+    const shared_ptr<Atom>& get_atom() const { return atom_; }
 
    private:
-    Atom* atom_;
+    shared_ptr<Atom> atom_;
 };
 
-// Helper class to store sets of atom handles in HandleTrie for pattern/incoming set indexing
+// Stores a set of atom handles in HandleTrie for pattern / incoming-set indexing.
+// Mutations must run under the trie node lock (insert/merge or HandleTrie::update);
+// readers snapshot a copy of the set under the same lock via get_stored_object.
 class HandleSetTrieValue : public HandleTrie::TrieValue {
    public:
     HandleSetTrieValue() {}
+    explicit HandleSetTrieValue(const string& handle) : handle_set_({handle}) {}
     ~HandleSetTrieValue() override {}
+    // Runs under the node lock (HandleTrie::insert on a duplicate key): union the sets.
     void merge(HandleTrie::TrieValue* other) override {
-        // Merge sets when the same handle is inserted multiple times
         HandleSetTrieValue* other_value = dynamic_cast<HandleSetTrieValue*>(other);
         if (other_value != NULL) {
             handle_set_.insert(other_value->handle_set_.begin(), other_value->handle_set_.end());
         }
     }
-    void add_handle(const string& handle) { handle_set_.insert(handle); }
+    // Runs under the node lock (HandleTrie::lookup_stored_object): hand out a copy.
+    // The caller takes ownership of the returned set.
+    void* get_stored_object(bool /*clone*/) override { return new set<string>(handle_set_); }
     void remove_handle(const string& handle) { handle_set_.erase(handle); }
-    const set<string>& get_handles() const { return handle_set_; }
     bool empty() const { return handle_set_.empty(); }
 
    private:
@@ -72,34 +83,38 @@ shared_ptr<Atom> clone_atom(const Atom* atom) {
 
 shared_ptr<HandleTrie> make_trie() { return make_shared<HandleTrie>(HANDLE_HASH_SIZE - 1); }
 
-// Returns the trie-owned Atom for a handle, or nullptr if absent (or not an AtomTrieValue).
-Atom* lookup_atom(HandleTrie& trie, const string& handle) {
-    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie.lookup(handle));
-    return atom_trie_value == nullptr ? nullptr : atom_trie_value->get_atom();
+// Snapshots the atom stored at `handle`. The owning reference is taken under the trie
+// node lock, so concurrent upserts/deletes cannot free the atom mid-read.
+shared_ptr<Atom> lookup_atom(HandleTrie& trie, const string& handle) {
+    unique_ptr<shared_ptr<Atom>> ref(
+        static_cast<shared_ptr<Atom>*>(trie.lookup_stored_object(handle, false)));
+    return ref == nullptr ? nullptr : std::move(*ref);
 }
 
-// Inserts `handle` into the HandleSetTrieValue stored at `key`, creating the entry if absent.
-// Used for both the pattern index (pattern -> links) and incoming sets (target -> links).
+// Snapshots the handle set stored at `key` (copy made under the trie node lock), or
+// nullptr if absent. Used for both the pattern index and incoming sets.
+unique_ptr<set<string>> lookup_handle_set(HandleTrie& trie, const string& key) {
+    return unique_ptr<set<string>>(static_cast<set<string>*>(trie.lookup_stored_object(key, false)));
+}
+
+// Inserts `handle` into the handle set stored at `key`, creating the entry if absent.
+// HandleTrie::insert runs HandleSetTrieValue::merge under the node lock, so the
+// mutation is safe against concurrent reader snapshots.
 void add_to_handle_set(HandleTrie& trie, const string& key, const string& handle) {
-    auto value = dynamic_cast<HandleSetTrieValue*>(trie.lookup(key));
-    if (value == NULL) {
-        value = new HandleSetTrieValue();
-        value->add_handle(handle);
-        trie.insert(key, value);
-    } else {
-        value->add_handle(handle);
-    }
+    trie.insert(key, new HandleSetTrieValue(handle));
 }
 
-// Removes `handle` from the HandleSetTrieValue stored at `key`, dropping the entry once empty.
+// Removes `handle` from the handle set stored at `key`, dropping the entry once empty.
+// Runs under the node lock via HandleTrie::update, safe against concurrent readers.
 void remove_from_handle_set(HandleTrie& trie, const string& key, const string& handle) {
-    auto value = dynamic_cast<HandleSetTrieValue*>(trie.lookup(key));
-    if (value != NULL) {
-        value->remove_handle(handle);
-        if (value->empty()) {
-            trie.remove(key);
-        }
-    }
+    trie.update(
+        key,
+        [](HandleTrie::TrieValue* value, void* data) -> bool {
+            auto* handle_set_value = dynamic_cast<HandleSetTrieValue*>(value);
+            handle_set_value->remove_handle(*static_cast<const string*>(data));
+            return handle_set_value->empty();  // true -> delete the entry
+        },
+        const_cast<string*>(&handle));
 }
 
 // All "VARIABLE at some target position" combinations used to build the default pattern
@@ -143,12 +158,12 @@ bool InMemoryDB::allow_nested_indexing() { return false; }
 // ---------------------------------------------------------------------------
 
 shared_ptr<Atom> InMemoryDB::get_atom(const string& handle) {
-    Atom* atom = lookup_atom(*load_tries()->atoms, handle);
+    auto atom = lookup_atom(*load_tries()->atoms, handle);
     if (atom == nullptr) {
         return nullptr;
     }
     // Return a deep copy (caller must not observe internal trie-owned storage).
-    return clone_atom(atom);
+    return clone_atom(atom.get());
 }
 
 shared_ptr<Node> InMemoryDB::get_node(const string& handle) {
@@ -163,33 +178,29 @@ shared_ptr<Link> InMemoryDB::get_link(const string& handle) {
 
 shared_ptr<HandleSet> InMemoryDB::query_for_pattern(const LinkSchema& link_schema) {
     auto handle_set = make_shared<HandleSetInMemory>();
-
-    auto pattern_trie_value =
-        dynamic_cast<HandleSetTrieValue*>(load_tries()->patterns->lookup(link_schema.handle()));
-    if (pattern_trie_value != NULL) {
-        for (const auto& handle : pattern_trie_value->get_handles()) {
+    auto handles = lookup_handle_set(*load_tries()->patterns, link_schema.handle());
+    if (handles != nullptr) {
+        for (const auto& handle : *handles) {
             handle_set->add_handle(handle);
         }
     }
-
     return handle_set;
 }
 
 shared_ptr<HandleList> InMemoryDB::query_for_targets(const string& handle) {
-    Atom* atom = lookup_atom(*load_tries()->atoms, handle);
+    auto atom = lookup_atom(*load_tries()->atoms, handle);
     if (atom == nullptr || !Atom::is_link(*atom)) {
         return nullptr;  // Absent or not a link, so no targets
     }
-    Link* link = dynamic_cast<Link*>(atom);
+    Link* link = dynamic_cast<Link*>(atom.get());
     return make_shared<HandleListInMemory>(link->targets);
 }
 
 shared_ptr<HandleSet> InMemoryDB::query_for_incoming_set(const string& handle) {
     auto handle_set = make_shared<HandleSetInMemory>();
-    auto incoming_set_trie_value =
-        dynamic_cast<HandleSetTrieValue*>(load_tries()->incoming->lookup(handle));
-    if (incoming_set_trie_value != NULL) {
-        for (const auto& link_handle : incoming_set_trie_value->get_handles()) {
+    auto handles = lookup_handle_set(*load_tries()->incoming, handle);
+    if (handles != nullptr) {
+        for (const auto& link_handle : *handles) {
             handle_set->add_handle(link_handle);
         }
     }
@@ -198,11 +209,11 @@ shared_ptr<HandleSet> InMemoryDB::query_for_incoming_set(const string& handle) {
 
 vector<shared_ptr<Atom>> InMemoryDB::get_matching_atoms(bool is_toplevel, Atom& key) {
     vector<shared_ptr<Atom>> matching_atoms;
-    Atom* atom = lookup_atom(*load_tries()->atoms, key.handle());
+    auto atom = lookup_atom(*load_tries()->atoms, key.handle());
     if (atom == nullptr) {
         return matching_atoms;
     }
-    auto cloned = clone_atom(atom);
+    auto cloned = clone_atom(atom.get());
     if (cloned != nullptr) {
         matching_atoms.push_back(cloned);
     }
@@ -214,12 +225,12 @@ bool InMemoryDB::atom_exists(const string& handle) {
 }
 
 bool InMemoryDB::node_exists(const string& handle) {
-    Atom* atom = lookup_atom(*load_tries()->atoms, handle);
+    auto atom = lookup_atom(*load_tries()->atoms, handle);
     return atom != nullptr && Atom::is_node(*atom);
 }
 
 bool InMemoryDB::link_exists(const string& handle) {
-    Atom* atom = lookup_atom(*load_tries()->atoms, handle);
+    auto atom = lookup_atom(*load_tries()->atoms, handle);
     return atom != nullptr && Atom::is_link(*atom);
 }
 
@@ -238,7 +249,7 @@ set<string> InMemoryDB::nodes_exist(const vector<string>& handles) {
     set<string> existing;
     auto trie = load_tries()->atoms;
     for (const auto& handle : handles) {
-        Atom* atom = lookup_atom(*trie, handle);
+        auto atom = lookup_atom(*trie, handle);
         if (atom != nullptr && Atom::is_node(*atom)) {
             existing.insert(handle);
         }
@@ -250,7 +261,7 @@ set<string> InMemoryDB::links_exist(const vector<string>& handles) {
     set<string> existing;
     auto trie = load_tries()->atoms;
     for (const auto& handle : handles) {
-        Atom* atom = lookup_atom(*trie, handle);
+        auto atom = lookup_atom(*trie, handle);
         if (atom != nullptr && Atom::is_link(*atom)) {
             existing.insert(handle);
         }
@@ -279,7 +290,8 @@ vector<shared_ptr<Atom>> InMemoryDB::get_all_atoms() {
                 return false;
             }
             auto* out = static_cast<vector<shared_ptr<Atom>>*>(data);
-            auto cloned = clone_atom(atom_trie_value->get_atom());
+            // Safe: traverse() runs this visitor under the node lock.
+            auto cloned = clone_atom(atom_trie_value->get_atom().get());
             if (cloned != nullptr) {
                 out->push_back(cloned);
             }
@@ -315,15 +327,16 @@ string InMemoryDB::add_node_unlocked(const Tries& tries,
     auto existing = trie->lookup(handle);
     if ((existing == NULL) || (merger == NULL)) {
         // Insert or upsert/replace — HandleTrie insert calls AtomTrieValue::merge,
-        // which deletes the previous Atom (if any) and takes ownership of the new one.
+        // which swaps in the new Atom (readers holding a ref keep the old one alive).
         Node* cloned_node = new Node(*node);
         trie->insert(handle, new AtomTrieValue(cloned_node));
         return handle;
     }
 
-    // Merge a copy; persist only when merge() returns true.
+    // Merge a copy; persist only when merge() returns true. Raw access is safe here:
+    // only writers free/replace values and writers are serialized by write_mutex_.
     auto* atom_trie_value = dynamic_cast<AtomTrieValue*>(existing);
-    unique_ptr<Node> working(new Node(*dynamic_cast<Node*>(atom_trie_value->get_atom())));
+    unique_ptr<Node> working(new Node(*dynamic_cast<Node*>(atom_trie_value->get_atom().get())));
     if (!merger->merge(working.get(), node)) {
         return "";
     }
@@ -410,7 +423,7 @@ vector<string> InMemoryDB::add_links_unlocked(const Tries& tries,
         bool is_new = (existing == NULL);
 
         if ((existing == NULL) || (merger == NULL)) {
-            // Insert or upsert/replace — AtomTrieValue::merge frees the previous Atom.
+            // Insert or upsert/replace — AtomTrieValue::merge swaps in the new Atom.
             Link* cloned_link = new Link(*link);
             trie->insert(link_handle, new AtomTrieValue(cloned_link));
         } else {
@@ -418,7 +431,7 @@ vector<string> InMemoryDB::add_links_unlocked(const Tries& tries,
             // On failure, skip incoming-set/pattern updates — the link was already
             // indexed by whichever add created it.
             auto* atom_trie_value = dynamic_cast<AtomTrieValue*>(existing);
-            unique_ptr<Link> working(new Link(*dynamic_cast<Link*>(atom_trie_value->get_atom())));
+            unique_ptr<Link> working(new Link(*dynamic_cast<Link*>(atom_trie_value->get_atom().get())));
             if (!merger->merge(working.get(), link)) {
                 handles.push_back("");
                 continue;
@@ -469,18 +482,17 @@ bool InMemoryDB::delete_node_unlocked(const Tries& tries,
     const auto& trie = tries.atoms;
     const auto& incoming_trie = tries.incoming;
 
-    Atom* atom = lookup_atom(*trie, handle);
+    auto atom = lookup_atom(*trie, handle);
     if (atom == nullptr || !Atom::is_node(*atom)) {
         return false;
     }
 
     vector<string> link_handles_to_delete;
 
-    auto incoming_set_trie_value = dynamic_cast<HandleSetTrieValue*>(incoming_trie->lookup(handle));
-    if (incoming_set_trie_value != NULL && !incoming_set_trie_value->empty()) {
+    auto incoming = lookup_handle_set(*incoming_trie, handle);
+    if (incoming != nullptr && !incoming->empty()) {
         if (delete_link_targets) {
-            link_handles_to_delete = vector<string>(incoming_set_trie_value->get_handles().begin(),
-                                                    incoming_set_trie_value->get_handles().end());
+            link_handles_to_delete = vector<string>(incoming->begin(), incoming->end());
         } else {
             // Cannot delete node that is referenced by links
             return false;
@@ -508,12 +520,12 @@ bool InMemoryDB::delete_link_unlocked(const Tries& tries,
     const auto& trie = tries.atoms;
     const auto& incoming_trie = tries.incoming;
 
-    Atom* atom = lookup_atom(*trie, handle);
+    auto atom = lookup_atom(*trie, handle);
     if (atom == nullptr || !Atom::is_link(*atom)) {
         return false;
     }
 
-    auto link = dynamic_cast<Link*>(atom);
+    auto link = dynamic_cast<Link*>(atom.get());
     auto targets = link->targets;
 
     vector<string> targets_to_delete;
@@ -522,9 +534,9 @@ bool InMemoryDB::delete_link_unlocked(const Tries& tries,
         remove_from_handle_set(*incoming_trie, target_handle, handle);
 
         if (delete_link_targets) {
-            auto incoming_set_trie_value =
-                dynamic_cast<HandleSetTrieValue*>(incoming_trie->lookup(target_handle));
-            if (incoming_set_trie_value == NULL || incoming_set_trie_value->empty()) {
+            // remove_from_handle_set drops entries that become empty, so a missing
+            // entry means the target has no remaining incoming links.
+            if (lookup_handle_set(*incoming_trie, target_handle) == nullptr) {
                 targets_to_delete.push_back(target_handle);
             }
         }
@@ -612,7 +624,8 @@ void InMemoryDB::re_index_patterns(bool flush_patterns) {
             if (atom_trie_value == nullptr) {
                 return false;
             }
-            Atom* atom = atom_trie_value->get_atom();
+            // Safe: traverse() runs this visitor under the node lock.
+            Atom* atom = atom_trie_value->get_atom().get();
             if (!Atom::is_link(*atom)) {
                 return false;
             }

--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -526,7 +526,7 @@ bool InMemoryDB::delete_link_unlocked(const Tries& tries,
     }
 
     auto link = dynamic_cast<Link*>(atom.get());
-    auto targets = link->targets;
+    const auto& targets = link->targets;
 
     vector<string> targets_to_delete;
 

--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -71,48 +71,84 @@ shared_ptr<Atom> clone_atom(const Atom* atom) {
 }
 
 shared_ptr<HandleTrie> make_trie() { return make_shared<HandleTrie>(HANDLE_HASH_SIZE - 1); }
+
+// Returns the trie-owned Atom for a handle, or nullptr if absent (or not an AtomTrieValue).
+Atom* lookup_atom(HandleTrie& trie, const string& handle) {
+    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie.lookup(handle));
+    return atom_trie_value == nullptr ? nullptr : atom_trie_value->get_atom();
+}
+
+// Inserts `handle` into the HandleSetTrieValue stored at `key`, creating the entry if absent.
+// Used for both the pattern index (pattern -> links) and incoming sets (target -> links).
+void add_to_handle_set(HandleTrie& trie, const string& key, const string& handle) {
+    auto value = dynamic_cast<HandleSetTrieValue*>(trie.lookup(key));
+    if (value == NULL) {
+        value = new HandleSetTrieValue();
+        value->add_handle(handle);
+        trie.insert(key, value);
+    } else {
+        value->add_handle(handle);
+    }
+}
+
+// Removes `handle` from the HandleSetTrieValue stored at `key`, dropping the entry once empty.
+void remove_from_handle_set(HandleTrie& trie, const string& key, const string& handle) {
+    auto value = dynamic_cast<HandleSetTrieValue*>(trie.lookup(key));
+    if (value != NULL) {
+        value->remove_handle(handle);
+        if (value->empty()) {
+            trie.remove(key);
+        }
+    }
+}
+
+// All "VARIABLE at some target position" combinations used to build the default pattern
+// index when no explicit schema was registered.
+vector<vector<string>> index_entries_combinations(unsigned int arity) {
+    vector<vector<string>> index_entries;
+    unsigned int total = 1 << arity;  // 2^arity
+
+    // Skip mask == 0 (all concrete): identical to the link's own handle; no separate pattern index.
+    for (unsigned int mask = 1; mask < total; ++mask) {
+        vector<string> index_entry;
+        for (unsigned int i = 0; i < arity; ++i) {
+            if (mask & (1 << i))
+                index_entry.push_back("*");
+            else
+                index_entry.push_back("v" + to_string(i + 1));
+        }
+        index_entries.push_back(index_entry);
+    }
+
+    return index_entries;
+}
 }  // namespace
 
-InMemoryDB::InMemoryDB(const string& context)
-    : context_(context),
-      atoms_trie_(make_trie()),
-      pattern_index_trie_(make_trie()),
-      incoming_sets_trie_(make_trie()) {}
+shared_ptr<InMemoryDB::Tries> InMemoryDB::make_tries() {
+    auto tries = make_shared<Tries>();
+    tries->atoms = make_trie();
+    tries->patterns = make_trie();
+    tries->incoming = make_trie();
+    return tries;
+}
+
+InMemoryDB::InMemoryDB(const string& context) : context_(context), tries_(make_tries()) {}
 
 InMemoryDB::~InMemoryDB() = default;
 
 bool InMemoryDB::allow_nested_indexing() { return false; }
-
-shared_ptr<HandleTrie> InMemoryDB::atoms_trie() const {
-    lock_guard<mutex> lock(trie_ptr_mutex_);
-    return atoms_trie_;
-}
-
-shared_ptr<HandleTrie> InMemoryDB::pattern_index_trie() const {
-    lock_guard<mutex> lock(trie_ptr_mutex_);
-    return pattern_index_trie_;
-}
-
-shared_ptr<HandleTrie> InMemoryDB::incoming_sets_trie() const {
-    lock_guard<mutex> lock(trie_ptr_mutex_);
-    return incoming_sets_trie_;
-}
 
 // ---------------------------------------------------------------------------
 // Reads — no write_mutex_; trie snapshots + HandleTrie's per-node locking
 // ---------------------------------------------------------------------------
 
 shared_ptr<Atom> InMemoryDB::get_atom(const string& handle) {
-    auto trie_value = atoms_trie()->lookup(handle);
-    if (trie_value == NULL) {
-        return nullptr;
-    }
-    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie_value);
-    if (atom_trie_value == NULL) {
+    Atom* atom = lookup_atom(*load_tries()->atoms, handle);
+    if (atom == nullptr) {
         return nullptr;
     }
     // Return a deep copy (caller must not observe internal trie-owned storage).
-    return clone_atom(atom_trie_value->get_atom());
+    return clone_atom(atom);
 }
 
 shared_ptr<Node> InMemoryDB::get_node(const string& handle) {
@@ -129,7 +165,7 @@ shared_ptr<HandleSet> InMemoryDB::query_for_pattern(const LinkSchema& link_schem
     auto handle_set = make_shared<HandleSetInMemory>();
 
     auto pattern_trie_value =
-        dynamic_cast<HandleSetTrieValue*>(pattern_index_trie()->lookup(link_schema.handle()));
+        dynamic_cast<HandleSetTrieValue*>(load_tries()->patterns->lookup(link_schema.handle()));
     if (pattern_trie_value != NULL) {
         for (const auto& handle : pattern_trie_value->get_handles()) {
             handle_set->add_handle(handle);
@@ -140,17 +176,9 @@ shared_ptr<HandleSet> InMemoryDB::query_for_pattern(const LinkSchema& link_schem
 }
 
 shared_ptr<HandleList> InMemoryDB::query_for_targets(const string& handle) {
-    auto trie_value = atoms_trie()->lookup(handle);
-    if (trie_value == NULL) {
-        return nullptr;
-    }
-    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie_value);
-    if (atom_trie_value == NULL) {
-        return nullptr;
-    }
-    Atom* atom = atom_trie_value->get_atom();
-    if (!Atom::is_link(*atom)) {
-        return nullptr;  // Not a link, so no targets
+    Atom* atom = lookup_atom(*load_tries()->atoms, handle);
+    if (atom == nullptr || !Atom::is_link(*atom)) {
+        return nullptr;  // Absent or not a link, so no targets
     }
     Link* link = dynamic_cast<Link*>(atom);
     return make_shared<HandleListInMemory>(link->targets);
@@ -159,7 +187,7 @@ shared_ptr<HandleList> InMemoryDB::query_for_targets(const string& handle) {
 shared_ptr<HandleSet> InMemoryDB::query_for_incoming_set(const string& handle) {
     auto handle_set = make_shared<HandleSetInMemory>();
     auto incoming_set_trie_value =
-        dynamic_cast<HandleSetTrieValue*>(incoming_sets_trie()->lookup(handle));
+        dynamic_cast<HandleSetTrieValue*>(load_tries()->incoming->lookup(handle));
     if (incoming_set_trie_value != NULL) {
         for (const auto& link_handle : incoming_set_trie_value->get_handles()) {
             handle_set->add_handle(link_handle);
@@ -170,52 +198,34 @@ shared_ptr<HandleSet> InMemoryDB::query_for_incoming_set(const string& handle) {
 
 vector<shared_ptr<Atom>> InMemoryDB::get_matching_atoms(bool is_toplevel, Atom& key) {
     vector<shared_ptr<Atom>> matching_atoms;
-    auto trie_value = atoms_trie()->lookup(key.handle());
-    if (trie_value == NULL) {
+    Atom* atom = lookup_atom(*load_tries()->atoms, key.handle());
+    if (atom == nullptr) {
         return matching_atoms;
     }
-    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie_value);
-    if (atom_trie_value == NULL) {
-        return matching_atoms;
-    }
-    auto cloned = clone_atom(atom_trie_value->get_atom());
+    auto cloned = clone_atom(atom);
     if (cloned != nullptr) {
         matching_atoms.push_back(cloned);
     }
     return matching_atoms;
 }
 
-bool InMemoryDB::atom_exists(const string& handle) { return atoms_trie()->lookup(handle) != NULL; }
+bool InMemoryDB::atom_exists(const string& handle) {
+    return load_tries()->atoms->lookup(handle) != NULL;
+}
 
 bool InMemoryDB::node_exists(const string& handle) {
-    auto trie_value = atoms_trie()->lookup(handle);
-    if (trie_value == NULL) {
-        return false;
-    }
-    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie_value);
-    if (atom_trie_value == NULL) {
-        return false;
-    }
-    Atom* atom = atom_trie_value->get_atom();
-    return Atom::is_node(*atom);
+    Atom* atom = lookup_atom(*load_tries()->atoms, handle);
+    return atom != nullptr && Atom::is_node(*atom);
 }
 
 bool InMemoryDB::link_exists(const string& handle) {
-    auto trie_value = atoms_trie()->lookup(handle);
-    if (trie_value == NULL) {
-        return false;
-    }
-    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie_value);
-    if (atom_trie_value == NULL) {
-        return false;
-    }
-    Atom* atom = atom_trie_value->get_atom();
-    return Atom::is_link(*atom);
+    Atom* atom = lookup_atom(*load_tries()->atoms, handle);
+    return atom != nullptr && Atom::is_link(*atom);
 }
 
 set<string> InMemoryDB::atoms_exist(const vector<string>& handles) {
     set<string> existing;
-    auto trie = atoms_trie();
+    auto trie = load_tries()->atoms;
     for (const auto& handle : handles) {
         if (trie->lookup(handle) != NULL) {
             existing.insert(handle);
@@ -226,8 +236,10 @@ set<string> InMemoryDB::atoms_exist(const vector<string>& handles) {
 
 set<string> InMemoryDB::nodes_exist(const vector<string>& handles) {
     set<string> existing;
+    auto trie = load_tries()->atoms;
     for (const auto& handle : handles) {
-        if (this->node_exists(handle)) {
+        Atom* atom = lookup_atom(*trie, handle);
+        if (atom != nullptr && Atom::is_node(*atom)) {
             existing.insert(handle);
         }
     }
@@ -236,8 +248,10 @@ set<string> InMemoryDB::nodes_exist(const vector<string>& handles) {
 
 set<string> InMemoryDB::links_exist(const vector<string>& handles) {
     set<string> existing;
+    auto trie = load_tries()->atoms;
     for (const auto& handle : handles) {
-        if (this->link_exists(handle)) {
+        Atom* atom = lookup_atom(*trie, handle);
+        if (atom != nullptr && Atom::is_link(*atom)) {
             existing.insert(handle);
         }
     }
@@ -248,11 +262,11 @@ size_t InMemoryDB::node_count() const { RAISE_ERROR("node_count() is not impleme
 
 size_t InMemoryDB::link_count() const { RAISE_ERROR("link_count() is not implemented yet"); }
 
-size_t InMemoryDB::atom_count() const { return static_cast<size_t>(atoms_trie()->size()); }
+size_t InMemoryDB::atom_count() const { return static_cast<size_t>(load_tries()->atoms->size()); }
 
 vector<shared_ptr<Atom>> InMemoryDB::get_all_atoms() {
     vector<shared_ptr<Atom>> atoms;
-    auto trie = atoms_trie();
+    auto trie = load_tries()->atoms;
     atoms.reserve(trie->size());
     trie->traverse(
         false,
@@ -289,12 +303,14 @@ string InMemoryDB::add_atom(const atoms::Atom* atom, const atoms::Merger* merger
 
 string InMemoryDB::add_node(const atoms::Node* node, const atoms::Merger* merger) {
     lock_guard<mutex> lock(write_mutex_);
-    return add_node_unlocked(node, merger);
+    return add_node_unlocked(*load_tries(), node, merger);
 }
 
-string InMemoryDB::add_node_unlocked(const atoms::Node* node, const atoms::Merger* merger) {
+string InMemoryDB::add_node_unlocked(const Tries& tries,
+                                     const atoms::Node* node,
+                                     const atoms::Merger* merger) {
     string handle = node->handle();
-    auto trie = atoms_trie();
+    const auto& trie = tries.atoms;
 
     auto existing = trie->lookup(handle);
     if ((existing == NULL) || (merger == NULL)) {
@@ -329,6 +345,7 @@ vector<string> InMemoryDB::add_atoms(const vector<atoms::Atom*>& atom_list,
         return {};
     }
     lock_guard<mutex> lock(write_mutex_);
+    auto tries = load_tries();
 
     vector<Node*> nodes;
     vector<Link*> links;
@@ -340,30 +357,29 @@ vector<string> InMemoryDB::add_atoms(const vector<atoms::Atom*>& atom_list,
             links.push_back(dynamic_cast<atoms::Link*>(atom));
         }
     }
-    auto node_handles = this->add_nodes_unlocked(nodes, is_transactional, merger);
-    auto link_handles = this->add_links_unlocked(links, is_transactional, merger);
+    vector<string> handles;
+    handles.reserve(atom_list.size());
+    for (const auto& node : nodes) {
+        handles.push_back(this->add_node_unlocked(*tries, node, merger));
+    }
+    auto link_handles = this->add_links_unlocked(*tries, links, is_transactional, merger);
 
-    node_handles.insert(node_handles.end(), link_handles.begin(), link_handles.end());
-    return node_handles;
+    handles.insert(handles.end(), link_handles.begin(), link_handles.end());
+    return handles;
 }
 
 vector<string> InMemoryDB::add_nodes(const vector<atoms::Node*>& nodes,
-                                     bool is_transactional,
+                                     bool /*is_transactional*/,
                                      const atoms::Merger* merger) {
     if (nodes.empty()) {
         return {};
     }
     lock_guard<mutex> lock(write_mutex_);
-    return add_nodes_unlocked(nodes, is_transactional, merger);
-}
-
-vector<string> InMemoryDB::add_nodes_unlocked(const vector<atoms::Node*>& nodes,
-                                              bool /*is_transactional*/,
-                                              const atoms::Merger* merger) {
+    auto tries = load_tries();
     vector<string> handles;
     handles.reserve(nodes.size());
     for (const auto& node : nodes) {
-        handles.push_back(this->add_node_unlocked(node, merger));
+        handles.push_back(this->add_node_unlocked(*tries, node, merger));
     }
     return handles;
 }
@@ -375,16 +391,17 @@ vector<string> InMemoryDB::add_links(const vector<atoms::Link*>& links,
         return {};
     }
     lock_guard<mutex> lock(write_mutex_);
-    return add_links_unlocked(links, is_transactional, merger);
+    return add_links_unlocked(*load_tries(), links, is_transactional, merger);
 }
 
-vector<string> InMemoryDB::add_links_unlocked(const vector<atoms::Link*>& links,
+vector<string> InMemoryDB::add_links_unlocked(const Tries& tries,
+                                              const vector<atoms::Link*>& links,
                                               bool /*is_transactional*/,
                                               const atoms::Merger* merger) {
     vector<string> handles;
     handles.reserve(links.size());
-    auto trie = atoms_trie();
-    auto pattern_trie = pattern_index_trie();
+    const auto& trie = tries.atoms;
+    const auto& pattern_trie = tries.patterns;
 
     for (const auto& link : links) {
         string link_handle = link->handle();
@@ -412,12 +429,12 @@ vector<string> InMemoryDB::add_links_unlocked(const vector<atoms::Link*>& links,
         // Content-addressed handles share targets, so indexes only need building on first insert.
         if (is_new) {
             for (const auto& target_handle : link->targets) {
-                this->add_incoming_set_unlocked(target_handle, link_handle);
+                add_to_handle_set(*tries.incoming, target_handle, link_handle);
             }
 
             auto pattern_handles = this->match_pattern_index_schema_unlocked(link);
             for (const auto& pattern_handle : pattern_handles) {
-                add_pattern_to(*pattern_trie, pattern_handle, link_handle);
+                add_to_handle_set(*pattern_trie, pattern_handle, link_handle);
             }
         }
 
@@ -429,35 +446,31 @@ vector<string> InMemoryDB::add_links_unlocked(const vector<atoms::Link*>& links,
 
 bool InMemoryDB::delete_atom(const string& handle, bool delete_link_targets) {
     lock_guard<mutex> lock(write_mutex_);
-    return delete_atom_unlocked(handle, delete_link_targets);
+    return delete_atom_unlocked(*load_tries(), handle, delete_link_targets);
 }
 
-bool InMemoryDB::delete_atom_unlocked(const string& handle, bool delete_link_targets) {
-    if (this->delete_node_unlocked(handle, delete_link_targets)) {
+bool InMemoryDB::delete_atom_unlocked(const Tries& tries,
+                                      const string& handle,
+                                      bool delete_link_targets) {
+    if (this->delete_node_unlocked(tries, handle, delete_link_targets)) {
         return true;
     }
-    return this->delete_link_unlocked(handle, delete_link_targets);
+    return this->delete_link_unlocked(tries, handle, delete_link_targets);
 }
 
 bool InMemoryDB::delete_node(const string& handle, bool delete_link_targets) {
     lock_guard<mutex> lock(write_mutex_);
-    return delete_node_unlocked(handle, delete_link_targets);
+    return delete_node_unlocked(*load_tries(), handle, delete_link_targets);
 }
 
-bool InMemoryDB::delete_node_unlocked(const string& handle, bool delete_link_targets) {
-    auto trie = atoms_trie();
-    auto incoming_trie = incoming_sets_trie();
+bool InMemoryDB::delete_node_unlocked(const Tries& tries,
+                                      const string& handle,
+                                      bool delete_link_targets) {
+    const auto& trie = tries.atoms;
+    const auto& incoming_trie = tries.incoming;
 
-    auto trie_value = trie->lookup(handle);
-    if (trie_value == NULL) {
-        return false;
-    }
-    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie_value);
-    if (atom_trie_value == NULL) {
-        return false;
-    }
-    Atom* atom = atom_trie_value->get_atom();
-    if (!Atom::is_node(*atom)) {
+    Atom* atom = lookup_atom(*trie, handle);
+    if (atom == nullptr || !Atom::is_node(*atom)) {
         return false;
     }
 
@@ -475,7 +488,7 @@ bool InMemoryDB::delete_node_unlocked(const string& handle, bool delete_link_tar
     }
 
     for (const auto& link_handle : link_handles_to_delete) {
-        this->delete_link_unlocked(link_handle, delete_link_targets);
+        this->delete_link_unlocked(tries, link_handle, delete_link_targets);
     }
 
     trie->remove(handle);
@@ -486,23 +499,17 @@ bool InMemoryDB::delete_node_unlocked(const string& handle, bool delete_link_tar
 
 bool InMemoryDB::delete_link(const string& handle, bool delete_link_targets) {
     lock_guard<mutex> lock(write_mutex_);
-    return delete_link_unlocked(handle, delete_link_targets);
+    return delete_link_unlocked(*load_tries(), handle, delete_link_targets);
 }
 
-bool InMemoryDB::delete_link_unlocked(const string& handle, bool delete_link_targets) {
-    auto trie = atoms_trie();
-    auto incoming_trie = incoming_sets_trie();
+bool InMemoryDB::delete_link_unlocked(const Tries& tries,
+                                      const string& handle,
+                                      bool delete_link_targets) {
+    const auto& trie = tries.atoms;
+    const auto& incoming_trie = tries.incoming;
 
-    auto trie_value = trie->lookup(handle);
-    if (trie_value == NULL) {
-        return false;
-    }
-    auto atom_trie_value = dynamic_cast<AtomTrieValue*>(trie_value);
-    if (atom_trie_value == NULL) {
-        return false;
-    }
-    Atom* atom = atom_trie_value->get_atom();
-    if (!Atom::is_link(*atom)) {
+    Atom* atom = lookup_atom(*trie, handle);
+    if (atom == nullptr || !Atom::is_link(*atom)) {
         return false;
     }
 
@@ -512,7 +519,7 @@ bool InMemoryDB::delete_link_unlocked(const string& handle, bool delete_link_tar
     vector<string> targets_to_delete;
 
     for (const auto& target_handle : targets) {
-        this->delete_incoming_set_unlocked(target_handle, handle);
+        remove_from_handle_set(*incoming_trie, target_handle, handle);
 
         if (delete_link_targets) {
             auto incoming_set_trie_value =
@@ -525,13 +532,13 @@ bool InMemoryDB::delete_link_unlocked(const string& handle, bool delete_link_tar
 
     vector<string> pattern_handles = this->match_pattern_index_schema_unlocked(link);
     for (const auto& pattern_handle : pattern_handles) {
-        this->delete_pattern_unlocked(pattern_handle, handle);
+        remove_from_handle_set(*tries.patterns, pattern_handle, handle);
     }
 
     trie->remove(handle);
 
     for (const auto& target_handle : targets_to_delete) {
-        this->delete_atom_unlocked(target_handle, delete_link_targets);
+        this->delete_atom_unlocked(tries, target_handle, delete_link_targets);
     }
 
     return true;
@@ -539,9 +546,10 @@ bool InMemoryDB::delete_link_unlocked(const string& handle, bool delete_link_tar
 
 uint InMemoryDB::delete_atoms(const vector<string>& handles, bool delete_link_targets) {
     lock_guard<mutex> lock(write_mutex_);
+    auto tries = load_tries();
     uint deleted_count = 0;
     for (const auto& handle : handles) {
-        if (this->delete_atom_unlocked(handle, delete_link_targets)) {
+        if (this->delete_atom_unlocked(*tries, handle, delete_link_targets)) {
             deleted_count++;
         }
     }
@@ -550,9 +558,10 @@ uint InMemoryDB::delete_atoms(const vector<string>& handles, bool delete_link_ta
 
 uint InMemoryDB::delete_nodes(const vector<string>& handles, bool delete_link_targets) {
     lock_guard<mutex> lock(write_mutex_);
+    auto tries = load_tries();
     uint deleted_count = 0;
     for (const auto& handle : handles) {
-        if (this->delete_node_unlocked(handle, delete_link_targets)) {
+        if (this->delete_node_unlocked(*tries, handle, delete_link_targets)) {
             deleted_count++;
         }
     }
@@ -561,9 +570,10 @@ uint InMemoryDB::delete_nodes(const vector<string>& handles, bool delete_link_ta
 
 uint InMemoryDB::delete_links(const vector<string>& handles, bool delete_link_targets) {
     lock_guard<mutex> lock(write_mutex_);
+    auto tries = load_tries();
     uint deleted_count = 0;
     for (const auto& handle : handles) {
-        if (this->delete_link_unlocked(handle, delete_link_targets)) {
+        if (this->delete_link_unlocked(*tries, handle, delete_link_targets)) {
             deleted_count++;
         }
     }
@@ -572,33 +582,26 @@ uint InMemoryDB::delete_links(const vector<string>& handles, bool delete_link_ta
 
 void InMemoryDB::drop_all() {
     lock_guard<mutex> lock(write_mutex_);
-    // Swap fresh tries instead of deleting in place: concurrent readers keep their
-    // pre-swap snapshots alive until they finish.
-    auto fresh_atoms = make_trie();
-    auto fresh_patterns = make_trie();
-    auto fresh_incoming = make_trie();
-    {
-        lock_guard<mutex> ptr_lock(trie_ptr_mutex_);
-        atoms_trie_ = move(fresh_atoms);
-        pattern_index_trie_ = move(fresh_patterns);
-        incoming_sets_trie_ = move(fresh_incoming);
-    }
+    // Publish a fresh bundle instead of deleting in place: concurrent readers keep
+    // their pre-swap snapshots alive until they finish.
+    store_tries(make_tries());
 }
 
 void InMemoryDB::re_index_patterns(bool flush_patterns) {
     lock_guard<mutex> lock(write_mutex_);
 
+    auto current = load_tries();
     // Build into a target trie, then publish. With flush_patterns the target is a fresh
     // trie swapped in at the end, so readers see either the old or the fully rebuilt
     // index — never a torn/deleted one.
-    shared_ptr<HandleTrie> target = flush_patterns ? make_trie() : pattern_index_trie();
+    shared_ptr<HandleTrie> target = flush_patterns ? make_trie() : current->patterns;
 
     struct ReIndexCtx {
         InMemoryDB* db;
         HandleTrie* target;
     } ctx{this, target.get()};
 
-    atoms_trie()->traverse(
+    current->atoms->traverse(
         false,
         [](HandleTrie::TrieNode* node, void* data) -> bool {
             auto* ctx = static_cast<ReIndexCtx*>(data);
@@ -617,21 +620,22 @@ void InMemoryDB::re_index_patterns(bool flush_patterns) {
             string link_handle = link->handle();
             auto pattern_handles = ctx->db->match_pattern_index_schema_unlocked(link);
             for (const auto& pattern_handle : pattern_handles) {
-                add_pattern_to(*ctx->target, pattern_handle, link_handle);
+                add_to_handle_set(*ctx->target, pattern_handle, link_handle);
             }
             return false;
         },
         &ctx);
 
     if (flush_patterns) {
-        lock_guard<mutex> ptr_lock(trie_ptr_mutex_);
-        pattern_index_trie_ = target;
+        auto next = make_shared<Tries>(*current);
+        next->patterns = std::move(target);
+        store_tries(std::move(next));
     }
 }
 
 void InMemoryDB::add_pattern(const string& pattern_handle, const string& atom_handle) {
     lock_guard<mutex> lock(write_mutex_);
-    add_pattern_to(*pattern_index_trie(), pattern_handle, atom_handle);
+    add_to_handle_set(*load_tries()->patterns, pattern_handle, atom_handle);
 }
 
 vector<string> InMemoryDB::match_pattern_index_schema(const Link* link) {
@@ -639,53 +643,6 @@ vector<string> InMemoryDB::match_pattern_index_schema(const Link* link) {
     // std::map, so unguarded concurrent read/write would be a data race.
     lock_guard<mutex> lock(write_mutex_);
     return match_pattern_index_schema_unlocked(link);
-}
-
-void InMemoryDB::add_pattern_to(HandleTrie& trie,
-                                const string& pattern_handle,
-                                const string& atom_handle) {
-    auto pattern_trie_value = dynamic_cast<HandleSetTrieValue*>(trie.lookup(pattern_handle));
-    if (pattern_trie_value == NULL) {
-        pattern_trie_value = new HandleSetTrieValue();
-        pattern_trie_value->add_handle(atom_handle);
-        trie.insert(pattern_handle, pattern_trie_value);
-    } else {
-        pattern_trie_value->add_handle(atom_handle);
-    }
-}
-
-void InMemoryDB::delete_pattern_unlocked(const string& pattern_handle, const string& atom_handle) {
-    auto trie = pattern_index_trie();
-    auto pattern_trie_value = dynamic_cast<HandleSetTrieValue*>(trie->lookup(pattern_handle));
-    if (pattern_trie_value != NULL) {
-        pattern_trie_value->remove_handle(atom_handle);
-        if (pattern_trie_value->empty()) {
-            trie->remove(pattern_handle);
-        }
-    }
-}
-
-void InMemoryDB::add_incoming_set_unlocked(const string& target_handle, const string& link_handle) {
-    auto trie = incoming_sets_trie();
-    auto incoming_set_trie_value = dynamic_cast<HandleSetTrieValue*>(trie->lookup(target_handle));
-    if (incoming_set_trie_value == NULL) {
-        incoming_set_trie_value = new HandleSetTrieValue();
-        incoming_set_trie_value->add_handle(link_handle);
-        trie->insert(target_handle, incoming_set_trie_value);
-    } else {
-        incoming_set_trie_value->add_handle(link_handle);
-    }
-}
-
-void InMemoryDB::delete_incoming_set_unlocked(const string& target_handle, const string& link_handle) {
-    auto trie = incoming_sets_trie();
-    auto incoming_set_trie_value = dynamic_cast<HandleSetTrieValue*>(trie->lookup(target_handle));
-    if (incoming_set_trie_value != NULL) {
-        incoming_set_trie_value->remove_handle(link_handle);
-        if (incoming_set_trie_value->empty()) {
-            trie->remove(target_handle);
-        }
-    }
 }
 
 void InMemoryDB::add_pattern_index_schema(const string& tokens,
@@ -713,7 +670,7 @@ vector<string> InMemoryDB::match_pattern_index_schema_unlocked(const Link* link)
             tokens.push_back("VARIABLE");
             tokens.push_back("v" + to_string(i + 1));
         }
-        auto index_entries = this->index_entries_combinations(link->arity());
+        auto index_entries = index_entries_combinations(link->arity());
         default_map = {{1, make_tuple(move(tokens), move(index_entries))}};
         iter_map = &default_map;
     }
@@ -757,23 +714,4 @@ vector<string> InMemoryDB::match_pattern_index_schema_unlocked(const Link* link)
         }
     }
     return pattern_handles;
-}
-
-vector<vector<string>> InMemoryDB::index_entries_combinations(unsigned int arity) {
-    vector<vector<string>> index_entries;
-    unsigned int total = 1 << arity;  // 2^arity
-
-    // Skip mask == 0 (all concrete): identical to the link's own handle; no separate pattern index.
-    for (unsigned int mask = 1; mask < total; ++mask) {
-        vector<string> index_entry;
-        for (unsigned int i = 0; i < arity; ++i) {
-            if (mask & (1 << i))
-                index_entry.push_back("*");
-            else
-                index_entry.push_back("v" + to_string(i + 1));
-        }
-        index_entries.push_back(index_entry);
-    }
-
-    return index_entries;
 }

--- a/src/atomdb/inmemorydb/InMemoryDB.h
+++ b/src/atomdb/inmemorydb/InMemoryDB.h
@@ -27,6 +27,11 @@ namespace atomdb {
  * - Pure reads (get_*, query_*, *_exist(s), counts, get_all_atoms) take no InMemoryDB-wide
  *   lock. Each read atomically loads a Tries snapshot and relies on HandleTrie's
  *   hand-over-hand per-node locking for the traversal itself.
+ * - Value lifetime: readers never keep raw pointers into trie-owned storage. Atoms are
+ *   handed out as shared_ptr refs and handle sets as copies, both extracted under the
+ *   trie node lock (get_stored_object), so concurrent deletes/upserts of the same handle
+ *   cannot free data mid-read. Set mutations also run under the node lock (insert/merge
+ *   for adds, HandleTrie::update for removals).
  * - Mutations (add_*, delete_*, re_index_patterns, drop_all, add_pattern_index_schema) are
  *   serialized by write_mutex_ so the three tries stay mutually consistent and writers
  *   never insert into a trie that drop_all already retired.

--- a/src/atomdb/inmemorydb/InMemoryDB.h
+++ b/src/atomdb/inmemorydb/InMemoryDB.h
@@ -100,7 +100,9 @@ class InMemoryDB : public AtomDB {
 
     /** Returns deep clones of every stored atom. */
     vector<shared_ptr<Atom>> get_all_atoms();
-    /** Removes all stored atoms and resets all indexes. */
+    /** Removes all stored atoms and index entries. Pattern index schemas registered
+     *  via add_pattern_index_schema() are intentionally kept: they are configuration,
+     *  not data. */
     void drop_all();
 
     void add_pattern(const string& pattern_handle, const string& atom_handle);

--- a/src/atomdb/inmemorydb/InMemoryDB.h
+++ b/src/atomdb/inmemorydb/InMemoryDB.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "AtomDB.h"
@@ -23,13 +25,14 @@ namespace atomdb {
  *
  * Thread-safety model:
  * - Pure reads (get_*, query_*, *_exist(s), counts, get_all_atoms) take no InMemoryDB-wide
- *   lock. Each read snapshots the trie shared_ptrs (guarded by a leaf pointer mutex) and
- *   relies on HandleTrie's hand-over-hand per-node locking for the traversal itself.
+ *   lock. Each read atomically loads a Tries snapshot and relies on HandleTrie's
+ *   hand-over-hand per-node locking for the traversal itself.
  * - Mutations (add_*, delete_*, re_index_patterns, drop_all, add_pattern_index_schema) are
- *   serialized by write_mutex_ so the three tries stay mutually consistent.
- * - drop_all() and re_index_patterns(true) never delete tries in place: they build fresh
- *   tries and swap the shared_ptrs. Readers holding a pre-swap snapshot keep a live trie
- *   until they finish; it is freed when the last snapshot is dropped.
+ *   serialized by write_mutex_ so the three tries stay mutually consistent and writers
+ *   never insert into a trie that drop_all already retired.
+ * - drop_all() and re_index_patterns(true) never delete tries in place: they build a
+ *   fresh Tries bundle and atomically publish it. Readers holding a pre-swap snapshot
+ *   keep a live trie until they finish; it is freed when the last snapshot is dropped.
  *
  * Relaxed guarantee: a concurrent reader may briefly observe an atom before its pattern /
  * incoming-set index entries exist (writes stay atomic w.r.t. each other).
@@ -99,43 +102,42 @@ class InMemoryDB : public AtomDB {
     vector<string> match_pattern_index_schema(const Link* link);
 
    private:
-    // Trie snapshot accessors. Safe to use outside any lock: swaps happen only under
-    // trie_ptr_mutex_ (and write_mutex_), and old snapshots stay alive via shared_ptr.
-    shared_ptr<HandleTrie> atoms_trie() const;
-    shared_ptr<HandleTrie> pattern_index_trie() const;
-    shared_ptr<HandleTrie> incoming_sets_trie() const;
+    // One atomic publish of all three tries. Readers snapshot via load_tries();
+    // drop_all / re_index_patterns(true) publish a new bundle via store_tries().
+    // Mixing non-atomic reads/writes of tries_ with these is a data race.
+    struct Tries {
+        shared_ptr<HandleTrie> atoms;     // handle -> Atom*
+        shared_ptr<HandleTrie> patterns;  // pattern_handle -> set of atom handles
+        shared_ptr<HandleTrie> incoming;  // target_handle -> set of link handles
+    };
 
-    // Unlocked helpers — caller must hold write_mutex_.
-    string add_node_unlocked(const atoms::Node* node, const atoms::Merger* merger);
-    vector<string> add_nodes_unlocked(const vector<atoms::Node*>& nodes,
+    shared_ptr<Tries> load_tries() const { return atomic_load_explicit(&tries_, memory_order_acquire); }
+    void store_tries(shared_ptr<Tries> next) {
+        atomic_store_explicit(&tries_, std::move(next), memory_order_release);
+    }
+    static shared_ptr<Tries> make_tries();
+
+    // Unlocked helpers — caller must hold write_mutex_ and pass its own load_tries()
+    // snapshot, so each public mutation performs exactly one atomic load. They exist
+    // because write_mutex_ is non-recursive and deletes cascade (link -> orphaned
+    // targets -> links referencing them).
+    string add_node_unlocked(const Tries& tries, const atoms::Node* node, const atoms::Merger* merger);
+    vector<string> add_links_unlocked(const Tries& tries,
+                                      const vector<atoms::Link*>& links,
                                       bool is_transactional,
                                       const atoms::Merger* merger);
-    vector<string> add_links_unlocked(const vector<atoms::Link*>& links,
-                                      bool is_transactional,
-                                      const atoms::Merger* merger);
 
-    bool delete_atom_unlocked(const string& handle, bool delete_link_targets);
-    bool delete_node_unlocked(const string& handle, bool delete_link_targets);
-    bool delete_link_unlocked(const string& handle, bool delete_link_targets);
+    bool delete_atom_unlocked(const Tries& tries, const string& handle, bool delete_link_targets);
+    bool delete_node_unlocked(const Tries& tries, const string& handle, bool delete_link_targets);
+    bool delete_link_unlocked(const Tries& tries, const string& handle, bool delete_link_targets);
 
-    static void add_pattern_to(HandleTrie& trie,
-                               const string& pattern_handle,
-                               const string& atom_handle);
-    void delete_pattern_unlocked(const string& pattern_handle, const string& atom_handle);
-    void add_incoming_set_unlocked(const string& target_handle, const string& link_handle);
-    void delete_incoming_set_unlocked(const string& target_handle, const string& link_handle);
     vector<string> match_pattern_index_schema_unlocked(const Link* link);
-    vector<vector<string>> index_entries_combinations(unsigned int arity);
     void add_pattern_index_schema(const string& tokens, const vector<vector<string>>& index_entries);
 
     string context_;
     // Serializes mutations across the three tries. Reads never take it.
     mutable mutex write_mutex_;
-    // Leaf mutex guarding only the trie shared_ptr swaps below. Never held across trie ops.
-    mutable mutex trie_ptr_mutex_;
-    shared_ptr<HandleTrie> atoms_trie_;          // Stores handle -> Atom*
-    shared_ptr<HandleTrie> pattern_index_trie_;  // Stores pattern_handle -> set of atom handles
-    shared_ptr<HandleTrie> incoming_sets_trie_;  // Stores target_handle -> set of link handles
+    shared_ptr<Tries> tries_;
 
     map<int, tuple<vector<string>, vector<vector<string>>>> pattern_index_schema_map;
     int pattern_index_schema_next_priority{1};

--- a/src/commons/HandleTrie.cc
+++ b/src/commons/HandleTrie.cc
@@ -195,6 +195,26 @@ bool HandleTrie::remove(const string& key, bool delete_value) {
     return true;
 }
 
+bool HandleTrie::update(const string& key,
+                        bool (*visit_function)(TrieValue* value, void* data),
+                        void* data) {
+    TrieNode* node = fetch<TrieNode>(key, false, false);
+    if (node == NULL) {
+        return false;
+    }
+    if (node->value == NULL) {
+        node->trie_node_mutex.unlock();
+        return false;
+    }
+    if (visit_function(node->value, data)) {
+        delete node->value;
+        node->value = NULL;
+        this->_size--;
+    }
+    node->trie_node_mutex.unlock();
+    return true;
+}
+
 void HandleTrie::traverse(bool keep_root_locked,
                           bool (*visit_function)(TrieNode* node, void* data),
                           void* data) {

--- a/src/commons/HandleTrie.h
+++ b/src/commons/HandleTrie.h
@@ -110,6 +110,23 @@ class HandleTrie {
     bool remove(const string& key, bool delete_value = true);
 
     /**
+     * Run visit_function on the value stored at key while holding the node lock.
+     *
+     * This is the safe way to mutate a stored value while concurrent readers snapshot
+     * it via lookup_stored_object() (which also runs under the node lock). If
+     * visit_function returns true, the value is deleted and the key is cleared, as in
+     * remove().
+     *
+     * @param key Handle whose value is visited.
+     * @param visit_function Function called with the stored value; return true to have
+     *        the value deleted and the key cleared.
+     * @param data Additional information passed to visit_function or NULL if none.
+     *
+     * @return true if the key existed with a value, false otherwise.
+     */
+    bool update(const string& key, bool (*visit_function)(TrieValue* value, void* data), void* data);
+
+    /**
      * Traverse all keys (in-order) calling the passed visit_function once per stored value.
      *
      * @param keep_root_locked Keep root HandleTrie::TrieNode locked during the whole traversing

--- a/src/tests/cpp/inmemorydb_test.cc
+++ b/src/tests/cpp/inmemorydb_test.cc
@@ -1199,9 +1199,18 @@ TEST_F(InMemoryDBTest, ConcurrentReadsSurviveDropAll) {
     const vector<string> link_handles = add_links();
 
     atomic<bool> stop{false};
+    atomic<bool> go{false};
+    atomic<bool> writer_done{false};
+    atomic<int> readers_ready{0};
+    atomic<int> writer_publishes{0};
     atomic<int> reader_failures{0};
+    atomic<int> overlapping_batches{0};
 
     auto reader = [&]() {
+        readers_ready.fetch_add(1);
+        while (!go.load(memory_order_acquire)) {
+            this_thread::yield();
+        }
         while (!stop.load(memory_order_acquire)) {
             for (int i = 0; i < kNodes; ++i) {
                 auto atom = db->get_atom(link_handles[i]);
@@ -1216,6 +1225,12 @@ TEST_F(InMemoryDBTest, ConcurrentReadsSurviveDropAll) {
                     reader_failures.fetch_add(1);
                 }
             }
+            // Batch completed after at least one publish while the writer was still
+            // publishing: it provably overlapped the publication phase.
+            if (writer_publishes.load(memory_order_acquire) > 0 &&
+                !writer_done.load(memory_order_acquire)) {
+                overlapping_batches.fetch_add(1);
+            }
         }
     };
 
@@ -1224,23 +1239,42 @@ TEST_F(InMemoryDBTest, ConcurrentReadsSurviveDropAll) {
         readers.emplace_back(reader);
     }
 
+    // Start gate: make sure every reader is spinning before the writer starts, so
+    // reads genuinely overlap the drop_all() publications below.
+    while (readers_ready.load(memory_order_acquire) < kReaderThreads) {
+        this_thread::yield();
+    }
+    go.store(true, memory_order_release);
+
     // Writer: alternate wiping everything (publishes a fresh Tries bundle) with
-    // repopulating the same graph.
-    for (int iter = 0; iter < kWriterIterations; ++iter) {
+    // repopulating the same graph. Keep publishing (bounded) until at least one
+    // reader batch is seen overlapping, so the overlap assertion cannot be flaky.
+    auto publish_once = [&]() {
         db->drop_all();
         for (int i = 0; i < kNodes; ++i) {
             Node node("Symbol", "\"drop_all_node_" + to_string(i) + "\"");
             db->add_node(&node);
         }
         add_links();
+        writer_publishes.fetch_add(1, memory_order_release);
+    };
+    for (int iter = 0; iter < kWriterIterations; ++iter) {
+        publish_once();
+    }
+    for (int extra = 0;
+         overlapping_batches.load(memory_order_acquire) == 0 && extra < 10 * kWriterIterations;
+         ++extra) {
+        publish_once();
     }
 
+    writer_done.store(true, memory_order_release);
     stop.store(true, memory_order_release);
     for (auto& t : readers) {
         t.join();
     }
 
     EXPECT_EQ(reader_failures.load(), 0);
+    EXPECT_GT(overlapping_batches.load(), 0);  // reads really raced the publications
     EXPECT_EQ(db->atom_count(), static_cast<size_t>(2 * kNodes));
     for (int i = 0; i < kNodes; ++i) {
         EXPECT_TRUE(db->link_exists(link_handles[i]));
@@ -1267,7 +1301,12 @@ TEST_F(InMemoryDBTest, ConcurrentPatternQueriesSurviveReIndex) {
     }
 
     atomic<bool> stop{false};
+    atomic<bool> go{false};
+    atomic<bool> writer_done{false};
+    atomic<int> readers_ready{0};
+    atomic<int> writer_publishes{0};
     atomic<int> reader_failures{0};
+    atomic<int> overlapping_queries{0};
 
     auto reader = [&]() {
         // Pattern (node_0, *): exactly one link in the ring has node_0 as first target.
@@ -1279,9 +1318,19 @@ TEST_F(InMemoryDBTest, ConcurrentPatternQueriesSurviveReIndex) {
                                 "\"reindex_node_0\"",
                                 "VARIABLE",
                                 "x"});
+        readers_ready.fetch_add(1);
+        while (!go.load(memory_order_acquire)) {
+            this_thread::yield();
+        }
         while (!stop.load(memory_order_acquire)) {
             if (db->query_for_pattern(link_schema)->size() != 1) {
                 reader_failures.fetch_add(1);
+            }
+            // Query completed after at least one publish while the writer was still
+            // publishing: it provably overlapped the rebuild/swap phase.
+            if (writer_publishes.load(memory_order_acquire) > 0 &&
+                !writer_done.load(memory_order_acquire)) {
+                overlapping_queries.fetch_add(1);
             }
         }
     };
@@ -1291,16 +1340,34 @@ TEST_F(InMemoryDBTest, ConcurrentPatternQueriesSurviveReIndex) {
         readers.emplace_back(reader);
     }
 
+    // Start gate: make sure every reader is spinning before the writer starts, so
+    // queries genuinely overlap the pattern-trie swaps below.
+    while (readers_ready.load(memory_order_acquire) < kReaderThreads) {
+        this_thread::yield();
+    }
+    go.store(true, memory_order_release);
+
+    // Keep publishing (bounded) until at least one query is seen overlapping, so the
+    // overlap assertion cannot be flaky.
     for (int iter = 0; iter < kWriterIterations; ++iter) {
         db->re_index_patterns(true);
+        writer_publishes.fetch_add(1, memory_order_release);
+    }
+    for (int extra = 0;
+         overlapping_queries.load(memory_order_acquire) == 0 && extra < 10 * kWriterIterations;
+         ++extra) {
+        db->re_index_patterns(true);
+        writer_publishes.fetch_add(1, memory_order_release);
     }
 
+    writer_done.store(true, memory_order_release);
     stop.store(true, memory_order_release);
     for (auto& t : readers) {
         t.join();
     }
 
     EXPECT_EQ(reader_failures.load(), 0);
+    EXPECT_GT(overlapping_queries.load(), 0);  // queries really raced the swaps
     EXPECT_EQ(db->atom_count(), static_cast<size_t>(2 * kNodes));
 }
 

--- a/src/tests/cpp/inmemorydb_test.cc
+++ b/src/tests/cpp/inmemorydb_test.cc
@@ -1172,6 +1172,138 @@ TEST_F(InMemoryDBTest, ConcurrentReadsSurviveDeletesAndUpserts) {
     }
 }
 
+// Covers the store_tries() publish path of drop_all(): readers holding a pre-swap
+// snapshot must keep a live trie (no use-after-free) while the writer swaps in fresh
+// bundles and repopulates. Only swap-surviving invariants are asserted — a reader may
+// legitimately see an empty or partially repopulated DB at any point.
+TEST_F(InMemoryDBTest, ConcurrentReadsSurviveDropAll) {
+    constexpr int kNodes = 8;
+    constexpr int kWriterIterations = 100;
+    constexpr int kReaderThreads = 4;
+
+    // Handles are content-addressed, so both vectors are computed once and never
+    // mutated again — readers index into them concurrently.
+    vector<string> node_handles;
+    for (int i = 0; i < kNodes; ++i) {
+        Node node("Symbol", "\"drop_all_node_" + to_string(i) + "\"");
+        node_handles.push_back(db->add_node(&node));
+    }
+    auto add_links = [&]() {
+        vector<string> link_handles;
+        for (int i = 0; i < kNodes; ++i) {
+            Link link("Expression", {node_handles[i], node_handles[(i + 1) % kNodes]});
+            link_handles.push_back(db->add_link(&link));
+        }
+        return link_handles;
+    };
+    const vector<string> link_handles = add_links();
+
+    atomic<bool> stop{false};
+    atomic<int> reader_failures{0};
+
+    auto reader = [&]() {
+        while (!stop.load(memory_order_acquire)) {
+            for (int i = 0; i < kNodes; ++i) {
+                auto atom = db->get_atom(link_handles[i]);
+                if (atom != nullptr && atom->handle() != link_handles[i]) {
+                    reader_failures.fetch_add(1);
+                }
+                db->query_for_targets(link_handles[i]);
+                db->query_for_incoming_set(node_handles[i]);
+            }
+            for (const auto& atom : db->get_all_atoms()) {
+                if (atom == nullptr) {
+                    reader_failures.fetch_add(1);
+                }
+            }
+        }
+    };
+
+    vector<thread> readers;
+    for (int t = 0; t < kReaderThreads; ++t) {
+        readers.emplace_back(reader);
+    }
+
+    // Writer: alternate wiping everything (publishes a fresh Tries bundle) with
+    // repopulating the same graph.
+    for (int iter = 0; iter < kWriterIterations; ++iter) {
+        db->drop_all();
+        for (int i = 0; i < kNodes; ++i) {
+            Node node("Symbol", "\"drop_all_node_" + to_string(i) + "\"");
+            db->add_node(&node);
+        }
+        add_links();
+    }
+
+    stop.store(true, memory_order_release);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    EXPECT_EQ(reader_failures.load(), 0);
+    EXPECT_EQ(db->atom_count(), static_cast<size_t>(2 * kNodes));
+    for (int i = 0; i < kNodes; ++i) {
+        EXPECT_TRUE(db->link_exists(link_handles[i]));
+    }
+}
+
+// Covers the store_tries() publish path of re_index_patterns(true): the pattern index
+// is rebuilt into a fresh trie and swapped in while readers query it. Since the atom
+// set never changes, readers must always observe a complete index — either the old or
+// the fully rebuilt one, never a torn/partial one.
+TEST_F(InMemoryDBTest, ConcurrentPatternQueriesSurviveReIndex) {
+    constexpr int kNodes = 8;
+    constexpr int kWriterIterations = 200;
+    constexpr int kReaderThreads = 4;
+
+    vector<string> node_handles;
+    for (int i = 0; i < kNodes; ++i) {
+        Node node("Symbol", "\"reindex_node_" + to_string(i) + "\"");
+        node_handles.push_back(db->add_node(&node));
+    }
+    for (int i = 0; i < kNodes; ++i) {
+        Link link("Expression", {node_handles[i], node_handles[(i + 1) % kNodes]});
+        db->add_link(&link);
+    }
+
+    atomic<bool> stop{false};
+    atomic<int> reader_failures{0};
+
+    auto reader = [&]() {
+        // Pattern (node_0, *): exactly one link in the ring has node_0 as first target.
+        LinkSchema link_schema({"LINK_TEMPLATE",
+                                "Expression",
+                                "2",
+                                "NODE",
+                                "Symbol",
+                                "\"reindex_node_0\"",
+                                "VARIABLE",
+                                "x"});
+        while (!stop.load(memory_order_acquire)) {
+            if (db->query_for_pattern(link_schema)->size() != 1) {
+                reader_failures.fetch_add(1);
+            }
+        }
+    };
+
+    vector<thread> readers;
+    for (int t = 0; t < kReaderThreads; ++t) {
+        readers.emplace_back(reader);
+    }
+
+    for (int iter = 0; iter < kWriterIterations; ++iter) {
+        db->re_index_patterns(true);
+    }
+
+    stop.store(true, memory_order_release);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    EXPECT_EQ(reader_failures.load(), 0);
+    EXPECT_EQ(db->atom_count(), static_cast<size_t>(2 * kNodes));
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/src/tests/cpp/inmemorydb_test.cc
+++ b/src/tests/cpp/inmemorydb_test.cc
@@ -3,10 +3,12 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "Assignment.h"
@@ -1098,6 +1100,76 @@ TEST_F(InMemoryDBTest, AddLinksSkipIfExistsMergerReturnsEmptyHandleSlots) {
     delete existing;
     delete fresh;
     delete collision;
+}
+
+// Regression test: reads must stay safe (no use-after-free / torn reads) while writers
+// upsert and delete the very atoms and index entries being read. Readers snapshot atoms
+// (shared_ptr ref) and handle sets (copies) under the trie node lock; before that fix
+// this test crashed or triggered TSAN/ASAN reports.
+TEST_F(InMemoryDBTest, ConcurrentReadsSurviveDeletesAndUpserts) {
+    constexpr int kNodes = 8;
+    constexpr int kWriterIterations = 200;
+    constexpr int kReaderThreads = 4;
+
+    vector<string> node_handles;
+    for (int i = 0; i < kNodes; ++i) {
+        Node node("Symbol", "\"concurrent_node_" + to_string(i) + "\"");
+        node_handles.push_back(db->add_node(&node));
+    }
+
+    auto add_links = [&]() {
+        vector<string> link_handles;
+        for (int i = 0; i < kNodes; ++i) {
+            Link link("Expression", {node_handles[i], node_handles[(i + 1) % kNodes]});
+            link_handles.push_back(db->add_link(&link));
+        }
+        return link_handles;
+    };
+    vector<string> link_handles = add_links();  // stable: content-addressed handles
+
+    atomic<bool> stop{false};
+    atomic<int> reader_failures{0};
+
+    auto reader = [&]() {
+        while (!stop.load(memory_order_acquire)) {
+            for (int i = 0; i < kNodes; ++i) {
+                auto atom = db->get_atom(link_handles[i]);
+                if (atom != nullptr && atom->handle() != link_handles[i]) {
+                    reader_failures.fetch_add(1);
+                }
+                db->link_exists(link_handles[i]);
+                db->query_for_targets(link_handles[i]);
+                db->query_for_incoming_set(node_handles[i]);
+            }
+            db->get_all_atoms();
+        }
+    };
+
+    vector<thread> readers;
+    for (int t = 0; t < kReaderThreads; ++t) {
+        readers.emplace_back(reader);
+    }
+
+    // Writer: repeatedly upsert (in-place replace) and delete the links being read.
+    for (int iter = 0; iter < kWriterIterations; ++iter) {
+        add_links();  // upsert: AtomTrieValue::merge replaces the stored Link
+        for (int i = 0; i < kNodes; ++i) {
+            db->delete_link(link_handles[i], false);
+        }
+        add_links();
+    }
+
+    stop.store(true, memory_order_release);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    EXPECT_EQ(reader_failures.load(), 0);
+    EXPECT_EQ(db->atom_count(), static_cast<size_t>(2 * kNodes));
+    for (int i = 0; i < kNodes; ++i) {
+        EXPECT_TRUE(db->link_exists(link_handles[i]));
+        EXPECT_EQ(db->query_for_incoming_set(node_handles[i])->size(), 2u);
+    }
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

This PR refactors `InMemoryDB` to reduce locking on the read path and make concurrent access safe against use-after-free and torn reads in `HandleTrie`-backed storage.

- **Atomic `Tries` bundle** — the three tries (`atoms`, `patterns`, `incoming`) are published as a single `shared_ptr<Tries>` via `atomic_load` / `atomic_store`, replacing per-trie accessors guarded by `trie_ptr_mutex_`.
- **Lock-free reads** — pure read operations take no `InMemoryDB`-wide lock; they snapshot the bundle once and rely on `HandleTrie`'s hand-over-hand per-node locking.
- **Safe value lifetimes** — readers no longer hold raw pointers into trie-owned storage. Atoms are handed out as `shared_ptr` refs and handle sets as copies, both extracted under the trie node lock via `get_stored_object`.
- **`HandleTrie::update()`** — new primitive to mutate a stored value under the node lock (used for index set removals). Set additions already go through `insert()` → `merge()` under the same lock.
- **Simpler write path** — `_unlocked` helpers take a `const Tries&` snapshot so each public mutation performs exactly one atomic load; several trivial helpers were inlined or moved to file-local free functions.
- **Regression test** — `ConcurrentReadsSurviveDeletesAndUpserts` hammers reads while a writer upserts and deletes the same links.

## Motivation

`InMemoryDB` previously guarded three separate trie `shared_ptr`s with `trie_ptr_mutex_`. That added lock overhead on every read and made it easy to observe inconsistent combinations of tries (e.g. an atom present in `atoms` but not yet indexed in `patterns` / `incoming` across separate loads).

More critically, read paths used `HandleTrie::lookup()`, which returns raw `TrieValue*` / `Atom*` pointers. Concurrent `remove()` or upsert (`insert` → `merge()`) could free or replace those objects while a reader still held them, causing use-after-free on atoms and data races when iterating handle sets mutated by writers.
## Changes

### `InMemoryDB`

| Area | Before | After |
|------|--------|-------|
| Trie access | Three `shared_ptr`s + `trie_ptr_mutex_` | Single `shared_ptr<Tries>` published atomically |
| Reads | Snapshot each trie separately | One `load_tries()` per operation |
| Writes | `_unlocked` helpers re-loaded tries | One `load_tries()` under `write_mutex_`, passed by reference |
| `drop_all` / `re_index_patterns(true)` | Swap individual trie pointers | Publish a fresh `Tries` bundle via `store_tries()` |
| Atom storage | `AtomTrieValue` owned raw `Atom*` | `AtomTrieValue` holds `shared_ptr<Atom>`; `get_stored_object` bumps refcount under node lock |
| Index sets | Raw `lookup()` + iterate / mutate `std::set` | `lookup_stored_object` returns a set copy; adds via `insert()`; removals via `HandleTrie::update()` |

Helper consolidation:

- `lookup_atom()` — single place for safe atom lookup via `lookup_stored_object`
- `lookup_handle_set()` — safe set snapshot for pattern / incoming queries
- `add_to_handle_set()` / `remove_from_handle_set()` — file-local, lock-aware index helpers
- Removed: `add_nodes_unlocked`, `add_pattern_to`, `delete_pattern_unlocked`, `add_incoming_set_unlocked`, `delete_incoming_set_unlocked`, `index_entries_combinations` as class members (inlined or moved to anonymous namespace)

### `HandleTrie`

- Added `update(key, visit_function, data)` — runs a visitor on the stored value while holding the node lock; if the visitor returns `true`, the value is deleted and the key cleared (same semantics as `remove()`).
- Additive change; existing `HandleTrie` users (attention broker, stimulus spreader) are unaffected.

## Test plan

- [ ] `make bazel 'test --cache_test_results=no //tests/cpp:inmemorydb_test--test_output=errors'`
- [ ] `make bazel 'test --cache_test_results=no //tests/cpp:handle_trie_test--test_output=errors'`
- [ ] `make bazel 'test --cache_test_results=no //tests/cpp:remote_atomdb_test--test_output=errors'`