### PR TITLE
[#1208] Added new commands CYCLE_ENDED and BUILT_ATOMS_BUNDLE to query proxy hierarchy

### DIFF
--- a/src/agents/BaseProxy.cc
+++ b/src/agents/BaseProxy.cc
@@ -13,6 +13,7 @@ using namespace agents;
 string BaseProxy::ABORT = "abort";
 string BaseProxy::FINISHED = "finished";
 string BaseProxy::ALLOW_CYCLE_START = "allow_cycle_start";
+string BaseProxy::CYCLE_ENDED = "cycle_ended";
 
 string BaseProxy::ORCHESTRATION_SCHEMA = "orchestration_schema";
 
@@ -21,6 +22,8 @@ BaseProxy::BaseProxy() {
     this->abort_flag = false;
     this->error_flag = false;
     this->cycle_start_allowed_flag = false;
+    this->waiting_to_start_new_cycle = true;
+    this->waiting_log_flag = true;
     this->parameters = SystemParametersSingleton::get_instance()->get_base_proxy_params();
 
     set_orchestration_schema(
@@ -37,6 +40,11 @@ bool BaseProxy::finished() {
     return this->abort_flag || this->command_finished_flag;
 }
 
+bool BaseProxy::finished_cycle() {
+    lock_guard<mutex> semaphore(this->api_mutex);
+    return this->abort_flag || this->waiting_to_start_new_cycle;
+}
+
 void BaseProxy::abort() {
     lock_guard<mutex> semaphore(this->api_mutex);
     // RAISE_ERROR("Method not implemented");
@@ -44,6 +52,18 @@ void BaseProxy::abort() {
         to_remote_peer(ABORT, {});
     }
     this->abort_flag = true;
+}
+
+void BaseProxy::allow_cycle_start() {
+    lock_guard<mutex> semaphore(this->api_mutex);
+    if (this->waiting_to_start_new_cycle) {
+        if (!this->command_finished_flag) {
+            to_remote_peer(ALLOW_CYCLE_START, {});
+            this->waiting_to_start_new_cycle = false;
+        }
+    }  else {
+        RAISE_ERROR("Remote peer is not waiting to start a new cycle");
+    }
 }
 
 void BaseProxy::tokenize(vector<string>& output) {
@@ -54,6 +74,24 @@ void BaseProxy::tokenize(vector<string>& output) {
 
 // -------------------------------------------------------------------------------------------------
 // Server-side API
+
+void BaseProxy::cycle_ended() {
+    lock_guard<mutex> semaphore(this->api_mutex);
+    if (!this->command_finished_flag) {
+        switch (this->orchestration_schema) {
+            case NONE:
+                break;
+            case SYNC_ON_CYCLE_START:
+                this->waiting_to_start_new_cycle = true;
+                this->waiting_log_flag = true;
+                to_remote_peer(CYCLE_ENDED, {});
+                break;
+            default:
+                RAISE_ERROR("Invalid orchestration schema: " + std::to_string(this->orchestration_schema));
+                break;
+        }
+    }
+}
 
 void BaseProxy::untokenize(vector<string>& tokens) {
     unsigned int num_property_tokens =
@@ -77,14 +115,19 @@ bool BaseProxy::is_aborting() {
     return this->abort_flag;
 }
 
-bool BaseProxy::cycle_start_allowed() {
+bool BaseProxy::is_cycle_start_allowed() {
     lock_guard<mutex> semaphore(this->api_mutex);
     switch (this->orchestration_schema) {
         case NONE:
             return true;
         case SYNC_ON_CYCLE_START:
+            if (this->waiting_log_flag) {
+                this->waiting_log_flag = false;
+                LOG_INFO("Waiting for orchestrator to start a new cycle");
+            }
             if (this->cycle_start_allowed_flag) {
                 this->cycle_start_allowed_flag = false;
+                this->waiting_log_flag = true;
                 return true;
             } else {
                 return false;
@@ -129,6 +172,8 @@ bool BaseProxy::from_remote_peer(const string& command, const vector<string>& ar
             abort(args);
         } else if (command == ALLOW_CYCLE_START) {
             allow_cycle_start(args);
+        } else if (command == CYCLE_ENDED) {
+            cycle_ended(args);
         } else {
             return false;
         }
@@ -151,6 +196,12 @@ void BaseProxy::abort(const vector<string>& args) {
 void BaseProxy::allow_cycle_start(const vector<string>& args) {
     lock_guard<mutex> semaphore(this->api_mutex);
     this->cycle_start_allowed_flag = true;
+    this->waiting_to_start_new_cycle = false;
+}
+
+void BaseProxy::cycle_ended(const vector<string>& args) {
+    lock_guard<mutex> semaphore(this->api_mutex);
+    this->waiting_to_start_new_cycle = true;
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -162,5 +213,18 @@ void BaseProxy::set_orchestration_schema(ORCHESTRATION_SCHEMA_TYPE value) {
         RAISE_ERROR("Invalid orchestration tag: " + std::to_string(value));
     } else {
         this->orchestration_schema = value;
+        if (value == NONE) {
+            this->cycle_start_allowed_flag = true;
+            this->waiting_to_start_new_cycle = false;
+        } else {
+            this->cycle_start_allowed_flag = false;
+            this->waiting_to_start_new_cycle = true;
+            this->waiting_log_flag = true;
+        }
     }
+}
+
+bool BaseProxy::get_waiting_flag() {
+    lock_guard<mutex> semaphore(this->api_mutex);
+    return this->waiting_to_start_new_cycle;
 }

--- a/src/agents/BaseProxy.cc
+++ b/src/agents/BaseProxy.cc
@@ -61,7 +61,7 @@ void BaseProxy::allow_cycle_start() {
             to_remote_peer(ALLOW_CYCLE_START, {});
             this->waiting_to_start_new_cycle = false;
         }
-    }  else {
+    } else {
         RAISE_ERROR("Remote peer is not waiting to start a new cycle");
     }
 }
@@ -87,7 +87,8 @@ void BaseProxy::cycle_ended() {
                 to_remote_peer(CYCLE_ENDED, {});
                 break;
             default:
-                RAISE_ERROR("Invalid orchestration schema: " + std::to_string(this->orchestration_schema));
+                RAISE_ERROR("Invalid orchestration schema: " +
+                            std::to_string(this->orchestration_schema));
                 break;
         }
     }

--- a/src/agents/BaseProxy.h
+++ b/src/agents/BaseProxy.h
@@ -110,7 +110,7 @@ class BaseProxy : public BusCommandProxy {
     /**
      * Notifies remote proxy that a cycle just ended.
      */
-    void cycle_ended();
+    virtual void cycle_ended();
 
     /**
      * Returns a string representation with all command parameter values.

--- a/src/agents/BaseProxy.h
+++ b/src/agents/BaseProxy.h
@@ -29,7 +29,10 @@ class BaseProxy : public BusCommandProxy {
     // Commands allowed at the proxy level (caller <--> processor)
     static string ABORT;              // Abort current command
     static string FINISHED;           // Notification that all results have already been delivered
-    static string ALLOW_CYCLE_START;  // Orchestration command to allow the beginning of a new cycle
+    static string ALLOW_CYCLE_START;  // Orchestration command to allow the beginning of a new
+                                      // cycle in the remote peer.
+    static string CYCLE_ENDED;        // Orchestration command to notify remote peer that a cycle
+                                      // just ended
 
     BaseProxy();
     virtual ~BaseProxy();
@@ -45,12 +48,29 @@ class BaseProxy : public BusCommandProxy {
     virtual bool finished();
 
     /**
+     * Returns true iff all QueryAnswer objects have been iterated AND is waiting for new cycle.
+     *
+     * @return true iff all QueryAnswer objects have been iterated AND is waiting for new cycle.
+     */
+    virtual bool finished_cycle();
+
+    /**
      * Abort a query.
      *
      * When the caller calls this method, a message is sent to the query processor to abort
      * the search for QueryAnswers.
      */
     void abort();
+
+    /**
+     * Allows remote proxy to start a new cycle.
+     */
+    void allow_cycle_start();
+
+    /**
+     * Return true iff the remote peer is waiting to start a new cycle.
+     */
+    bool get_waiting_flag();
 
     /**
      * Write a tokenized representation of this proxy in the passed `output` vector.
@@ -85,7 +105,12 @@ class BaseProxy : public BusCommandProxy {
      *
      * @return true iff processor has green light to start a new cycle.
      */
-    bool cycle_start_allowed();
+    bool is_cycle_start_allowed();
+
+    /**
+     * Notifies remote proxy that a cycle just ended.
+     */
+    void cycle_ended();
 
     /**
      * Returns a string representation with all command parameter values.
@@ -133,6 +158,13 @@ class BaseProxy : public BusCommandProxy {
      */
     void allow_cycle_start(const vector<string>& args);
 
+    /**
+     * Piggyback method called by CYCLE_ENDED command
+     *
+     * @param args Command arguments (empty for CYCLE_ENDED command)
+     */
+    void cycle_ended(const vector<string>& args);
+
     virtual void pack_command_line_args() = 0;
 
     Properties parameters;
@@ -147,8 +179,10 @@ class BaseProxy : public BusCommandProxy {
     mutex api_mutex;
     bool abort_flag;
     bool command_finished_flag;
-    bool cycle_start_allowed_flag;
     ORCHESTRATION_SCHEMA_TYPE orchestration_schema;
+    bool cycle_start_allowed_flag;
+    bool waiting_log_flag;
+    bool waiting_to_start_new_cycle; // disregarded if orchestration_schema is NONE.
 };
 
 }  // namespace agents

--- a/src/agents/BaseProxy.h
+++ b/src/agents/BaseProxy.h
@@ -182,7 +182,7 @@ class BaseProxy : public BusCommandProxy {
     ORCHESTRATION_SCHEMA_TYPE orchestration_schema;
     bool cycle_start_allowed_flag;
     bool waiting_log_flag;
-    bool waiting_to_start_new_cycle; // disregarded if orchestration_schema is NONE.
+    bool waiting_to_start_new_cycle;  // disregarded if orchestration_schema is NONE.
 };
 
 }  // namespace agents

--- a/src/agents/BaseQueryProxy.cc
+++ b/src/agents/BaseQueryProxy.cc
@@ -98,7 +98,8 @@ vector<string> BaseQueryProxy::get_built_atoms() {
 void BaseQueryProxy::push(shared_ptr<QueryAnswer> answer) {
     lock_guard<recursive_mutex> semaphore(this->api_mutex);
     this->answer_bundle_vector.push_back(answer->tokenize());
-    LOG_DEBUG("Answer pushed to bundle: " + answer->to_string() + " tokens: [" + this->answer_bundle_vector.back() + "]");
+    LOG_DEBUG("Answer pushed to bundle: " + answer->to_string() + " tokens: [" +
+              this->answer_bundle_vector.back() + "]");
     if (this->answer_bundle_vector.size() >= this->parameters.get<unsigned int>(MAX_BUNDLE_SIZE)) {
         flush_answer_bundle();
     }

--- a/src/agents/BaseQueryProxy.cc
+++ b/src/agents/BaseQueryProxy.cc
@@ -11,6 +11,7 @@ using namespace agents;
 
 string BaseQueryProxy::ABORT = "abort";
 string BaseQueryProxy::ANSWER_BUNDLE = "answer_bundle";
+string BaseQueryProxy::BUILT_ATOMS_BUNDLE = "built_atoms_bundle";
 string BaseQueryProxy::FINISHED = "finished";
 
 string BaseQueryProxy::UNIQUE_ASSIGNMENT_FLAG = "unique_assignment_flag";
@@ -26,13 +27,13 @@ string BaseQueryProxy::ALLOW_INCOMPLETE_CHAIN_PATH = "allow_incomplete_chain_pat
 
 BaseQueryProxy::BaseQueryProxy() {
     // constructor typically used in processor
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     init();
 }
 
 BaseQueryProxy::BaseQueryProxy(const vector<string>& tokens, const string& context) : BaseProxy() {
     // constructor typically used in requestor
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     init();
     this->context = context;
     this->query_tokens.insert(this->query_tokens.end(), tokens.begin(), tokens.end());
@@ -50,7 +51,7 @@ BaseQueryProxy::~BaseQueryProxy() {}
 // Client-side API
 
 shared_ptr<QueryAnswer> BaseQueryProxy::pop() {
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     if (this->is_aborting()) {
         return shared_ptr<QueryAnswer>(NULL);
     } else {
@@ -59,16 +60,17 @@ shared_ptr<QueryAnswer> BaseQueryProxy::pop() {
 }
 
 unsigned int BaseQueryProxy::get_count() {
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     return this->answer_count;
 }
 
 void BaseQueryProxy::set_count(unsigned int count) {
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     this->answer_count = count;
 }
 
 void BaseQueryProxy::tokenize(vector<string>& output) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     output.insert(output.begin(), this->query_tokens.begin(), this->query_tokens.end());
     output.insert(output.begin(), std::to_string(this->query_tokens.size()));
     output.insert(output.begin(), this->get_context());
@@ -76,26 +78,47 @@ void BaseQueryProxy::tokenize(vector<string>& output) {
 }
 
 bool BaseQueryProxy::finished() {
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     return (this->is_aborting() || (BaseProxy::finished() && this->answer_queue.empty()));
+}
+
+bool BaseQueryProxy::finished_cycle() {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
+    return (this->is_aborting() || (BaseProxy::finished_cycle() && this->answer_queue.empty()));
+}
+
+vector<string> BaseQueryProxy::get_built_atoms() {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
+    return this->built_atoms;
 }
 
 // -------------------------------------------------------------------------------------------------
 // Server-side API
 
 void BaseQueryProxy::push(shared_ptr<QueryAnswer> answer) {
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     this->answer_bundle_vector.push_back(answer->tokenize());
-    LOG_DEBUG("Answer pushed to bundle: " + answer->to_string() + " tokens: [" +
-              this->answer_bundle_vector.back() + "]");
+    LOG_DEBUG("Answer pushed to bundle: " + answer->to_string() + " tokens: [" + this->answer_bundle_vector.back() + "]");
     if (this->answer_bundle_vector.size() >= this->parameters.get<unsigned int>(MAX_BUNDLE_SIZE)) {
         flush_answer_bundle();
     }
 }
 
+void BaseQueryProxy::push_built_atom(const string& handle) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
+    this->built_atoms_bundle_vector.push_back(handle);
+    LOG_DEBUG("Built atom pushed to bundle: " + handle);
+}
+
 void BaseQueryProxy::flush_answer_bundle() {
-    LOG_DEBUG("Flushing " << this->answer_bundle_vector.size() << " answers in bundle");
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
+    if (this->built_atoms_bundle_vector.size() > 0) {
+        LOG_DEBUG("Flushing " << this->built_atoms_bundle_vector.size() << " answers in bundle");
+        to_remote_peer(BUILT_ATOMS_BUNDLE, this->built_atoms_bundle_vector);
+        this->built_atoms_bundle_vector.clear();
+    }
     if (this->answer_bundle_vector.size() > 0) {
+        LOG_DEBUG("Flushing " << this->answer_bundle_vector.size() << " atoms in bundle");
         to_remote_peer(ANSWER_BUNDLE, this->answer_bundle_vector);
         this->answer_bundle_vector.clear();
     }
@@ -103,11 +126,13 @@ void BaseQueryProxy::flush_answer_bundle() {
 }
 
 void BaseQueryProxy::query_processing_finished() {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     flush_answer_bundle();
     to_remote_peer(FINISHED, {});
 }
 
 void BaseQueryProxy::untokenize(vector<string>& tokens) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     BaseProxy::untokenize(tokens);
     this->context = tokens[0];
     unsigned int num_query_tokens = std::stoi(tokens[1]);
@@ -118,16 +143,17 @@ void BaseQueryProxy::untokenize(vector<string>& tokens) {
 }
 
 const string& BaseQueryProxy::get_context() {
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     return this->context;
 }
 
 const vector<string>& BaseQueryProxy::get_query_tokens() {
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     return this->query_tokens;
 }
 
 string BaseQueryProxy::to_string() {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     string answer = "{";
     answer += "context: " + this->get_context();
     answer += ", tokens: [";
@@ -208,6 +234,8 @@ bool BaseQueryProxy::from_remote_peer(const string& command, const vector<string
     } else {
         if (command == ANSWER_BUNDLE) {
             answer_bundle(args);
+        } else if (command == BUILT_ATOMS_BUNDLE) {
+            built_atoms_bundle(args);
         } else {
             return false;
         }
@@ -216,16 +244,29 @@ bool BaseQueryProxy::from_remote_peer(const string& command, const vector<string
 }
 
 void BaseQueryProxy::answer_bundle(const vector<string>& args) {
-    lock_guard<mutex> semaphore(this->api_mutex);
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
     if (!this->is_aborting()) {
         if (args.size() == 0) {
-            RAISE_ERROR("Invalid empty query answer bundle");
+            LOG_INFO("Disregarding empty query answer bundle");
         } else {
             for (auto tokens : args) {
                 QueryAnswer* query_answer = new QueryAnswer();
                 query_answer->untokenize(tokens);
                 this->answer_queue.enqueue((void*) query_answer);
                 this->answer_count++;
+            }
+        }
+    }
+}
+
+void BaseQueryProxy::built_atoms_bundle(const vector<string>& args) {
+    lock_guard<recursive_mutex> semaphore(this->api_mutex);
+    if (!this->is_aborting()) {
+        if (args.size() == 0) {
+            LOG_INFO("Disregarding empty built atoms answer bundle");
+        } else {
+            for (auto handle : args) {
+                this->built_atoms.push_back(handle);
             }
         }
     }

--- a/src/agents/BaseQueryProxy.cc
+++ b/src/agents/BaseQueryProxy.cc
@@ -244,6 +244,11 @@ bool BaseQueryProxy::from_remote_peer(const string& command, const vector<string
     }
 }
 
+void BaseQueryProxy::cycle_ended() {
+    flush_answer_bundle();
+    BaseProxy::cycle_ended();
+}
+
 void BaseQueryProxy::answer_bundle(const vector<string>& args) {
     lock_guard<recursive_mutex> semaphore(this->api_mutex);
     if (!this->is_aborting()) {

--- a/src/agents/BaseQueryProxy.h
+++ b/src/agents/BaseQueryProxy.h
@@ -38,11 +38,11 @@ class BaseQueryProxy : public BaseProxy {
     // Constructors, destructors and static state
 
     // Commands allowed at the proxy level (caller <--> processor)
-    static string ANSWER_BUNDLE;      // Delivery of a bundle with QueryAnswer objects
-    static string BUILT_ATOMS_BUNDLE; // Delivery of a bundle with handles of newly built atoms
-    static string ABORT;              // Abort current query
-    static string FINISHED;           // Notification that all query results have already been
-                                      // delivered
+    static string ANSWER_BUNDLE;       // Delivery of a bundle with QueryAnswer objects
+    static string BUILT_ATOMS_BUNDLE;  // Delivery of a bundle with handles of newly built atoms
+    static string ABORT;               // Abort current query
+    static string FINISHED;            // Notification that all query results have already been
+                                       // delivered
 
     // Query command's optional parameters
     static string UNIQUE_ASSIGNMENT_FLAG;  // When true, query operators (e.g. And, Or) don't output

--- a/src/agents/BaseQueryProxy.h
+++ b/src/agents/BaseQueryProxy.h
@@ -38,9 +38,11 @@ class BaseQueryProxy : public BaseProxy {
     // Constructors, destructors and static state
 
     // Commands allowed at the proxy level (caller <--> processor)
-    static string ANSWER_BUNDLE;  // Delivery of a bundle with QueryAnswer objects
-    static string ABORT;          // Abort current query
-    static string FINISHED;       // Notification that all query results have alkready been delivered
+    static string ANSWER_BUNDLE;      // Delivery of a bundle with QueryAnswer objects
+    static string BUILT_ATOMS_BUNDLE; // Delivery of a bundle with handles of newly built atoms
+    static string ABORT;              // Abort current query
+    static string FINISHED;           // Notification that all query results have already been
+                                      // delivered
 
     // Query command's optional parameters
     static string UNIQUE_ASSIGNMENT_FLAG;  // When true, query operators (e.g. And, Or) don't output
@@ -135,6 +137,20 @@ class BaseQueryProxy : public BaseProxy {
      */
     virtual bool finished();
 
+    /**
+     * Returns true iff all QueryAnswer objects have been iterated AND is waiting for new cycle.
+     *
+     * @return true iff all QueryAnswer objects have been iterated AND is waiting for new cycle.
+     */
+    virtual bool finished_cycle();
+
+    /**
+     * Returns the handles of the atoms newly built so far.
+     *
+     * @return the handles of the atoms newly built so far.
+     */
+    vector<string> get_built_atoms();
+
     // ---------------------------------------------------------------------------------------------
     // Server-side API
 
@@ -153,6 +169,14 @@ class BaseQueryProxy : public BaseProxy {
      * @param answer Answer to push.
      */
     virtual void push(shared_ptr<QueryAnswer> answer);
+
+    /**
+     * Push the handle of a newly built atom to the proxy. This handle will end in the peer proxy
+     * but it may not happen immediatelly because of the buffering algorithm.
+     *
+     * @param answer Answer to push.
+     */
+    virtual void push_built_atom(const string& handle);
 
     /**
      * Send current answer bundle to remote client peer.
@@ -211,6 +235,13 @@ class BaseQueryProxy : public BaseProxy {
     void answer_bundle(const vector<string>& args);
 
     /**
+     * Piggyback method called by BUILT_ATOMS_BUNDLE command
+     *
+     * @param args Command arguments (tokenized QueryAnswer objects)
+     */
+    void built_atoms_bundle(const vector<string>& args);
+
+    /**
      * Piggyback method called by FINISHED command
      *
      * @param args Command arguments (empty for FINISHED command)
@@ -223,12 +254,14 @@ class BaseQueryProxy : public BaseProxy {
     void init();
     void recursive_metta_mapping(string handle, map<string, string>& table);
 
-    mutex api_mutex;
+    recursive_mutex api_mutex;
     SharedQueue answer_queue;
+    vector<string> built_atoms;
     unsigned int answer_count;
     string context;
     vector<string> query_tokens;
     vector<string> answer_bundle_vector;
+    vector<string> built_atoms_bundle_vector;
     shared_ptr<AtomDB> atomdb;
 };
 

--- a/src/agents/BaseQueryProxy.h
+++ b/src/agents/BaseQueryProxy.h
@@ -228,6 +228,11 @@ class BaseQueryProxy : public BaseProxy {
     virtual bool from_remote_peer(const string& command, const vector<string>& args) override;
 
     /**
+     * Notifies remote proxy that a cycle just ended.
+     */
+    void cycle_ended() override;
+
+    /**
      * Piggyback method called by ANSWER_BUNDLE command
      *
      * @param args Command arguments (tokenized QueryAnswer objects)

--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -577,7 +577,7 @@ void QueryEvolutionProcessor::evolve_query(shared_ptr<StoppableThread> monitor,
     RAM_FOOTPRINT_START(evolution);
     STOP_WATCH_START(evolution);
     while (!monitor->stopped() && !proxy->stop_criteria_met()) {
-        while (!monitor->stopped() && !proxy->cycle_start_allowed()) {
+        while (!monitor->stopped() && !proxy->is_cycle_start_allowed()) {
             Utils::sleep();
         }
         if (monitor->stopped()) {
@@ -620,6 +620,7 @@ void QueryEvolutionProcessor::evolve_query(shared_ptr<StoppableThread> monitor,
         this->generation_count++;
     }
     proxy->flush_answer_bundle();
+    proxy->cycle_ended();
     if (this->generation_count > 0) {
         LOG_INFO("--------------------");
         LOG_INFO("Last generation with answer improvement: " +

--- a/src/agents/evolution/QueryEvolutionProcessor.cc
+++ b/src/agents/evolution/QueryEvolutionProcessor.cc
@@ -618,9 +618,9 @@ void QueryEvolutionProcessor::evolve_query(shared_ptr<StoppableThread> monitor,
         RAM_FOOTPRINT_CHECK(evolution, "Generation " + std::to_string(this->generation_count));
         STOP_WATCH_FINISH(generation, "OneGeneration");
         this->generation_count++;
+        proxy->cycle_ended();
     }
     proxy->flush_answer_bundle();
-    proxy->cycle_ended();
     if (this->generation_count > 0) {
         LOG_INFO("--------------------");
         LOG_INFO("Last generation with answer improvement: " +

--- a/src/agents/query_engine/PatternMatchingQueryProcessor.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProcessor.cc
@@ -134,10 +134,14 @@ void PatternMatchingQueryProcessor::update_attention_broker_single_answer(
         // }
     }
 
-    if (single_answer.size() > 1) {
-        AttentionBrokerClient::correlate(single_answer, proxy->get_context());
+    if (control_single != BaseQueryProxy::NONE) {
+        if (single_answer.size() > 1) {
+            AttentionBrokerClient::correlate(single_answer, proxy->get_context());
+        } else {
+            LOG_DEBUG("Too few handles (" + std::to_string(single_answer.size()) + ") to correlate");
+        }
     } else {
-        LOG_DEBUG("Too few handles (" + std::to_string(single_answer.size()) + ") to correlate");
+        LOG_DEBUG("No correlation update");
     }
 }
 
@@ -163,6 +167,11 @@ void PatternMatchingQueryProcessor::process_query_answers(
     unsigned int max_answers = proxy->parameters.get<unsigned int>(BaseQueryProxy::MAX_ANSWERS);
     bool populate_metta = proxy->parameters.get<bool>(BaseQueryProxy::POPULATE_METTA_MAPPING);
     while ((answer = query_sink->input_buffer->pop_query_answer()) != NULL) {
+        if (proxy->is_aborting()) {
+            LOG_INFO("Query aborted");
+            delete answer;
+            return;
+        }
         answer_count++;
         update_attention_broker_single_answer(proxy, answer, joint_answer);
         if (proxy->parameters.get<bool>(PatternMatchingQueryProxy::COUNT_FLAG)) {

--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -2,8 +2,6 @@
 
 #include "ServiceBus.h"
 #include "SystemParametersSingleton.h"
-
-#define LOG_LEVEL INFO_LEVEL
 #include "Logger.h"
 
 using namespace query_engine;

--- a/src/agents/query_engine/PatternMatchingQueryProxy.cc
+++ b/src/agents/query_engine/PatternMatchingQueryProxy.cc
@@ -1,8 +1,8 @@
 #include "PatternMatchingQueryProxy.h"
 
+#include "Logger.h"
 #include "ServiceBus.h"
 #include "SystemParametersSingleton.h"
-#include "Logger.h"
 
 using namespace query_engine;
 

--- a/src/agents/query_engine/QueryNode.cc
+++ b/src/agents/query_engine/QueryNode.cc
@@ -1,10 +1,9 @@
 #include "QueryNode.h"
 
 #include "LeadershipBroker.h"
+#include "Logger.h"
 #include "MessageBroker.h"
 #include "Utils.h"
-
-#include "Logger.h"
 
 using namespace query_node;
 using namespace std;

--- a/src/agents/query_engine/QueryNode.cc
+++ b/src/agents/query_engine/QueryNode.cc
@@ -4,7 +4,6 @@
 #include "MessageBroker.h"
 #include "Utils.h"
 
-#define LOG_LEVEL INFO_LEVEL
 #include "Logger.h"
 
 using namespace query_node;

--- a/src/tests/cpp/base_proxy_test.cc
+++ b/src/tests/cpp/base_proxy_test.cc
@@ -26,14 +26,20 @@ class TestProxy : public BaseProxy {
 
 TEST(BaseProxyTest, basics) {
     TestProxy proxy;
-    EXPECT_TRUE(proxy.cycle_start_allowed());
-    EXPECT_TRUE(proxy.cycle_start_allowed());
+    EXPECT_FALSE(proxy.get_waiting_flag());
+    EXPECT_TRUE(proxy.is_cycle_start_allowed());
+    EXPECT_TRUE(proxy.is_cycle_start_allowed());
     proxy.set_orchestration(1);
-    EXPECT_FALSE(proxy.cycle_start_allowed());
-    EXPECT_FALSE(proxy.cycle_start_allowed());
+    EXPECT_TRUE(proxy.get_waiting_flag());
+    EXPECT_FALSE(proxy.is_cycle_start_allowed());
+    EXPECT_TRUE(proxy.get_waiting_flag());
+    EXPECT_FALSE(proxy.is_cycle_start_allowed());
+    EXPECT_TRUE(proxy.get_waiting_flag());
     proxy.allow_cycle_start({});
-    EXPECT_TRUE(proxy.cycle_start_allowed());
-    EXPECT_FALSE(proxy.cycle_start_allowed());
+    EXPECT_FALSE(proxy.get_waiting_flag());
+    EXPECT_TRUE(proxy.is_cycle_start_allowed());
+    EXPECT_FALSE(proxy.get_waiting_flag());
+    EXPECT_FALSE(proxy.is_cycle_start_allowed());
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
WIP towards #1208 

Another PR with new features and small fixes required to add the new LCA implementation. In this PR we add two new commands to query proxy hierarchy: CYCLE_ENDED and BUILT_ATOMS_BUNDLE. The former allows the client (whoever issued the query) to detect that the server has already finished a cycle and is waiting for a signal from the orchestrator to start a new one. The later allows the server to send the handles of newly created atoms back to the caller that requested it (this feature is not used by current agents but it's required for LCA).