### PR TITLE
[#1255] Add integration tests to Makefile target: test-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deploy:
 	@bash $(CURDIR)/scripts/deployment/fn_deploy.sh
 
 integration-tests:
-	@bash $(CURDIR)/scripts/deployment/tests.sh
+	@bash -x $(CURDIR)/src/tests/scripts/all_integration_tests.sh $(OPTIONS)
 
 build-deployment:
 	@docker build -f .docker/deployment/Dockerfile -t das-deployment:latest .
@@ -100,9 +100,13 @@ test-clear:
 test-all-no-cache: setup-test-all
 	@$(MAKE) bazel 'test --show_progress --cache_test_results=no //tests/...'
 
-test-all: 
+unit-tests:
 	@$(MAKE) setup-test-all
 	@$(MAKE) bazel 'test --show_progress //tests/...'
+
+test-all:
+	@$(MAKE) unit-tests
+	@$(MAKE) integration-tests
 
 test-agents-integration:
 	@bash  ./src/scripts/integration_test_setup.sh &

--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,3 @@ test-coverage-check: build-image
 		--workdir "/opt/das/src" \
 		das-builder \
 		./scripts/bazel_coverage_check.sh
-
-# Catch-all pattern to prevent make from complaining about unknown targets
-%:
-	@:
-


### PR DESCRIPTION
In this PR we renamed previous target `test-all` to `unit-tests`. So, after this PR, one must call `make unit-tests` to have the exact same behavior previously obtained by `make test-all`.

After this PR, `make test-all` is redefined to call targets `unit-tests` and `integration-tests`.

We redefined the target `integration-tests` which was outdated and wasn't being used anywhere. Now `make integration-tests` runs all integration tests we have defined in `src/tests/integration`. Currently, we have only `lca_integration_test` but other tests will be added in the near future.

`make integration-tests` raises a warning that it stops/prune all currently running docker containers. So it asks for confirmation before continuing. To skip this confirmation one can run `make integration-tests OPTIONS=-y` or, similarly, `make test-all OPTIONS=-y`. 

We also deleted an empty clause which prevented `make` from reporting errors when an invalid target was requested in the command line.