### PR TITLE
[#1208] Synchronize BusNode public API to make it thread-safe

### DIFF
--- a/src/distributed_algorithm_node/BusNode.cc
+++ b/src/distributed_algorithm_node/BusNode.cc
@@ -85,7 +85,7 @@ void BusNode::set_ownership(const string& command, const string& node_id) {
     this->bus.set_ownership(command, node_id);
 }
 
-const string& BusNode::get_ownership(const string& command) { 
+const string& BusNode::get_ownership(const string& command) {
     lock_guard<recursive_mutex> semaphore(this->api_mutex);
     return this->bus.get_ownership(command);
 }
@@ -145,13 +145,9 @@ void BusNode::broadcast_my_commands(const string& target_id) {
 
 BusNode::Bus::Bus() {}
 
-BusNode::Bus::Bus(const Bus& other) {
-    this->command_owner = other.command_owner;
-}
+BusNode::Bus::Bus(const Bus& other) { this->command_owner = other.command_owner; }
 
-bool BusNode::Bus::operator==(const Bus& other) {
-    return this->command_owner == other.command_owner;
-}
+bool BusNode::Bus::operator==(const Bus& other) { return this->command_owner == other.command_owner; }
 
 BusNode::Bus& BusNode::Bus::operator=(const Bus& other) {
     Bus aux(other);

--- a/src/distributed_algorithm_node/BusNode.cc
+++ b/src/distributed_algorithm_node/BusNode.cc
@@ -85,7 +85,7 @@ void BusNode::set_ownership(const string& command, const string& node_id) {
     this->bus.set_ownership(command, node_id);
 }
 
-const string& BusNode::get_ownership(const string& command) {
+const string BusNode::get_ownership(const string& command) {
     lock_guard<recursive_mutex> semaphore(this->api_mutex);
     return this->bus.get_ownership(command);
 }

--- a/src/distributed_algorithm_node/BusNode.cc
+++ b/src/distributed_algorithm_node/BusNode.cc
@@ -40,6 +40,7 @@ BusNode::BusNode(const string& node_id,
 // DistributedAlgorithmNode virtual API
 
 void BusNode::node_joined_network(const string& node_id) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     if (this->is_master) {
         LOG_INFO("New element " << node_id << " joined the service BUS");
     }
@@ -48,6 +49,7 @@ void BusNode::node_joined_network(const string& node_id) {
 }
 
 string BusNode::cast_leadership_vote() {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     if (this->is_master) {
         return this->node_id();
     } else {
@@ -56,6 +58,7 @@ string BusNode::cast_leadership_vote() {
 }
 
 shared_ptr<Message> BusNode::message_factory(string& command, vector<string>& args) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     shared_ptr<Message> message = DistributedAlgorithmNode::message_factory(command, args);
     if (message) {
         return message;
@@ -78,12 +81,17 @@ shared_ptr<Message> BusNode::message_factory(string& command, vector<string>& ar
 // BusNode public methods
 
 void BusNode::set_ownership(const string& command, const string& node_id) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     this->bus.set_ownership(command, node_id);
 }
 
-const string& BusNode::get_ownership(const string& command) { return this->bus.get_ownership(command); }
+const string& BusNode::get_ownership(const string& command) { 
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
+    return this->bus.get_ownership(command);
+}
 
 void BusNode::send_bus_command(const string& command, const vector<string>& args) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     string target_id = this->bus.get_ownership(command);
     if (target_id == "") {
         RAISE_ERROR("Bus: no owner is defined for command <" + command + ">");
@@ -95,6 +103,7 @@ void BusNode::send_bus_command(const string& command, const vector<string>& args
 }
 
 void BusNode::take_ownership(const set<string>& commands) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     for (auto command : commands) {
         LOG_INFO("BUS node " << this->node_id() << " is taking ownership of command " << command);
         this->bus.set_ownership(command, node_id());
@@ -104,6 +113,7 @@ void BusNode::take_ownership(const set<string>& commands) {
 }
 
 string BusNode::to_string() {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     string answer = DistributedAlgorithmNode::to_string();
     answer += " Bus: " + this->bus.to_string();
     return answer;
@@ -135,9 +145,13 @@ void BusNode::broadcast_my_commands(const string& target_id) {
 
 BusNode::Bus::Bus() {}
 
-BusNode::Bus::Bus(const Bus& other) { this->command_owner = other.command_owner; }
+BusNode::Bus::Bus(const Bus& other) {
+    this->command_owner = other.command_owner;
+}
 
-bool BusNode::Bus::operator==(const Bus& other) { return this->command_owner == other.command_owner; }
+bool BusNode::Bus::operator==(const Bus& other) {
+    return this->command_owner == other.command_owner;
+}
 
 BusNode::Bus& BusNode::Bus::operator=(const Bus& other) {
     Bus aux(other);

--- a/src/distributed_algorithm_node/BusNode.h
+++ b/src/distributed_algorithm_node/BusNode.h
@@ -151,7 +151,7 @@ class BusNode : public DistributedAlgorithmNode {
      * @param command Command being looked up
      * @return The node_id of the BusNode with command's ownership or "" is none is set
      */
-    const string& get_ownership(const string& command);
+    const string get_ownership(const string& command);
 
     /**
      * Set ownership of passed commands to this node and broadcast this information

--- a/src/distributed_algorithm_node/BusNode.h
+++ b/src/distributed_algorithm_node/BusNode.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <mutex>
+#include <string>
 
 #include "DistributedAlgorithmNode.h"
 

--- a/src/distributed_algorithm_node/BusNode.h
+++ b/src/distributed_algorithm_node/BusNode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <mutex>
 
 #include "DistributedAlgorithmNode.h"
 
@@ -183,6 +184,7 @@ class BusNode : public DistributedAlgorithmNode {
 
    private:
     set<string> my_commands;
+    recursive_mutex api_mutex;
 
     void join_bus();
     void broadcast_my_commands(const string& target_id = "");

--- a/src/tests/cpp/bus_node_test.cc
+++ b/src/tests/cpp/bus_node_test.cc
@@ -139,12 +139,18 @@ TEST(BusNode, basics) {
 
     Utils::sleep(1000);
 
-    for (auto node : {node1, node2, node3}) {
-        EXPECT_EQ(node.get_ownership("c1"), node1_id);
-        EXPECT_EQ(node.get_ownership("c2"), node1_id);
-        EXPECT_EQ(node.get_ownership("c3"), node2_id);
-        EXPECT_EQ(node.get_ownership("c4"), "");
-    }
+    EXPECT_EQ(node1.get_ownership("c1"), node1_id);
+    EXPECT_EQ(node1.get_ownership("c2"), node1_id);
+    EXPECT_EQ(node1.get_ownership("c3"), node2_id);
+    EXPECT_EQ(node1.get_ownership("c4"), "");
+    EXPECT_EQ(node2.get_ownership("c1"), node1_id);
+    EXPECT_EQ(node2.get_ownership("c2"), node1_id);
+    EXPECT_EQ(node2.get_ownership("c3"), node2_id);
+    EXPECT_EQ(node2.get_ownership("c4"), "");
+    EXPECT_EQ(node3.get_ownership("c1"), node1_id);
+    EXPECT_EQ(node3.get_ownership("c2"), node1_id);
+    EXPECT_EQ(node3.get_ownership("c3"), node2_id);
+    EXPECT_EQ(node3.get_ownership("c4"), "");
 }
 
 TEST(BusNode, bus) {


### PR DESCRIPTION
WIP towards #1208 

Another step towards #1208, in this PR we just make BusNode public API synchronized in order to make the class thread-safe.  This change is linked to this issue because during the implementation of integration tests for LCA we found the synchronization issue and it need to be fixed in order to make the mentioned test work.