### PR TITLE
[HOTFIX] Fixes a bug introduced in the last commit of PR #1249

### DIFF
--- a/src/agents/link_creation_agent/link_creators/AndTwoPredicates.cc
+++ b/src/agents/link_creation_agent/link_creators/AndTwoPredicates.cc
@@ -37,6 +37,7 @@ LinkCreationStats AndTwoPredicates::create(shared_ptr<QueryAnswer> query_answer)
             extract_mentioned_predicates(mentioned_predicates1, predicates[1]);
             if (!Utils::intersects(mentioned_predicates0, mentioned_predicates1)) {
                 vector<string> targets = {LOGICAL_AND_HANDLE, predicates[0], predicates[1]};
+                add_or_update_link(targets, 1.0);
                 stats.created++;
                 double strength = 1;
                 for (string& h : query_answer->get_handles_vector()) {

--- a/src/tests/integration/cpp/lca_integration_test.cc
+++ b/src/tests/integration/cpp/lca_integration_test.cc
@@ -109,7 +109,7 @@ static bool test_and_two_predicates() {
             Utils::sleep();
         }
     }
-    success &= assert_equal(proxy->get_count(), 7816, "link creation count");
+    success &= assert_equal(proxy->get_count(), 10530, "link creation count");
     AtomDBSingleton::get_instance()->delete_atoms(proxy->get_built_atoms());
 
     finish_test_case(test_case, success);


### PR DESCRIPTION
In commit 475aace416e414b09405fe6cc04845c8c27b0d65 we removed, by mistake, a call to add_or_update_link(). We didn't noticed it because we didn't explicitly run LCA integration tests after this change (integration tests are not integrated in `make test-all` yet).

After the fix we noticed that the change in that commit changes the baseline of the regression we make in the LCA integration test. That's why the test itself needed to be updated as well.