### PR TITLE
[Bazel][MacOS] Use python `3.10.12`

### DIFF
--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -31,8 +31,11 @@ bazel_dep(name = "rules_python", version = "1.8.2")
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")  # Use extensions:python.bzl
 python.toolchain(
     is_default = True,
-    # No singular aqui
-    python_version = "3.10",
+    # Pin the patch version. The "3.10" alias follows whichever 3.10.x
+    # rules_python currently ships (1.1.0 → 3.10.16, 1.8.2 → 3.10.19).
+    # Standalone builds from 20240224 onward include share/terminfo, which
+    # rctx.delete cannot remove on Docker Desktop. 3.10.12 (20230726) does not.
+    python_version = "3.10.12",
 )
 
 # Bazel to run linters and formatters


### PR DESCRIPTION
`bazel` uses a python version (`3.10.16`) that is not compatible with MacOS Docker Desktop when setting `3.10` at `src/MODULE.bazel` .

Forcing `bazel` to use `3.10.12` fixes that.