### PR TITLE
Extract PublicKey from AtomDBAPITypes

### DIFF
--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -10,6 +10,7 @@
 #include "LinkSchema.h"
 #include "Merger.h"
 #include "Properties.h"
+#include "PublicKey.h"
 
 using namespace std;
 using namespace commons;
@@ -116,7 +117,7 @@ class AtomDB : public HandleDecoder {
     bool empty() const { return atom_count() == 0; }
 
     virtual vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
-        const atomdb_api_types::PublicKey& public_key) const {
+        const PublicKey& public_key) const {
         return {};
     }
 };

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <algorithm>
 #include <map>
-#include <optional>
 #include <vector>
 
 #include "Link.h"
@@ -80,23 +78,6 @@ class AccessPermissionEntry {
     virtual bool get_write() const = 0;
     virtual unsigned int get_tokens_size() const = 0;
     virtual const char* get_token(unsigned int index) const = 0;
-};
-
-class PublicKey {
-   public:
-    vector<string> keys;
-    map<string, unsigned int> peer_to_key;
-
-    bool is_single_key() const { return this->peer_to_key.empty(); }
-
-    explicit PublicKey(const string& key) : keys{key} {}
-    explicit PublicKey(const map<string, string>& peer_keys) {
-        this->keys.reserve(peer_keys.size());
-        for (const auto& [peer, key] : peer_keys) {
-            this->peer_to_key[peer] = this->keys.size();
-            this->keys.push_back(key);
-        }
-    }
 };
 
 class AccessPermissionDocument {

--- a/src/atomdb/BUILD
+++ b/src/atomdb/BUILD
@@ -12,6 +12,7 @@ cc_library(
         ":atomdb_singleton",
         ":atomdbutils",
         ":protected_atomdb",
+        ":public_key",
         "//atomdb/adapterdb:adapterdb_lib",
         "//atomdb/inmemorydb:inmemorydb_lib",
         "//atomdb/morkdb:morkdb_lib",
@@ -38,11 +39,23 @@ cc_library(
 )
 
 cc_library(
+    name = "public_key",
+    srcs = ["PublicKey.cc"],
+    hdrs = ["PublicKey.h"],
+    includes = ["."],
+    deps = [
+        "//commons:commons_lib",
+        "@nlohmann_json//:json",
+    ],
+)
+
+cc_library(
     name = "atomdb",
     hdrs = ["AtomDB.h"],
     includes = ["."],
     deps = [
         ":atomdb_api_types",
+        ":public_key",
         "//commons/atoms:atoms_lib",
     ],
 )

--- a/src/atomdb/ProtectedAtomDB.cc
+++ b/src/atomdb/ProtectedAtomDB.cc
@@ -21,157 +21,151 @@ ProtectedAtomDB::ProtectedAtomDB(shared_ptr<AtomDB> backend) : backend(backend) 
 // --------------------------------------------------------------------------------
 // Public methods
 
-shared_ptr<Atom> ProtectedAtomDB::get_atom(const string& handle,
-                                           const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<Atom> ProtectedAtomDB::get_atom(const string& handle, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::get_atom(handle, public_key) is not implemented yet");
 }
 
-shared_ptr<Node> ProtectedAtomDB::get_node(const string& handle,
-                                           const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<Node> ProtectedAtomDB::get_node(const string& handle, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::get_node(handle, public_key) is not implemented yet");
 }
 
-shared_ptr<Link> ProtectedAtomDB::get_link(const string& handle,
-                                           const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<Link> ProtectedAtomDB::get_link(const string& handle, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::get_link(handle, public_key) is not implemented yet");
 }
 
-vector<shared_ptr<Atom>> ProtectedAtomDB::get_matching_atoms(
-    bool is_toplevel, Atom& key, const atomdb_api_types::PublicKey& public_key) {
+vector<shared_ptr<Atom>> ProtectedAtomDB::get_matching_atoms(bool is_toplevel,
+                                                             Atom& key,
+                                                             const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::get_matching_atoms(..., public_key) is not implemented yet");
 }
 
-shared_ptr<atomdb_api_types::HandleSet> ProtectedAtomDB::query_for_pattern(
-    const LinkSchema& link_schema, const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<atomdb_api_types::HandleSet> ProtectedAtomDB::query_for_pattern(const LinkSchema& link_schema,
+                                                                           const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::query_for_pattern(link_schema, public_key) is not implemented yet");
 }
 
 shared_ptr<atomdb_api_types::HandleList> ProtectedAtomDB::query_for_targets(
-    const string& handle, const atomdb_api_types::PublicKey& public_key) {
+    const string& handle, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::query_for_targets(handle, public_key) is not implemented yet");
 }
 
 shared_ptr<atomdb_api_types::HandleSet> ProtectedAtomDB::query_for_incoming_set(
-    const string& handle, const atomdb_api_types::PublicKey& public_key) {
+    const string& handle, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::query_for_incoming_set(handle, public_key) is not implemented yet");
 }
 
-bool ProtectedAtomDB::atom_exists(const string& handle, const atomdb_api_types::PublicKey& public_key) {
+bool ProtectedAtomDB::atom_exists(const string& handle, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::atom_exists(handle, public_key) is not implemented yet");
 }
 
-bool ProtectedAtomDB::node_exists(const string& handle, const atomdb_api_types::PublicKey& public_key) {
+bool ProtectedAtomDB::node_exists(const string& handle, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::node_exists(handle, public_key) is not implemented yet");
 }
 
-bool ProtectedAtomDB::link_exists(const string& handle, const atomdb_api_types::PublicKey& public_key) {
+bool ProtectedAtomDB::link_exists(const string& handle, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::link_exists(handle, public_key) is not implemented yet");
 }
 
-set<string> ProtectedAtomDB::atoms_exist(const vector<string>& handles,
-                                         const atomdb_api_types::PublicKey& public_key) {
+set<string> ProtectedAtomDB::atoms_exist(const vector<string>& handles, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::atoms_exist(handles, public_key) is not implemented yet");
 }
 
-set<string> ProtectedAtomDB::nodes_exist(const vector<string>& handles,
-                                         const atomdb_api_types::PublicKey& public_key) {
+set<string> ProtectedAtomDB::nodes_exist(const vector<string>& handles, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::nodes_exist(handles, public_key) is not implemented yet");
 }
 
-set<string> ProtectedAtomDB::links_exist(const vector<string>& handles,
-                                         const atomdb_api_types::PublicKey& public_key) {
+set<string> ProtectedAtomDB::links_exist(const vector<string>& handles, const PublicKey& public_key) {
     RAISE_ERROR("ProtectedAtomDB::links_exist(handles, public_key) is not implemented yet");
 }
 
 string ProtectedAtomDB::add_atom(const atoms::Atom* atom,
-                                 const atomdb_api_types::PublicKey& public_key,
+                                 const PublicKey& public_key,
                                  const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_atom(atom, public_key) is not implemented yet");
 }
 
 string ProtectedAtomDB::add_node(const atoms::Node* node,
-                                 const atomdb_api_types::PublicKey& public_key,
+                                 const PublicKey& public_key,
                                  const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_node(node, public_key) is not implemented yet");
 }
 
 string ProtectedAtomDB::add_link(const atoms::Link* link,
-                                 const atomdb_api_types::PublicKey& public_key,
+                                 const PublicKey& public_key,
                                  const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_link(link, public_key) is not implemented yet");
 }
 
 vector<string> ProtectedAtomDB::add_atoms(const vector<atoms::Atom*>& atom_list,
-                                          const atomdb_api_types::PublicKey& public_key,
+                                          const PublicKey& public_key,
                                           bool is_transactional,
                                           const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_atoms(atom_list, public_key) is not implemented yet");
 }
 
 vector<string> ProtectedAtomDB::add_nodes(const vector<atoms::Node*>& nodes,
-                                          const atomdb_api_types::PublicKey& public_key,
+                                          const PublicKey& public_key,
                                           bool is_transactional,
                                           const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_nodes(nodes, public_key) is not implemented yet");
 }
 
 vector<string> ProtectedAtomDB::add_links(const vector<atoms::Link*>& links,
-                                          const atomdb_api_types::PublicKey& public_key,
+                                          const PublicKey& public_key,
                                           bool is_transactional,
                                           const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_links(links, public_key) is not implemented yet");
 }
 
 bool ProtectedAtomDB::delete_atom(const string& handle,
-                                  const atomdb_api_types::PublicKey& public_key,
+                                  const PublicKey& public_key,
                                   bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_atom(handle, public_key) is not implemented yet");
 }
 
 bool ProtectedAtomDB::delete_node(const string& handle,
-                                  const atomdb_api_types::PublicKey& public_key,
+                                  const PublicKey& public_key,
                                   bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_node(handle, public_key) is not implemented yet");
 }
 
 bool ProtectedAtomDB::delete_link(const string& handle,
-                                  const atomdb_api_types::PublicKey& public_key,
+                                  const PublicKey& public_key,
                                   bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_link(handle, public_key) is not implemented yet");
 }
 
 uint ProtectedAtomDB::delete_atoms(const vector<string>& handles,
-                                   const atomdb_api_types::PublicKey& public_key,
+                                   const PublicKey& public_key,
                                    bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_atoms(handles, public_key) is not implemented yet");
 }
 
 uint ProtectedAtomDB::delete_nodes(const vector<string>& handles,
-                                   const atomdb_api_types::PublicKey& public_key,
+                                   const PublicKey& public_key,
                                    bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_nodes(handles, public_key) is not implemented yet");
 }
 
 uint ProtectedAtomDB::delete_links(const vector<string>& handles,
-                                   const atomdb_api_types::PublicKey& public_key,
+                                   const PublicKey& public_key,
                                    bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_links(handles, public_key) is not implemented yet");
 }
 
-void ProtectedAtomDB::re_index_patterns(const atomdb_api_types::PublicKey& public_key,
-                                        bool flush_patterns) {
+void ProtectedAtomDB::re_index_patterns(const PublicKey& public_key, bool flush_patterns) {
     RAISE_ERROR("ProtectedAtomDB::re_index_patterns(public_key) is not implemented yet");
 }
 
-size_t ProtectedAtomDB::node_count(const atomdb_api_types::PublicKey& public_key) const {
+size_t ProtectedAtomDB::node_count(const PublicKey& public_key) const {
     RAISE_ERROR("ProtectedAtomDB::node_count(public_key) is not implemented yet");
 }
 
-size_t ProtectedAtomDB::link_count(const atomdb_api_types::PublicKey& public_key) const {
+size_t ProtectedAtomDB::link_count(const PublicKey& public_key) const {
     RAISE_ERROR("ProtectedAtomDB::link_count(public_key) is not implemented yet");
 }
 
-size_t ProtectedAtomDB::atom_count(const atomdb_api_types::PublicKey& public_key) const {
+size_t ProtectedAtomDB::atom_count(const PublicKey& public_key) const {
     RAISE_ERROR("ProtectedAtomDB::atom_count(public_key) is not implemented yet");
 }
 

--- a/src/atomdb/ProtectedAtomDB.h
+++ b/src/atomdb/ProtectedAtomDB.h
@@ -37,72 +37,69 @@ class ProtectedAtomDB : public AtomDB {
     atomdb_api_types::ProtectionMode get_protection_mode() const override;
 
     shared_ptr<Atom> get_atom(const string& handle) override;
-    shared_ptr<Atom> get_atom(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<Atom> get_atom(const string& handle, const PublicKey& public_key);
 
     shared_ptr<Node> get_node(const string& handle) override;
-    shared_ptr<Node> get_node(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<Node> get_node(const string& handle, const PublicKey& public_key);
 
     shared_ptr<Link> get_link(const string& handle) override;
-    shared_ptr<Link> get_link(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<Link> get_link(const string& handle, const PublicKey& public_key);
 
     vector<shared_ptr<Atom>> get_matching_atoms(bool is_toplevel, Atom& key) override;
     vector<shared_ptr<Atom>> get_matching_atoms(bool is_toplevel,
                                                 Atom& key,
-                                                const atomdb_api_types::PublicKey& public_key);
+                                                const PublicKey& public_key);
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const LinkSchema& link_schema) override;
-    shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(
-        const LinkSchema& link_schema, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const LinkSchema& link_schema,
+                                                              const PublicKey& public_key);
 
     shared_ptr<atomdb_api_types::HandleList> query_for_targets(const string& handle) override;
-    shared_ptr<atomdb_api_types::HandleList> query_for_targets(
-        const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<atomdb_api_types::HandleList> query_for_targets(const string& handle,
+                                                               const PublicKey& public_key);
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_incoming_set(const string& handle) override;
-    shared_ptr<atomdb_api_types::HandleSet> query_for_incoming_set(
-        const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<atomdb_api_types::HandleSet> query_for_incoming_set(const string& handle,
+                                                                   const PublicKey& public_key);
 
     bool atom_exists(const string& handle) override;
-    bool atom_exists(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    bool atom_exists(const string& handle, const PublicKey& public_key);
 
     bool node_exists(const string& handle) override;
-    bool node_exists(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    bool node_exists(const string& handle, const PublicKey& public_key);
 
     bool link_exists(const string& handle) override;
-    bool link_exists(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    bool link_exists(const string& handle, const PublicKey& public_key);
 
     set<string> atoms_exist(const vector<string>& handles) override;
-    set<string> atoms_exist(const vector<string>& handles,
-                            const atomdb_api_types::PublicKey& public_key);
+    set<string> atoms_exist(const vector<string>& handles, const PublicKey& public_key);
 
     set<string> nodes_exist(const vector<string>& handles) override;
-    set<string> nodes_exist(const vector<string>& handles,
-                            const atomdb_api_types::PublicKey& public_key);
+    set<string> nodes_exist(const vector<string>& handles, const PublicKey& public_key);
 
     set<string> links_exist(const vector<string>& handles) override;
-    set<string> links_exist(const vector<string>& handles,
-                            const atomdb_api_types::PublicKey& public_key);
+    set<string> links_exist(const vector<string>& handles, const PublicKey& public_key);
 
     string add_atom(const atoms::Atom* atom, const atoms::Merger* merger = NULL) override;
     string add_atom(const atoms::Atom* atom,
-                    const atomdb_api_types::PublicKey& public_key,
+                    const PublicKey& public_key,
                     const atoms::Merger* merger = NULL);
 
     string add_node(const atoms::Node* node, const atoms::Merger* merger = NULL) override;
     string add_node(const atoms::Node* node,
-                    const atomdb_api_types::PublicKey& public_key,
+                    const PublicKey& public_key,
                     const atoms::Merger* merger = NULL);
 
     string add_link(const atoms::Link* link, const atoms::Merger* merger = NULL) override;
     string add_link(const atoms::Link* link,
-                    const atomdb_api_types::PublicKey& public_key,
+                    const PublicKey& public_key,
                     const atoms::Merger* merger = NULL);
 
     vector<string> add_atoms(const vector<atoms::Atom*>& atom_list,
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL) override;
     vector<string> add_atoms(const vector<atoms::Atom*>& atom_list,
-                             const atomdb_api_types::PublicKey& public_key,
+                             const PublicKey& public_key,
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL);
 
@@ -110,7 +107,7 @@ class ProtectedAtomDB : public AtomDB {
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL) override;
     vector<string> add_nodes(const vector<atoms::Node*>& nodes,
-                             const atomdb_api_types::PublicKey& public_key,
+                             const PublicKey& public_key,
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL);
 
@@ -118,51 +115,51 @@ class ProtectedAtomDB : public AtomDB {
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL) override;
     vector<string> add_links(const vector<atoms::Link*>& links,
-                             const atomdb_api_types::PublicKey& public_key,
+                             const PublicKey& public_key,
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL);
 
     bool delete_atom(const string& handle, bool delete_link_targets = false) override;
     bool delete_atom(const string& handle,
-                     const atomdb_api_types::PublicKey& public_key,
+                     const PublicKey& public_key,
                      bool delete_link_targets = false);
 
     bool delete_node(const string& handle, bool delete_link_targets = false) override;
     bool delete_node(const string& handle,
-                     const atomdb_api_types::PublicKey& public_key,
+                     const PublicKey& public_key,
                      bool delete_link_targets = false);
 
     bool delete_link(const string& handle, bool delete_link_targets = false) override;
     bool delete_link(const string& handle,
-                     const atomdb_api_types::PublicKey& public_key,
+                     const PublicKey& public_key,
                      bool delete_link_targets = false);
 
     uint delete_atoms(const vector<string>& handles, bool delete_link_targets = false) override;
     uint delete_atoms(const vector<string>& handles,
-                      const atomdb_api_types::PublicKey& public_key,
+                      const PublicKey& public_key,
                       bool delete_link_targets = false);
 
     uint delete_nodes(const vector<string>& handles, bool delete_link_targets = false) override;
     uint delete_nodes(const vector<string>& handles,
-                      const atomdb_api_types::PublicKey& public_key,
+                      const PublicKey& public_key,
                       bool delete_link_targets = false);
 
     uint delete_links(const vector<string>& handles, bool delete_link_targets = false) override;
     uint delete_links(const vector<string>& handles,
-                      const atomdb_api_types::PublicKey& public_key,
+                      const PublicKey& public_key,
                       bool delete_link_targets = false);
 
     void re_index_patterns(bool flush_patterns = true) override;
-    void re_index_patterns(const atomdb_api_types::PublicKey& public_key, bool flush_patterns = true);
+    void re_index_patterns(const PublicKey& public_key, bool flush_patterns = true);
 
     size_t node_count() const override;
-    size_t node_count(const atomdb_api_types::PublicKey& public_key) const;
+    size_t node_count(const PublicKey& public_key) const;
 
     size_t link_count() const override;
-    size_t link_count(const atomdb_api_types::PublicKey& public_key) const;
+    size_t link_count(const PublicKey& public_key) const;
 
     size_t atom_count() const override;
-    size_t atom_count(const atomdb_api_types::PublicKey& public_key) const;
+    size_t atom_count(const PublicKey& public_key) const;
 
    private:
     shared_ptr<AtomDB> backend;

--- a/src/atomdb/PublicKey.cc
+++ b/src/atomdb/PublicKey.cc
@@ -1,0 +1,97 @@
+#include "PublicKey.h"
+
+#include <exception>
+#include <nlohmann/json.hpp>
+
+#include "Utils.h"
+
+using json = nlohmann::json;
+using namespace commons;
+
+namespace atomdb {
+
+PublicKey::PublicKey(const string& key) : keys{key} {
+    if (key.empty()) {
+        RAISE_ERROR("PublicKey cannot be empty");
+    }
+}
+
+PublicKey::PublicKey(const map<string, string>& peer_keys) {
+    if (peer_keys.empty()) {
+        RAISE_ERROR("PublicKey cannot be empty");
+    }
+    this->keys.reserve(peer_keys.size());
+    for (const auto& [peer, key] : peer_keys) {
+        if (peer.empty() || key.empty()) {
+            RAISE_ERROR("PublicKey peer and key must be non-empty");
+        }
+        this->peer_to_key[peer] = this->keys.size();
+        this->keys.push_back(key);
+    }
+}
+
+optional<string> PublicKey::key_for_peer(const string& peer_uid) const {
+    if (this->is_single_key()) {
+        return this->keys[0];
+    }
+    auto it = this->peer_to_key.find(peer_uid);
+    if (it == this->peer_to_key.end()) {
+        return nullopt;
+    }
+    if (it->second >= this->keys.size()) {
+        RAISE_ERROR("PublicKey peer_to_key index out of range for peer: " + peer_uid);
+    }
+    return this->keys[it->second];
+}
+
+optional<PublicKey> PublicKey::for_peer(const string& peer_uid) const {
+    if (this->is_single_key()) {
+        return *this;
+    }
+    auto key = this->key_for_peer(peer_uid);
+    if (!key.has_value()) {
+        return nullopt;
+    }
+    return PublicKey(key.value());
+}
+
+map<string, string> PublicKey::peer_keys() const {
+    map<string, string> result;
+    for (const auto& [peer, idx] : this->peer_to_key) {
+        if (idx >= this->keys.size()) {
+            RAISE_ERROR("PublicKey peer_to_key index out of range for peer: " + peer);
+        }
+        result[peer] = this->keys[idx];
+    }
+    return result;
+}
+
+optional<PublicKey> PublicKey::from_json(const string& json_string) {
+    json parsed;
+    try {
+        parsed = json::parse(json_string);
+    } catch (const exception& exception) {
+        RAISE_ERROR("Invalid PublicKey JSON: " + string(exception.what()));
+    }
+
+    if (parsed.is_string()) {
+        return PublicKey(parsed.get<string>());
+    }
+    if (!parsed.is_object()) {
+        RAISE_ERROR("PublicKey JSON must be an object or a string");
+    }
+    if (parsed.empty()) {
+        return nullopt;
+    }
+
+    map<string, string> peer_keys;
+    for (auto it = parsed.begin(); it != parsed.end(); ++it) {
+        if (!it.value().is_string()) {
+            RAISE_ERROR("PublicKey JSON values must be strings (peer '" + it.key() + "')");
+        }
+        peer_keys[it.key()] = it.value().get<string>();
+    }
+    return PublicKey(peer_keys);
+}
+
+}  // namespace atomdb

--- a/src/atomdb/PublicKey.h
+++ b/src/atomdb/PublicKey.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+namespace atomdb {
+
+class PublicKey {
+   public:
+    /**
+     * @brief Builds a PublicKey from its JSON wire form.
+     *
+     * Accepts a map, `{"uid_peerA":"key_peerA","uid_peerB":"key_peerB"}`, or a bare JSON string,
+     */
+    static optional<PublicKey> from_json(const string& json_string);
+
+    explicit PublicKey(const string& key);
+    explicit PublicKey(const map<string, string>& peer_keys);
+    ~PublicKey() = default;
+
+    inline bool is_single_key() const { return this->peer_to_key.empty(); }
+    inline const string& key() const { return this->keys[0]; }
+
+    /**
+     * @brief Key assigned to a peer.
+     *
+     * A single-key PublicKey broadcasts the same key to every peer. A mapped PublicKey
+     * looks up `peer_uid` in the map. Returns nullopt when the peer is not in the map.
+     */
+    optional<string> key_for_peer(const string& peer_uid) const;
+
+    /**
+     * @brief Single-key PublicKey to send to a given peer.
+     *
+     * Returns this object when it is already a single key, or a new single-key PublicKey sliced
+     * from the peer-to-key map. Returns nullopt when the peer is not in the map.
+     */
+    optional<PublicKey> for_peer(const string& peer_uid) const;
+
+    /**
+     * @brief Peer uid -> key string entries. Empty when this is a single-key PublicKey.
+     */
+    map<string, string> peer_keys() const;
+
+   private:
+    vector<string> keys;
+    map<string, unsigned int> peer_to_key;
+};
+
+}  // namespace atomdb

--- a/src/atomdb/adapterdb/AdapterDB.cc
+++ b/src/atomdb/adapterdb/AdapterDB.cc
@@ -65,7 +65,7 @@ bool AdapterDB::composite_type_enabled() const {
     return this->atomdb_backend->composite_type_enabled();
 }
 vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> AdapterDB::get_access_permissions(
-    const atomdb_api_types::PublicKey& public_key) const {
+    const PublicKey& public_key) const {
     this->ensure_backend_ready();
     return this->atomdb_backend->get_access_permissions(public_key);
 }

--- a/src/atomdb/adapterdb/AdapterDB.h
+++ b/src/atomdb/adapterdb/AdapterDB.h
@@ -117,7 +117,7 @@ class AdapterDB : public AtomDB {
      * Returns an empty vector if the backend has no matching permissions.
      */
     vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
-        const atomdb_api_types::PublicKey& public_key) const override;
+        const PublicKey& public_key) const override;
 
    private:
     AdapterDbType adapter_type;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -63,20 +63,19 @@ RedisMongoDB::~RedisMongoDB() {
 bool RedisMongoDB::allow_nested_indexing() { return false; }
 
 vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> RedisMongoDB::get_access_permissions(
-    const atomdb_api_types::PublicKey& public_key) const {
+    const PublicKey& public_key) const {
     vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> documents;
 
     if (public_key.is_single_key()) {
-        auto document = this->load_access_permission_document(public_key.keys[0]);
+        auto document = this->load_access_permission_document(public_key.key());
         if (document.has_value()) {
             documents.push_back(document.value());
         }
         return documents;
     }
 
-    for (const auto& [peer_uid, idx] : (public_key.peer_to_key)) {
-        string key = public_key.keys[idx];
-        auto document = this->load_access_permission_document(key);
+    for (const auto& peer_key : public_key.peer_keys()) {
+        auto document = this->load_access_permission_document(peer_key.second);
         if (document.has_value()) {
             documents.push_back(document.value());
         }

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -38,7 +38,7 @@ class RedisMongoDB : public AtomDB {
      * Returns an empty vector if no matching documents exist.
      */
     vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
-        const atomdb_api_types::PublicKey& public_key) const override;
+        const PublicKey& public_key) const override;
     atomdb_api_types::ProtectionMode get_protection_mode() const override;
 
     static string REDIS_PATTERNS_PREFIX;

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -44,7 +44,7 @@ bool RemoteAtomDBPeer::composite_type_enabled() const {
     return local_persistence_ && local_persistence_->composite_type_enabled();
 }
 vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> RemoteAtomDBPeer::get_access_permissions(
-    const atomdb_api_types::PublicKey& public_key) const {
+    const PublicKey& public_key) const {
     if (!atomdb_) return AtomDB::get_access_permissions(public_key);
     return atomdb_->get_access_permissions(public_key);
 }

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -120,7 +120,7 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
      * Returns an empty vector if there is no remote AtomDB or it has no matching permissions.
      */
     vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
-        const atomdb_api_types::PublicKey& public_key) const override;
+        const PublicKey& public_key) const override;
 
    private:
     shared_ptr<InMemoryDB> write_buffer() const;

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -852,6 +852,21 @@ cc_test(
 )
 
 cc_test(
+    name = "public_key_test",
+    size = "small",
+    srcs = ["public_key_test.cc"],
+    copts = [
+        "-Iexternal/gtest/googletest/include",
+        "-Iexternal/gtest/googletest",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//atomdb:public_key",
+        "@com_github_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "protected_atomdb_test",
     size = "small",
     srcs = ["protected_atomdb_test.cc"],

--- a/src/tests/cpp/public_key_test.cc
+++ b/src/tests/cpp/public_key_test.cc
@@ -1,0 +1,94 @@
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include "PublicKey.h"
+#include "gtest/gtest.h"
+
+using namespace atomdb;
+using namespace std;
+
+TEST(PublicKeyTest, SingleKeyConstructor) {
+    PublicKey key("admin");
+    EXPECT_TRUE(key.is_single_key());
+    EXPECT_EQ(key.key(), "admin");
+    EXPECT_TRUE(key.peer_keys().empty());
+}
+
+TEST(PublicKeyTest, SingleKeyConstructorRejectsEmpty) { EXPECT_THROW(PublicKey(""), runtime_error); }
+
+TEST(PublicKeyTest, MappedConstructor) {
+    PublicKey key(map<string, string>{{"peerA", "admin"}, {"peerB", "reader"}});
+    EXPECT_FALSE(key.is_single_key());
+    EXPECT_EQ(key.peer_keys().size(), 2u);
+    EXPECT_EQ(key.peer_keys()["peerA"], "admin");
+    EXPECT_EQ(key.peer_keys()["peerB"], "reader");
+}
+
+TEST(PublicKeyTest, MappedConstructorRejectsEmptyMap) {
+    EXPECT_THROW(PublicKey(map<string, string>{}), runtime_error);
+}
+
+TEST(PublicKeyTest, MappedConstructorRejectsEmptyPeerOrKey) {
+    EXPECT_THROW(PublicKey(map<string, string>{{"", "admin"}}), runtime_error);
+    EXPECT_THROW(PublicKey(map<string, string>{{"peerA", ""}}), runtime_error);
+}
+
+TEST(PublicKeyTest, KeyForPeerBroadcastsSingleKey) {
+    PublicKey key("admin");
+    EXPECT_EQ(key.key_for_peer("peerA"), "admin");
+    EXPECT_EQ(key.key_for_peer("missing"), "admin");
+}
+
+TEST(PublicKeyTest, KeyForPeerLooksUpMappedKey) {
+    PublicKey key(map<string, string>{{"peerA", "admin"}, {"peerB", "reader"}});
+    EXPECT_EQ(key.key_for_peer("peerA"), "admin");
+    EXPECT_EQ(key.key_for_peer("peerB"), "reader");
+    EXPECT_FALSE(key.key_for_peer("missing").has_value());
+}
+
+TEST(PublicKeyTest, ForPeerReturnsSelfWhenSingleKey) {
+    PublicKey key("admin");
+    optional<PublicKey> sliced = key.for_peer("any");
+    ASSERT_TRUE(sliced.has_value());
+    EXPECT_TRUE(sliced->is_single_key());
+    EXPECT_EQ(sliced->key(), "admin");
+}
+
+TEST(PublicKeyTest, ForPeerSlicesMappedKey) {
+    PublicKey key(map<string, string>{{"peerA", "admin"}, {"peerB", "reader"}});
+    optional<PublicKey> sliced = key.for_peer("peerA");
+    ASSERT_TRUE(sliced.has_value());
+    EXPECT_TRUE(sliced->is_single_key());
+    EXPECT_EQ(sliced->key(), "admin");
+    EXPECT_FALSE(key.for_peer("missing").has_value());
+}
+
+TEST(PublicKeyTest, FromJsonAcceptsObjectAndString) {
+    optional<PublicKey> mapped = PublicKey::from_json(R"({"peerA":"admin","peerB":"unused"})");
+    ASSERT_TRUE(mapped.has_value());
+    EXPECT_FALSE(mapped->is_single_key());
+    EXPECT_EQ(mapped->peer_keys().size(), 2u);
+    EXPECT_EQ(mapped->key_for_peer("peerA"), "admin");
+    EXPECT_EQ(mapped->key_for_peer("peerB"), "unused");
+
+    optional<PublicKey> single = PublicKey::from_json(R"("admin")");
+    ASSERT_TRUE(single.has_value());
+    EXPECT_TRUE(single->is_single_key());
+    EXPECT_EQ(single->key(), "admin");
+}
+
+TEST(PublicKeyTest, FromJsonEmptyObjectIsAbsent) {
+    EXPECT_FALSE(PublicKey::from_json("{}").has_value());
+}
+
+TEST(PublicKeyTest, FromJsonRejectsInvalidPayloads) {
+    EXPECT_THROW(PublicKey::from_json("not-json"), runtime_error);
+    EXPECT_THROW(PublicKey::from_json("[]"), runtime_error);
+    EXPECT_THROW(PublicKey::from_json("1"), runtime_error);
+    EXPECT_THROW(PublicKey::from_json("null"), runtime_error);
+    EXPECT_THROW(PublicKey::from_json(R"({"peerA":1})"), runtime_error);
+    EXPECT_THROW(PublicKey::from_json(R"(")"), runtime_error);
+    EXPECT_THROW(PublicKey::from_json(R"("")"), runtime_error);
+}

--- a/src/tests/cpp/test_commons/mocks/MockAtomDB.h
+++ b/src/tests/cpp/test_commons/mocks/MockAtomDB.h
@@ -28,7 +28,7 @@ class AtomDBMock : public AtomDB {
     MOCK_METHOD(bool, composite_type_enabled, (), (const, override));
     MOCK_METHOD(vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>>,
                 get_access_permissions,
-                (const atomdb_api_types::PublicKey& public_key),
+                (const PublicKey& public_key),
                 (const, override));
     MOCK_METHOD(ProtectionMode, get_protection_mode, (), (const, override));
     MOCK_METHOD(shared_ptr<Atom>, get_atom, (const string& handle), (override));


### PR DESCRIPTION
Move `PublicKey` out of `AtomDBAPITypes.h` into `PublicKey.h` / `PublicKey.cc`.

- Members keys and peer_to_key are private.
- Access goes through `key()`, `peer_keys()`, `key_for_peer()`, and `for_peer()`.
- Adds `from_json()`