### PR TITLE
Refactor access permission types to abstract API

### DIFF
--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -114,7 +114,7 @@ class AtomDB : public HandleDecoder {
 
     bool empty() const { return atom_count() == 0; }
 
-    virtual vector<atomdb_api_types::AccessPermissionDocument> get_access_permissions(
+    virtual vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
         const atomdb_api_types::PublicKey& public_key) const {
         return {};
     }

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -73,15 +73,13 @@ class AtomDocument {
 
 class AccessPermissionEntry {
    public:
-    LinkSchema schema;
-    bool read;
-    bool write;
+    AccessPermissionEntry() = default;
+    virtual ~AccessPermissionEntry() = default;
 
-    AccessPermissionEntry(const LinkSchema& schema, bool read, bool write)
-        : schema(schema), read(read), write(write) {}
-
-    AccessPermissionEntry(const vector<string>& tokens, bool read, bool write)
-        : schema(tokens), read(read), write(write) {}
+    virtual bool get_read() const = 0;
+    virtual bool get_write() const = 0;
+    virtual unsigned int get_tokens_size() const = 0;
+    virtual const char* get_token(unsigned int index) const = 0;
 };
 
 class PublicKey {
@@ -103,21 +101,13 @@ class PublicKey {
 
 class AccessPermissionDocument {
    public:
-    string access_key;
-    bool full_access;
-    vector<AccessPermissionEntry> entries;
+    AccessPermissionDocument() = default;
+    virtual ~AccessPermissionDocument() = default;
 
-    AccessPermissionDocument(const string& access_key,
-                             bool full_access,
-                             const vector<AccessPermissionEntry>& entries)
-        : access_key(access_key), full_access(full_access), entries(entries) {
-        if (full_access && !entries.empty()) {
-            RAISE_ERROR("entries must be empty when full_access is true");
-        }
-        if (!full_access && entries.empty()) {
-            RAISE_ERROR("entries must be non-empty when full_access is false");
-        }
-    }
+    virtual const char* get_access_key() const = 0;
+    virtual bool get_full_access() const = 0;
+    virtual unsigned int get_entries_size() const = 0;
+    virtual const AccessPermissionEntry& get_entry(unsigned int index) const = 0;
 };
 
 }  // namespace atomdb_api_types

--- a/src/atomdb/adapterdb/AdapterDB.cc
+++ b/src/atomdb/adapterdb/AdapterDB.cc
@@ -64,7 +64,7 @@ bool AdapterDB::composite_type_enabled() const {
     this->ensure_backend_ready();
     return this->atomdb_backend->composite_type_enabled();
 }
-vector<atomdb_api_types::AccessPermissionDocument> AdapterDB::get_access_permissions(
+vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> AdapterDB::get_access_permissions(
     const atomdb_api_types::PublicKey& public_key) const {
     this->ensure_backend_ready();
     return this->atomdb_backend->get_access_permissions(public_key);

--- a/src/atomdb/adapterdb/AdapterDB.h
+++ b/src/atomdb/adapterdb/AdapterDB.h
@@ -114,7 +114,7 @@ class AdapterDB : public AtomDB {
      * Forwards the lookup to the backend once it is ready.
      * Returns an empty vector if the backend has no matching permissions.
      */
-    vector<atomdb_api_types::AccessPermissionDocument> get_access_permissions(
+    vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
         const atomdb_api_types::PublicKey& public_key) const override;
 
    private:

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -59,9 +59,9 @@ RedisMongoDB::~RedisMongoDB() {
 
 bool RedisMongoDB::allow_nested_indexing() { return false; }
 
-vector<atomdb_api_types::AccessPermissionDocument> RedisMongoDB::get_access_permissions(
+vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> RedisMongoDB::get_access_permissions(
     const atomdb_api_types::PublicKey& public_key) const {
-    vector<atomdb_api_types::AccessPermissionDocument> documents;
+    vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> documents;
 
     if (public_key.is_single_key()) {
         auto document = this->load_access_permission_document(public_key.keys[0]);
@@ -81,8 +81,8 @@ vector<atomdb_api_types::AccessPermissionDocument> RedisMongoDB::get_access_perm
     return documents;
 }
 
-optional<atomdb_api_types::AccessPermissionDocument> RedisMongoDB::load_access_permission_document(
-    const string& public_key) const {
+optional<shared_ptr<atomdb_api_types::AccessPermissionDocument>>
+RedisMongoDB::load_access_permission_document(const string& public_key) const {
     string handle = Hasher::plain_string_hash(public_key);
 
     auto access_permission_doc = this->get_document(handle, MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME);
@@ -92,54 +92,11 @@ optional<atomdb_api_types::AccessPermissionDocument> RedisMongoDB::load_access_p
     }
 
     auto mongodb_doc = dynamic_pointer_cast<atomdb_api_types::MongodbDocument>(access_permission_doc);
-    auto document = nlohmann::json::parse(bsoncxx::to_json(mongodb_doc->value().view()));
-    if (!document.is_object()) {
-        RAISE_ERROR("AccessPermissionDocument must be a JSON object");
+    auto document = make_shared<atomdb_api_types::MongodbAccessPermissionDocument>(mongodb_doc->value());
+    if (string(document->get_access_key()) != public_key) {
+        RAISE_ERROR("AccessPermissionDocument public_key does not match its lookup key");
     }
-    if (!document.contains("public_key") || !document["public_key"].is_string()) {
-        RAISE_ERROR("AccessPermissionDocument missing required string filed 'public_key'");
-    }
-    if (!document.contains("full_access") || !document["full_access"].is_boolean()) {
-        RAISE_ERROR("AccessPermissionDocument missing required boolean field 'full_access'");
-    }
-    if (!document.contains("allowed_schemas") || !document["allowed_schemas"].is_array()) {
-        RAISE_ERROR("AccessPermissionDocument missing required array field 'allowed_schemas'");
-    }
-
-    vector<atomdb_api_types::AccessPermissionEntry> entries;
-    for (const auto& item : document["allowed_schemas"]) {
-        if (!item.is_object()) {
-            RAISE_ERROR("AccessPermissionDocument allowed_schemas item must be an object");
-        }
-        if (!item.contains("tokens") || !item["tokens"].is_array()) {
-            RAISE_ERROR(
-                "AccessPermissionDocument allowed_schemas item missing required array field "
-                "'tokens'");
-        }
-        if (!item.contains("read") || !item["read"].is_boolean()) {
-            RAISE_ERROR(
-                "AccessPermissionDocument allowed_schemas item missing required boolean field "
-                "'read'");
-        }
-        if (!item.contains("write") || !item["write"].is_boolean()) {
-            RAISE_ERROR(
-                "AccessPermissionDocument allowed_schemas item missing required boolean field "
-                "'write'");
-        }
-
-        vector<string> tokens;
-        for (const auto& token : item["tokens"]) {
-            if (!token.is_string() || token.get<string>().empty()) {
-                RAISE_ERROR("AccessPermissionDocument allowed_schemas tokens must be non-empty strings");
-            }
-            tokens.push_back(token.get<string>());
-        }
-
-        entries.emplace_back(tokens, item["read"].get<bool>(), item["write"].get<bool>());
-    }
-
-    return atomdb_api_types::AccessPermissionDocument(
-        public_key, document["full_access"].get<bool>(), entries);
+    return document;
 }
 
 void RedisMongoDB::redis_setup(const JsonConfig& config) {

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -37,7 +37,7 @@ class RedisMongoDB : public AtomDB {
      * Looks up access-permission documents in MongoDB for the given public key(s).
      * Returns an empty vector if no matching documents exist.
      */
-    vector<atomdb_api_types::AccessPermissionDocument> get_access_permissions(
+    vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
         const atomdb_api_types::PublicKey& public_key) const override;
 
     static string REDIS_PATTERNS_PREFIX;
@@ -176,7 +176,7 @@ class RedisMongoDB : public AtomDB {
      * @brief Loads and parses one access_permissions Mongo document for the given public key.
      * @return nullopt when no document exists for that key.
      */
-    optional<atomdb_api_types::AccessPermissionDocument> load_access_permission_document(
+    optional<shared_ptr<atomdb_api_types::AccessPermissionDocument>> load_access_permission_document(
         const string& public_key) const;
 
     vector<shared_ptr<atomdb_api_types::AtomDocument>> get_documents(const vector<string>& handles,

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.cc
@@ -269,3 +269,96 @@ MongodbDocument::MongodbDocument(const atoms::Link* link,
     add_custom_attributes(doc, link->custom_attributes);
     this->document = doc.extract();
 }
+
+MongodbAccessPermissionEntry::MongodbAccessPermissionEntry(bsoncxx::document::view entry_view)
+    : entry_view_(entry_view) {}
+
+bool MongodbAccessPermissionEntry::get_read() const {
+    return this->entry_view_["read"].get_bool().value;
+}
+
+bool MongodbAccessPermissionEntry::get_write() const {
+    return this->entry_view_["write"].get_bool().value;
+}
+
+unsigned int MongodbAccessPermissionEntry::get_tokens_size() const {
+    auto tokens = this->entry_view_["tokens"].get_array().value;
+    return static_cast<unsigned int>(std::distance(tokens.begin(), tokens.end()));
+}
+
+const char* MongodbAccessPermissionEntry::get_token(unsigned int index) const {
+    auto tokens = this->entry_view_["tokens"].get_array().value;
+    if (index >= this->get_tokens_size()) {
+        RAISE_ERROR("Access permission entry token index out of bounds: " + to_string(index));
+    }
+    return tokens[index].get_string().value.data();
+}
+
+MongodbAccessPermissionDocument::MongodbAccessPermissionDocument(bsoncxx::document::value document)
+    : document_(std::move(document)) {
+    this->validate_document_view(this->document_view());
+    for (const auto& item : this->document_view()["allowed_schemas"].get_array().value) {
+        this->entries_.emplace_back(item.get_document().value);
+    }
+}
+
+void MongodbAccessPermissionDocument::validate_document_view(bsoncxx::document::view view) const {
+    if (!view["public_key"] || view["public_key"].type() != bsoncxx::type::k_string) {
+        RAISE_ERROR("AccessPermissionDocument missing required string field 'public_key'");
+    }
+    if (!view["full_access"] || view["full_access"].type() != bsoncxx::type::k_bool) {
+        RAISE_ERROR("AccessPermissionDocument missing required boolean field 'full_access'");
+    }
+    if (!view["allowed_schemas"] || view["allowed_schemas"].type() != bsoncxx::type::k_array) {
+        RAISE_ERROR("AccessPermissionDocument missing required array field 'allowed_schemas'");
+    }
+
+    for (const auto& item : view["allowed_schemas"].get_array().value) {
+        if (item.type() != bsoncxx::type::k_document) {
+            RAISE_ERROR("AccessPermissionDocument allowed_schemas item must be an object");
+        }
+        auto entry_view = item.get_document().value;
+        if (!entry_view["tokens"] || entry_view["tokens"].type() != bsoncxx::type::k_array) {
+            RAISE_ERROR(
+                "AccessPermissionDocument allowed_schemas item missing required array field 'tokens'");
+        }
+        if (!entry_view["read"] || entry_view["read"].type() != bsoncxx::type::k_bool) {
+            RAISE_ERROR(
+                "AccessPermissionDocument allowed_schemas item missing required boolean field 'read'");
+        }
+        if (!entry_view["write"] || entry_view["write"].type() != bsoncxx::type::k_bool) {
+            RAISE_ERROR(
+                "AccessPermissionDocument allowed_schemas item missing required boolean field 'write'");
+        }
+        for (const auto& token : entry_view["tokens"].get_array().value) {
+            if (token.type() != bsoncxx::type::k_string || token.get_string().value.size() == 0) {
+                RAISE_ERROR("AccessPermissionDocument allowed_schemas tokens must be non-empty strings");
+            }
+        }
+    }
+}
+
+bsoncxx::document::value MongodbAccessPermissionDocument::value() const { return this->document_; }
+
+bsoncxx::document::view MongodbAccessPermissionDocument::document_view() const {
+    return this->document_.view();
+}
+
+const char* MongodbAccessPermissionDocument::get_access_key() const {
+    return this->document_view()["public_key"].get_string().value.data();
+}
+
+bool MongodbAccessPermissionDocument::get_full_access() const {
+    return this->document_view()["full_access"].get_bool().value;
+}
+
+unsigned int MongodbAccessPermissionDocument::get_entries_size() const {
+    return static_cast<unsigned int>(this->entries_.size());
+}
+
+const AccessPermissionEntry& MongodbAccessPermissionDocument::get_entry(unsigned int index) const {
+    if (index >= this->entries_.size()) {
+        RAISE_ERROR("Access permission entry index out of bounds: " + to_string(index));
+    }
+    return this->entries_[index];
+}

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
@@ -117,6 +117,13 @@ class MongodbAccessPermissionDocument : public AccessPermissionDocument {
     explicit MongodbAccessPermissionDocument(bsoncxx::v_noabi::document::value document);
     ~MongodbAccessPermissionDocument() override = default;
 
+    // entries_ hold views into document_'s buffer, so copying or moving this object
+    // would leave those views pointing at another object's storage.
+    MongodbAccessPermissionDocument(const MongodbAccessPermissionDocument&) = delete;
+    MongodbAccessPermissionDocument& operator=(const MongodbAccessPermissionDocument&) = delete;
+    MongodbAccessPermissionDocument(MongodbAccessPermissionDocument&&) = delete;
+    MongodbAccessPermissionDocument& operator=(MongodbAccessPermissionDocument&&) = delete;
+
     bsoncxx::v_noabi::document::value value() const;
 
     const char* get_access_key() const override;

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
@@ -117,8 +117,10 @@ class MongodbAccessPermissionDocument : public AccessPermissionDocument {
     explicit MongodbAccessPermissionDocument(bsoncxx::v_noabi::document::value document);
     ~MongodbAccessPermissionDocument() override = default;
 
-    // entries_ hold views into document_'s buffer, so copying or moving this object
-    // would leave those views pointing at another object's storage.
+    /**
+     * Keep this document non-copyable and non-movable because entries_ holds
+     * views into document_'s buffer.
+     */
     MongodbAccessPermissionDocument(const MongodbAccessPermissionDocument&) = delete;
     MongodbAccessPermissionDocument& operator=(const MongodbAccessPermissionDocument&) = delete;
     MongodbAccessPermissionDocument(MongodbAccessPermissionDocument&&) = delete;

--- a/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDBAPITypes.h
@@ -98,5 +98,39 @@ class MongodbDocument : public AtomDocument {
     bsoncxx::v_noabi::stdx::optional<bsoncxx::v_noabi::document::value> document;
 };
 
+class MongodbAccessPermissionEntry : public AccessPermissionEntry {
+   public:
+    explicit MongodbAccessPermissionEntry(bsoncxx::v_noabi::document::view entry_view);
+    ~MongodbAccessPermissionEntry() override = default;
+
+    bool get_read() const override;
+    bool get_write() const override;
+    unsigned int get_tokens_size() const override;
+    const char* get_token(unsigned int index) const override;
+
+   private:
+    bsoncxx::v_noabi::document::view entry_view_;
+};
+
+class MongodbAccessPermissionDocument : public AccessPermissionDocument {
+   public:
+    explicit MongodbAccessPermissionDocument(bsoncxx::v_noabi::document::value document);
+    ~MongodbAccessPermissionDocument() override = default;
+
+    bsoncxx::v_noabi::document::value value() const;
+
+    const char* get_access_key() const override;
+    bool get_full_access() const override;
+    unsigned int get_entries_size() const override;
+    const AccessPermissionEntry& get_entry(unsigned int index) const override;
+
+   private:
+    bsoncxx::v_noabi::document::value document_;
+    vector<MongodbAccessPermissionEntry> entries_;
+
+    void validate_document_view(bsoncxx::v_noabi::document::view view) const;
+    bsoncxx::v_noabi::document::view document_view() const;
+};
+
 }  // namespace atomdb_api_types
 }  // namespace atomdb

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -39,7 +39,7 @@ bool RemoteAtomDBPeer::allow_nested_indexing() { return atomdb_->allow_nested_in
 bool RemoteAtomDBPeer::composite_type_enabled() const {
     return local_persistence_ && local_persistence_->composite_type_enabled();
 }
-vector<atomdb_api_types::AccessPermissionDocument> RemoteAtomDBPeer::get_access_permissions(
+vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> RemoteAtomDBPeer::get_access_permissions(
     const atomdb_api_types::PublicKey& public_key) const {
     if (!atomdb_) return AtomDB::get_access_permissions(public_key);
     return atomdb_->get_access_permissions(public_key);

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -118,7 +118,7 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
      * Delegates the lookup to the remote AtomDB; local persistence is not consulted.
      * Returns an empty vector if there is no remote AtomDB or it has no matching permissions.
      */
-    vector<atomdb_api_types::AccessPermissionDocument> get_access_permissions(
+    vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
         const atomdb_api_types::PublicKey& public_key) const override;
 
    private:

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -1434,21 +1434,27 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsReturnsStoredDocuments) {
 
     auto admin_permissions = db->get_access_permissions(PublicKey("key_admin"));
     ASSERT_EQ(admin_permissions.size(), 1u);
-    EXPECT_EQ(admin_permissions[0].access_key, "key_admin");
-    EXPECT_TRUE(admin_permissions[0].full_access);
-    EXPECT_TRUE(admin_permissions[0].entries.empty());
+    EXPECT_EQ(admin_permissions[0]->get_access_key(), "key_admin");
+    EXPECT_TRUE(admin_permissions[0]->get_full_access());
+    EXPECT_EQ(admin_permissions[0]->get_entries_size(), 0u);
 
     auto reader_permissions = db->get_access_permissions(PublicKey("key_reader"));
     ASSERT_EQ(reader_permissions.size(), 1u);
-    EXPECT_EQ(reader_permissions[0].access_key, "key_reader");
-    EXPECT_FALSE(reader_permissions[0].full_access);
-    ASSERT_EQ(reader_permissions[0].entries.size(), 1u);
-    EXPECT_TRUE(reader_permissions[0].entries[0].read);
-    EXPECT_FALSE(reader_permissions[0].entries[0].write);
+    EXPECT_EQ(reader_permissions[0]->get_access_key(), "key_reader");
+    EXPECT_FALSE(reader_permissions[0]->get_full_access());
+    ASSERT_EQ(reader_permissions[0]->get_entries_size(), 1u);
+    const auto& reader_entry = reader_permissions[0]->get_entry(0);
+    EXPECT_TRUE(reader_entry.get_read());
+    EXPECT_FALSE(reader_entry.get_write());
     vector<string> expected_tokens = {
         "LINK_TEMPLATE", "Expression", "2", "NODE", "Symbol", "Similarity", "VARIABLE", "VARIABLE"};
     LinkSchema expected_schema(expected_tokens);
-    EXPECT_EQ(reader_permissions[0].entries[0].schema.handle(), expected_schema.handle());
+    vector<string> actual_tokens;
+    actual_tokens.reserve(reader_entry.get_tokens_size());
+    for (unsigned int i = 0; i < reader_entry.get_tokens_size(); ++i) {
+        actual_tokens.push_back(reader_entry.get_token(i));
+    }
+    EXPECT_EQ(LinkSchema(actual_tokens).handle(), expected_schema.handle());
 
     auto map_permissions = db->get_access_permissions(
         PublicKey(map<string, string>{{"peer_a", "key_admin"}, {"peer_b", "key_reader"}}));

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -1484,6 +1484,24 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsRejectsInvalidDocument) {
     collection.delete_many({});
 }
 
+TEST(MongodbAccessPermissionEntryTest, GetTokensSizeReturnsArrayLength) {
+    using bsoncxx::builder::basic::kvp;
+    using bsoncxx::builder::basic::make_document;
+
+    for (unsigned int size = 0; size <= 5; ++size) {
+        bsoncxx::builder::basic::array tokens_array;
+        for (unsigned int i = 0; i < size; ++i) {
+            tokens_array.append("token_" + to_string(i));
+        }
+        auto document =
+            make_document(kvp("tokens", tokens_array), kvp("read", true), kvp("write", false));
+
+        MongodbAccessPermissionEntry entry(document.view());
+
+        EXPECT_EQ(entry.get_tokens_size(), size);
+    }
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(new RedisMongoDBTestEnvironment());

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -1434,13 +1434,13 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsReturnsStoredDocuments) {
 
     auto admin_permissions = db->get_access_permissions(PublicKey("key_admin"));
     ASSERT_EQ(admin_permissions.size(), 1u);
-    EXPECT_EQ(admin_permissions[0]->get_access_key(), "key_admin");
+    EXPECT_STREQ(admin_permissions[0]->get_access_key(), "key_admin");
     EXPECT_TRUE(admin_permissions[0]->get_full_access());
     EXPECT_EQ(admin_permissions[0]->get_entries_size(), 0u);
 
     auto reader_permissions = db->get_access_permissions(PublicKey("key_reader"));
     ASSERT_EQ(reader_permissions.size(), 1u);
-    EXPECT_EQ(reader_permissions[0]->get_access_key(), "key_reader");
+    EXPECT_STREQ(reader_permissions[0]->get_access_key(), "key_reader");
     EXPECT_FALSE(reader_permissions[0]->get_full_access());
     ASSERT_EQ(reader_permissions[0]->get_entries_size(), 1u);
     const auto& reader_entry = reader_permissions[0]->get_entry(0);

--- a/src/tests/cpp/test_commons/mocks/MockAtomDB.h
+++ b/src/tests/cpp/test_commons/mocks/MockAtomDB.h
@@ -25,7 +25,7 @@ class AtomDBMock : public AtomDB {
    public:
     MOCK_METHOD(bool, allow_nested_indexing, (), (override));
     MOCK_METHOD(bool, composite_type_enabled, (), (const, override));
-    MOCK_METHOD(vector<atomdb_api_types::AccessPermissionDocument>,
+    MOCK_METHOD(vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>>,
                 get_access_permissions,
                 (const atomdb_api_types::PublicKey& public_key),
                 (const, override));


### PR DESCRIPTION
Required by #922 
## Summary

- Turn `AccessPermissionEntry` and `AccessPermissionDocument` into abstract interfaces with virtual getters instead of public fields
- Add read-only MongoDB implementations: `MongodbAccessPermissionEntry` and `MongodbAccessPermissionDocument`
- Update `RedisMongoDB` to load permissions directly from BSON (removes JSON parsing path)
- Change `get_access_permissions()` to return `vector<shared_ptr<AccessPermissionDocument>>`
