### PR TITLE
Remove `AtomDB` context and use prefix for `RedisMongoDB`

### DIFF
--- a/config/das.json
+++ b/config/das.json
@@ -80,7 +80,6 @@
             {
                 "uid": "peer1",
                 "type": "redismongodb",
-                "context": "",
                 "mongodb": {
                     "endpoint": "localhost:40021",
                     "username": "admin",
@@ -97,7 +96,6 @@
             {
                 "uid": "peer2",
                 "type": "redismongodb",
-                "context": "",
                 "mongodb": {
                     "endpoint": "localhost:40031",
                     "username": "admin",
@@ -114,10 +112,8 @@
             {
                 "uid": "peer3",
                 "type": "inmemorydb",
-                "context": "",
                 "local_persistence": {
                     "type": "redismongodb",
-                    "context": "",
                     "composite_type_enabled": false,
                     "mongodb": {
                         "endpoint": "localhost:40041",

--- a/src/atomdb/AtomDBFactory.cc
+++ b/src/atomdb/AtomDBFactory.cc
@@ -14,7 +14,7 @@ using namespace commons;
 // --------------------------------------------------------------------------------
 // Public methods
 
-shared_ptr<AtomDB> AtomDBFactory::create(const JsonConfig& config, const string& context) {
+shared_ptr<AtomDB> AtomDBFactory::create(const JsonConfig& config) {
     auto atomdb_type = config.at_path("type").get_or<string>("");
 
     AtomDBType type = AtomDB::string_to_type(atomdb_type);
@@ -23,9 +23,9 @@ shared_ptr<AtomDB> AtomDBFactory::create(const JsonConfig& config, const string&
 
     if (type == AtomDBType::RedisMongoDB || type == AtomDBType::MorkDB ||
         type == AtomDBType::InMemoryDB) {
-        atomdb = create_basic_atomdb(config, context);
+        atomdb = create_basic_atomdb(config);
     } else if (type == AtomDBType::RemoteAtomDB || type == AtomDBType::AdapterDB) {
-        atomdb = create_composite_atomdb(config, context);
+        atomdb = create_composite_atomdb(config);
     } else {
         RAISE_ERROR("AtomDBFactory: unsupported AtomDB type: " + atomdb_type);
     }
@@ -36,7 +36,7 @@ shared_ptr<AtomDB> AtomDBFactory::create(const JsonConfig& config, const string&
 // --------------------------------------------------------------------------------
 // Private methods
 
-shared_ptr<AtomDB> AtomDBFactory::create_basic_atomdb(const JsonConfig& config, const string& context) {
+shared_ptr<AtomDB> AtomDBFactory::create_basic_atomdb(const JsonConfig& config) {
     auto atomdb_type = config.at_path("type").get_or<string>("");
 
     AtomDBType type = AtomDB::string_to_type(atomdb_type);
@@ -45,11 +45,11 @@ shared_ptr<AtomDB> AtomDBFactory::create_basic_atomdb(const JsonConfig& config, 
 
     if (type == AtomDBType::RedisMongoDB) {
         // make_shared cannot access RedisMongoDB's private ctor; friend can via new.
-        atomdb = shared_ptr<RedisMongoDB>(new RedisMongoDB(context, false, config));
+        atomdb = shared_ptr<RedisMongoDB>(new RedisMongoDB(config));
     } else if (type == AtomDBType::MorkDB) {
-        atomdb = make_shared<MorkDB>(context, config);
+        atomdb = make_shared<MorkDB>(config);
     } else if (type == AtomDBType::InMemoryDB) {
-        atomdb = make_shared<InMemoryDB>(context.empty() ? "inmemorydb_" : context);
+        atomdb = make_shared<InMemoryDB>();
     } else {
         RAISE_ERROR("AtomDBFactory: '" + atomdb_type + "' is not a basic AtomDB type");
     }
@@ -57,8 +57,7 @@ shared_ptr<AtomDB> AtomDBFactory::create_basic_atomdb(const JsonConfig& config, 
     return atomdb;
 }
 
-shared_ptr<AtomDB> AtomDBFactory::create_composite_atomdb(const JsonConfig& config,
-                                                          const string& context) {
+shared_ptr<AtomDB> AtomDBFactory::create_composite_atomdb(const JsonConfig& config) {
     auto atomdb_type = config.at_path("type").get_or<string>("");
 
     AtomDBType type = AtomDB::string_to_type(atomdb_type);
@@ -81,12 +80,10 @@ shared_ptr<AtomDB> AtomDBFactory::create_composite_atomdb(const JsonConfig& conf
             auto local_persistence_config =
                 peer_config.at_path("local_persistence").get_or<JsonConfig>(JsonConfig());
             if (!local_persistence_config.empty()) {
-                string local_context = local_persistence_config.at_path("context").get_or<string>("");
-                local_persistence = create_basic_atomdb(local_persistence_config, local_context);
+                local_persistence = create_basic_atomdb(local_persistence_config);
             }
-            string peer_context = peer_config.at_path("context").get_or<string>("");
-            remote_peers[uid] = make_shared<RemoteAtomDBPeer>(
-                create_basic_atomdb(peer_config, peer_context), local_persistence, uid);
+            remote_peers[uid] =
+                make_shared<RemoteAtomDBPeer>(create_basic_atomdb(peer_config), local_persistence, uid);
         }
 
         atomdb = make_shared<RemoteAtomDB>(remote_peers);
@@ -94,7 +91,7 @@ shared_ptr<AtomDB> AtomDBFactory::create_composite_atomdb(const JsonConfig& conf
         // The backend AtomDB in AdapterDB could be RemoteAtomDB ?
         auto atomdb_backend_config =
             config.at_path("adapterdb.atomdb_backend").get_or<JsonConfig>(JsonConfig());
-        auto basic_atomdb = create_basic_atomdb(atomdb_backend_config, context);
+        auto basic_atomdb = create_basic_atomdb(atomdb_backend_config);
         atomdb = make_shared<AdapterDB>(config, basic_atomdb);
     } else {
         RAISE_ERROR("AtomDBFactory: '" + atomdb_type + "' is not a composite AtomDB type");

--- a/src/atomdb/AtomDBFactory.h
+++ b/src/atomdb/AtomDBFactory.h
@@ -26,7 +26,16 @@ namespace atomdb {
 class AtomDBFactory {
    public:
     /**
-     * @brief Creates a AtomDB and wraps it with ProtectedAtomDB when is applyable.
+     * @brief Creates an AtomDB from config and wraps it with ProtectedAtomDB when applicable.
+     *
+     * @param config AtomDB configuration. Required key: `"type"` (`redismongodb`, `morkdb`,
+     *        `inmemorydb`, `remotedb`, or `adapterdb`).
+     *
+     * Breaking change: `create()` no longer takes a `context` argument. Redis/Mongo namespace
+     * isolation is now per backend via optional `JsonConfig["prefix"]` on that backend's
+     * config (`redismongodb` / `morkdb`, including each remotedb peer and
+     * `adapterdb.atomdb_backend`). The prefix is prepended to Redis keys and MongoDB database
+     * and collection names (e.g. `"test_"` yields DB `test_das`). Omit it for the default names.
      */
     static shared_ptr<AtomDB> create(const JsonConfig& config);
 

--- a/src/atomdb/AtomDBFactory.h
+++ b/src/atomdb/AtomDBFactory.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <string>
 
 #include "AtomDB.h"
 #include "JsonConfig.h"
@@ -29,15 +28,14 @@ class AtomDBFactory {
     /**
      * @brief Creates a AtomDB and wraps it with ProtectedAtomDB when is applyable.
      */
-    static shared_ptr<AtomDB> create(const JsonConfig& config, const string& context = "");
+    static shared_ptr<AtomDB> create(const JsonConfig& config);
 
    private:
     // Supported types: redismongodb, morkdb, inmemorydb.
-    static shared_ptr<AtomDB> create_basic_atomdb(const JsonConfig& config, const string& context = "");
+    static shared_ptr<AtomDB> create_basic_atomdb(const JsonConfig& config);
 
     // Supported types: remotedb, adapterdb.
-    static shared_ptr<AtomDB> create_composite_atomdb(const JsonConfig& config,
-                                                      const string& context = "");
+    static shared_ptr<AtomDB> create_composite_atomdb(const JsonConfig& config);
 
     /**
      * @brief Applies protection wrapping when enabled.

--- a/src/atomdb/adapterdb/AdapterDB.cc
+++ b/src/atomdb/adapterdb/AdapterDB.cc
@@ -232,7 +232,10 @@ size_t AdapterDB::atom_count() const {
 // ==============================
 
 string AdapterDB::mongodb_db_name() const {
-    return RedisMongoDB::MONGODB_DB_NAME.empty() ? MONGODB_DB_NAME : RedisMongoDB::MONGODB_DB_NAME;
+    if (auto redis_mongo = dynamic_pointer_cast<RedisMongoDB>(this->atomdb_backend)) {
+        return redis_mongo->MONGODB_DB_NAME;
+    }
+    return MONGODB_DB_NAME;
 }
 
 void AdapterDB::initialize(bool skip_atomdb_backend_empty) {

--- a/src/atomdb/adapterdb/AdapterDB.cc
+++ b/src/atomdb/adapterdb/AdapterDB.cc
@@ -13,6 +13,7 @@
 #include "PostgresMappingStrategy.h"
 #include "PostgresWrapper.h"
 #include "Processor.h"
+#include "RedisMongoDB.h"
 #include "Utils.h"
 #include "processor/ThreadPool.h"
 
@@ -31,8 +32,8 @@ string AdapterDB::MONGODB_ADAPTER_COLLECTION_NAME = "adapterdb";
 //  Construction / destruction
 // ==============================
 
-AdapterDB::AdapterDB(const JsonConfig& config, std::shared_ptr<AtomDB> backend, const string& context)
-    : context(context), config(config), atomdb_backend(backend) {
+AdapterDB::AdapterDB(const JsonConfig& config, std::shared_ptr<AtomDB> backend)
+    : config(config), atomdb_backend(backend) {
     this->initialize(true);
 }
 
@@ -230,7 +231,9 @@ size_t AdapterDB::atom_count() const {
 //  Private
 // ==============================
 
-string AdapterDB::mongodb_db_name() const { return this->context + MONGODB_DB_NAME; }
+string AdapterDB::mongodb_db_name() const {
+    return RedisMongoDB::MONGODB_DB_NAME.empty() ? MONGODB_DB_NAME : RedisMongoDB::MONGODB_DB_NAME;
+}
 
 void AdapterDB::initialize(bool skip_atomdb_backend_empty) {
     this->validate_adapterdb_type();

--- a/src/atomdb/adapterdb/AdapterDB.h
+++ b/src/atomdb/adapterdb/AdapterDB.h
@@ -34,7 +34,7 @@ inline AdapterDbType parse_adapter_db_type(const string& value) {
 
 class AdapterDB : public AtomDB {
    public:
-    AdapterDB(const JsonConfig& config, shared_ptr<AtomDB> backend, const string& context = "");
+    AdapterDB(const JsonConfig& config, shared_ptr<AtomDB> backend);
     ~AdapterDB() override;
 
     static const string MONGODB_DB_NAME;
@@ -121,7 +121,6 @@ class AdapterDB : public AtomDB {
 
    private:
     AdapterDbType adapter_type;
-    string context;
     JsonConfig config;
     shared_ptr<AtomDB> atomdb_backend;
     atomic<bool> backend_ready{false};

--- a/src/atomdb/adapterdb/BUILD
+++ b/src/atomdb/adapterdb/BUILD
@@ -17,6 +17,7 @@ cc_library(
     includes = ["."],
     deps = [
         "//atomdb",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//commons:commons_lib",
         "//commons/atoms:atoms_lib",
         "//db_adapter:db_adapter_lib",

--- a/src/atomdb/adapterdb/README.md
+++ b/src/atomdb/adapterdb/README.md
@@ -121,7 +121,6 @@ feature as f WHERE f.feature_id<=500;
             {
                 "uid": "peer1",
                 "type": "redismongodb",
-                "context": "remotedb_test_peer1_",
                 "mongodb": {
                     "endpoint": "localhost:40021",
                     "username": "admin",
@@ -133,7 +132,6 @@ feature as f WHERE f.feature_id<=500;
                 },
                 "local_persistence": {
                     "type": "morkdb",
-                    "context": "remotedb_test_peer1_local_",
                     "mongodb": {
                         "endpoint": "localhost:40021",
                         "username": "admin",
@@ -147,10 +145,8 @@ feature as f WHERE f.feature_id<=500;
             {
                 "uid": "peer2",
                 "type": "inmemorydb",
-                "context": "remotedb_test_peer2_",
                 "local_persistence": {
-                    "type": "inmemorydb",
-                    "context": "remotedb_test_peer2_local_"
+                    "type": "inmemorydb"
                 }
             }
         ]

--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -147,7 +147,7 @@ shared_ptr<InMemoryDB::Tries> InMemoryDB::make_tries() {
     return tries;
 }
 
-InMemoryDB::InMemoryDB(const string& context) : context_(context), tries_(make_tries()) {}
+InMemoryDB::InMemoryDB() : tries_(make_tries()) {}
 
 InMemoryDB::~InMemoryDB() = default;
 

--- a/src/atomdb/inmemorydb/InMemoryDB.h
+++ b/src/atomdb/inmemorydb/InMemoryDB.h
@@ -44,7 +44,7 @@ namespace atomdb {
  */
 class InMemoryDB : public AtomDB {
    public:
-    InMemoryDB(const string& context = "");
+    InMemoryDB();
     ~InMemoryDB();
 
     bool allow_nested_indexing() override;
@@ -144,7 +144,6 @@ class InMemoryDB : public AtomDB {
     vector<string> match_pattern_index_schema_unlocked(const Link* link);
     void add_pattern_index_schema(const string& tokens, const vector<vector<string>>& index_entries);
 
-    string context_;
     // Serializes mutations across the three tries. Reads never take it.
     mutable mutex write_mutex_;
     shared_ptr<Tries> tries_;

--- a/src/atomdb/morkdb/MorkDB.cc
+++ b/src/atomdb/morkdb/MorkDB.cc
@@ -130,10 +130,7 @@ string MorkClient::url_encode(const string& value) {
 }
 // <--
 
-// --> MorkDB : RedisMongoDB(context, skip_redis = true)
-MorkDB::MorkDB(const string& context, const JsonConfig& config) : RedisMongoDB(context, true, config) {
-    mork_setup(config);
-}
+MorkDB::MorkDB(const JsonConfig& config) : RedisMongoDB(config) { mork_setup(config); }
 
 MorkDB::~MorkDB() {}
 

--- a/src/atomdb/morkdb/MorkDB.h
+++ b/src/atomdb/morkdb/MorkDB.h
@@ -40,7 +40,7 @@ class MorkClient {
 
 class MorkDB : public RedisMongoDB {
    public:
-    MorkDB(const string& context, const JsonConfig& config);
+    MorkDB(const JsonConfig& config);
     ~MorkDB();
 
     bool allow_nested_indexing() override;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -40,13 +40,13 @@ string RedisMongoDB::MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME;
 string RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::size];
 uint RedisMongoDB::MONGODB_CHUNK_SIZE;
 
-RedisMongoDB::RedisMongoDB(const string& context, bool skip_redis, const JsonConfig& config)
-    : context(context),
-      skip_redis_(skip_redis),
+RedisMongoDB::RedisMongoDB(const JsonConfig& config)
+    : skip_redis_(config.at_path("type").get_or<string>("") != "redismongodb"),
       composite_type_enabled_(config.at_path("composite_type_enabled").get_or<bool>(true)),
       cluster_flag(false),
       protection_mode(atomdb_api_types::ProtectionMode::PROTECTED) {
-    initialize_statics(context);
+    string prefix = config.at_path("prefix").get_or<string>("");
+    initialize_statics(prefix);
     mongodb_setup(config);
     load_protection_mode();
     load_pattern_index_schema();

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -27,18 +27,27 @@ using namespace atomdb;
 using namespace commons;
 using namespace atoms;
 
-string RedisMongoDB::REDIS_PATTERNS_PREFIX;
-string RedisMongoDB::REDIS_OUTGOING_PREFIX;
-string RedisMongoDB::REDIS_INCOMING_PREFIX;
 uint RedisMongoDB::REDIS_CHUNK_SIZE;
-string RedisMongoDB::MONGODB_DB_NAME;
-string RedisMongoDB::MONGODB_NODES_COLLECTION_NAME;
-string RedisMongoDB::MONGODB_LINKS_COLLECTION_NAME;
-string RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME;
-string RedisMongoDB::MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME;
-string RedisMongoDB::MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME;
 string RedisMongoDB::MONGODB_FIELD_NAME[MONGODB_FIELD::size];
 uint RedisMongoDB::MONGODB_CHUNK_SIZE;
+
+void RedisMongoDB::initialize_namespace(const string& prefix) {
+    REDIS_PATTERNS_PREFIX = prefix + "patterns";
+    REDIS_OUTGOING_PREFIX = prefix + "outgoing_set";
+    REDIS_INCOMING_PREFIX = prefix + "incoming_set";
+    REDIS_CHUNK_SIZE = 10000;
+    MONGODB_DB_NAME = prefix + "das";
+    MONGODB_NODES_COLLECTION_NAME = prefix + "nodes";
+    MONGODB_LINKS_COLLECTION_NAME = prefix + "links";
+    MONGODB_CONFIG_COLLECTION_NAME = prefix + "config";
+    MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME = prefix + "pattern_index_schema";
+    MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME = prefix + "access_permissions";
+    MONGODB_FIELD_NAME[MONGODB_FIELD::ID] = "_id";
+    MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS] = "targets";
+    MONGODB_FIELD_NAME[MONGODB_FIELD::NAME] = "name";
+    MONGODB_FIELD_NAME[MONGODB_FIELD::NAMED_TYPE] = "named_type";
+    MONGODB_CHUNK_SIZE = 1000;
+}
 
 RedisMongoDB::RedisMongoDB(const JsonConfig& config)
     : skip_redis_(config.at_path("type").get_or<string>("") != "redismongodb"),
@@ -46,7 +55,7 @@ RedisMongoDB::RedisMongoDB(const JsonConfig& config)
       cluster_flag(false),
       protection_mode(atomdb_api_types::ProtectionMode::PROTECTED) {
     string prefix = config.at_path("prefix").get_or<string>("");
-    initialize_statics(prefix);
+    initialize_namespace(prefix);
     mongodb_setup(config);
     load_protection_mode();
     load_pattern_index_schema();
@@ -1307,7 +1316,7 @@ void RedisMongoDB::load_protection_mode() {
                                 : atomdb_api_types::ProtectionMode::UNPROTECTED;
 }
 
-string RedisMongoDB::protection_config_document_id() {
+string RedisMongoDB::protection_config_document_id() const {
     return Hasher::plain_string_hash(MONGODB_CONFIG_COLLECTION_NAME);
 }
 

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -41,36 +41,21 @@ class RedisMongoDB : public AtomDB {
         const atomdb_api_types::PublicKey& public_key) const override;
     atomdb_api_types::ProtectionMode get_protection_mode() const override;
 
-    static string REDIS_PATTERNS_PREFIX;
-    static string REDIS_OUTGOING_PREFIX;
-    static string REDIS_INCOMING_PREFIX;
+    // Redis key prefixes and MongoDB database/collection names are per-instance so two
+    // backends (e.g. remotedb peers) can use different JsonConfig["prefix"] values.
+    string REDIS_PATTERNS_PREFIX;
+    string REDIS_OUTGOING_PREFIX;
+    string REDIS_INCOMING_PREFIX;
+    string MONGODB_DB_NAME;
+    string MONGODB_NODES_COLLECTION_NAME;
+    string MONGODB_LINKS_COLLECTION_NAME;
+    string MONGODB_CONFIG_COLLECTION_NAME;
+    string MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME;
+    string MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME;
+
     static uint REDIS_CHUNK_SIZE;
-    static string MONGODB_DB_NAME;
-    static string MONGODB_NODES_COLLECTION_NAME;
-    static string MONGODB_LINKS_COLLECTION_NAME;
-    static string MONGODB_CONFIG_COLLECTION_NAME;
-    static string MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME;
-    static string MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME;
     static string MONGODB_FIELD_NAME[MONGODB_FIELD::size];
     static uint MONGODB_CHUNK_SIZE;
-
-    static void initialize_statics(const string& prefix = "") {
-        REDIS_PATTERNS_PREFIX = prefix + "patterns";
-        REDIS_OUTGOING_PREFIX = prefix + "outgoing_set";
-        REDIS_INCOMING_PREFIX = prefix + "incoming_set";
-        REDIS_CHUNK_SIZE = 10000;
-        MONGODB_DB_NAME = prefix + "das";
-        MONGODB_NODES_COLLECTION_NAME = prefix + "nodes";
-        MONGODB_LINKS_COLLECTION_NAME = prefix + "links";
-        MONGODB_CONFIG_COLLECTION_NAME = prefix + "config";
-        MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME = prefix + "pattern_index_schema";
-        MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME = prefix + "access_permissions";
-        MONGODB_FIELD_NAME[MONGODB_FIELD::ID] = "_id";
-        MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS] = "targets";
-        MONGODB_FIELD_NAME[MONGODB_FIELD::NAME] = "name";
-        MONGODB_FIELD_NAME[MONGODB_FIELD::NAMED_TYPE] = "named_type";
-        MONGODB_CHUNK_SIZE = 1000;
-    }
 
     // HandleDecoder interface
     shared_ptr<Atom> get_atom(const string& handle);
@@ -215,7 +200,8 @@ class RedisMongoDB : public AtomDB {
 
     void load_pattern_index_schema();
     void load_protection_mode();
-    static string protection_config_document_id();
+    string protection_config_document_id() const;
+    void initialize_namespace(const string& prefix);
     vector<string> match_pattern_index_schema(const Link* link);
     vector<vector<string>> index_entries_combinations(unsigned int arity);
 

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -54,17 +54,17 @@ class RedisMongoDB : public AtomDB {
     static string MONGODB_FIELD_NAME[MONGODB_FIELD::size];
     static uint MONGODB_CHUNK_SIZE;
 
-    static void initialize_statics(const string& context = "") {
-        REDIS_PATTERNS_PREFIX = context + "patterns";
-        REDIS_OUTGOING_PREFIX = context + "outgoing_set";
-        REDIS_INCOMING_PREFIX = context + "incoming_set";
+    static void initialize_statics(const string& prefix = "") {
+        REDIS_PATTERNS_PREFIX = prefix + "patterns";
+        REDIS_OUTGOING_PREFIX = prefix + "outgoing_set";
+        REDIS_INCOMING_PREFIX = prefix + "incoming_set";
         REDIS_CHUNK_SIZE = 10000;
-        MONGODB_DB_NAME = context + "das";
-        MONGODB_NODES_COLLECTION_NAME = context + "nodes";
-        MONGODB_LINKS_COLLECTION_NAME = context + "links";
-        MONGODB_CONFIG_COLLECTION_NAME = context + "config";
-        MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME = context + "pattern_index_schema";
-        MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME = context + "access_permissions";
+        MONGODB_DB_NAME = prefix + "das";
+        MONGODB_NODES_COLLECTION_NAME = prefix + "nodes";
+        MONGODB_LINKS_COLLECTION_NAME = prefix + "links";
+        MONGODB_CONFIG_COLLECTION_NAME = prefix + "config";
+        MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME = prefix + "pattern_index_schema";
+        MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME = prefix + "access_permissions";
         MONGODB_FIELD_NAME[MONGODB_FIELD::ID] = "_id";
         MONGODB_FIELD_NAME[MONGODB_FIELD::TARGETS] = "targets";
         MONGODB_FIELD_NAME[MONGODB_FIELD::NAME] = "name";
@@ -158,10 +158,9 @@ class RedisMongoDB : public AtomDB {
 
    protected:
     friend class AtomDBFactory;
-    RedisMongoDB(const string& context, bool skip_redis, const JsonConfig& config);
+    RedisMongoDB(const JsonConfig& config);
 
    private:
-    string context;
     bool skip_redis_;
     bool composite_type_enabled_;
     bool cluster_flag;

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -25,8 +25,8 @@ RemoteAtomDBPeer::RemoteAtomDBPeer(shared_ptr<AtomDB> remote_atomdb,
                                    shared_ptr<AtomDB> local_persistence,
                                    const string& uid)
     : uid_(uid),
-      write_buffer_(make_shared<InMemoryDB>(uid + "_wb")),
-      read_cache_(make_shared<InMemoryDB>(uid + "_rc")),
+      write_buffer_(make_shared<InMemoryDB>()),
+      read_cache_(make_shared<InMemoryDB>()),
       atomdb_(remote_atomdb),
       local_persistence_(local_persistence) {
     if (local_persistence_ &&
@@ -709,8 +709,8 @@ void RemoteAtomDBPeer::release_cache(bool /*persist_to_local*/, bool /*persist_e
         // to it) finish — see quiescence wait below.
         old_write_buffer = write_buffer_;
         old_read_cache = read_cache_;
-        write_buffer_ = make_shared<InMemoryDB>(uid_ + "_wb");
-        read_cache_ = make_shared<InMemoryDB>(uid_ + "_rc");
+        write_buffer_ = make_shared<InMemoryDB>();
+        read_cache_ = make_shared<InMemoryDB>();
         fetched_link_templates_.clear();
     }
 

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -114,6 +114,7 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
 
     const string& get_uid() const { return uid_; }
     bool is_readonly() const { return local_persistence_ == nullptr; }
+    shared_ptr<AtomDB> get_remote_atomdb() const { return atomdb_; }
 
     /**
      * Delegates the lookup to the remote AtomDB; local persistence is not consulted.

--- a/src/main/db_loader.cc
+++ b/src/main/db_loader.cc
@@ -46,10 +46,10 @@ void ctrl_c_handler(int) {
 int main(int argc, char* argv[]) {
     // make run-db-loader OPTIONS="--config=config/das.json"
     //
-    // make run-db-loader OPTIONS="--config=config/das.json --context=test_1m_ --threads=8
+    // make run-db-loader OPTIONS="--config=config/das.json --threads=8
     // --links=1000000 --arity=3 --chunk=5000"
     //
-    // make run-db-loader OPTIONS="--config=config/das.json --context=test_1m_ --file=/path/to/file.metta
+    // make run-db-loader OPTIONS="--config=config/das.json --file=/path/to/file.metta
     // --threads=8 --chunk=5000"
 
     string config_path = flag_from_argv_or(argc, argv, "--config=", "");
@@ -58,7 +58,6 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    string context = flag_from_argv_or(argc, argv, "--context=", "");
     string file_path = flag_from_argv_or(argc, argv, "--file=", "");
 
     int num_threads = Utils::string_to_int(flag_from_argv_or(argc, argv, "--threads=", "8"));
@@ -69,7 +68,7 @@ int main(int argc, char* argv[]) {
     JsonConfig json_config = JsonConfigParser::load(config_path);
     auto atomdb_config = json_config.at_path("atomdb").get_or<JsonConfig>(JsonConfig());
 
-    auto atomdb = AtomDBFactory::create(atomdb_config, context);
+    auto atomdb = AtomDBFactory::create(atomdb_config);
 
     signal(SIGINT, &ctrl_c_handler);
     signal(SIGTERM, &ctrl_c_handler);

--- a/src/scripts/test_all_setup.sh
+++ b/src/scripts/test_all_setup.sh
@@ -15,7 +15,7 @@ DAS_MORK_HOSTNAME=0.0.0.0
 DAS_MORK_PORT=40022
 
 REDIS_IMAGE=redis:7.2.3-alpine
-MONGODB_IMAGE=mongodb/mongodb-community-server:8.2-ubuntu2204
+MONGODB_IMAGE=mongodb/mongodb-community-server:8.0.4-ubuntu2204
 METTA_LOADER_IMAGE=trueagi/das:1.0.0-metta-parser
 MORK_IMAGE=trueagi/das:mork-server-1.1.0
 MORK_LOADER_IMAGE=trueagi/das:mork-loader-1.1.0

--- a/src/scripts/test_all_setup.sh
+++ b/src/scripts/test_all_setup.sh
@@ -15,7 +15,7 @@ DAS_MORK_HOSTNAME=0.0.0.0
 DAS_MORK_PORT=40022
 
 REDIS_IMAGE=redis:7.2.3-alpine
-MONGODB_IMAGE=mongodb/mongodb-community-server:8.0.4-ubuntu2204
+MONGODB_IMAGE=mongodb/mongodb-community-server:8.2-ubuntu2204
 METTA_LOADER_IMAGE=trueagi/das:1.0.0-metta-parser
 MORK_IMAGE=trueagi/das:mork-server-1.1.0
 MORK_LOADER_IMAGE=trueagi/das:mork-loader-1.1.0

--- a/src/tests/assets/adapterdb_config.json
+++ b/src/tests/assets/adapterdb_config.json
@@ -45,7 +45,6 @@
                 "uid": "peer1",
                 "type": "redismongodb",
                 "composite_type_enabled": true,
-                "context": "remotedb_test_peer1_",
                 "mongodb": {
                     "endpoint": "localhost:40021",
                     "username": "admin",
@@ -58,7 +57,6 @@
                 "local_persistence": {
                     "type": "morkdb",
                     "composite_type_enabled": true,
-                    "context": "remotedb_test_peer1_local_",
                     "mongodb": {
                         "endpoint": "localhost:40021",
                         "username": "admin",
@@ -72,10 +70,8 @@
             {
                 "uid": "peer2",
                 "type": "inmemorydb",
-                "context": "remotedb_test_peer2_",
                 "local_persistence": {
-                    "type": "inmemorydb",
-                    "context": "remotedb_test_peer2_local_"
+                    "type": "inmemorydb"
                 }
             }
         ]

--- a/src/tests/assets/adapterdb_config.json
+++ b/src/tests/assets/adapterdb_config.json
@@ -44,6 +44,7 @@
             {
                 "uid": "peer1",
                 "type": "redismongodb",
+                "prefix": "remotedb_test_peer1_",
                 "composite_type_enabled": true,
                 "mongodb": {
                     "endpoint": "localhost:40021",
@@ -56,6 +57,7 @@
                 },
                 "local_persistence": {
                     "type": "morkdb",
+                    "prefix": "remotedb_test_peer1_local_",
                     "composite_type_enabled": true,
                     "mongodb": {
                         "endpoint": "localhost:40021",

--- a/src/tests/assets/remotedb_config.json
+++ b/src/tests/assets/remotedb_config.json
@@ -3,10 +3,9 @@
         {
             "uid": "peer1",
             "type": "inmemorydb",
-            "context": "remotedb_test_peer1_",
             "local_persistence": {
                 "type": "morkdb",
-                "context": "remotedb_test_peer1_local_",
+                "prefix": "remote_atomdb_test_",
                 "morkdb": {
                     "endpoint": "localhost:40022"
                 },
@@ -19,8 +18,7 @@
         },
         {
             "uid": "peer2",
-            "type": "inmemorydb",
-            "context": "remotedb_test_peer2_"
+            "type": "inmemorydb"
         }
     ]
 }

--- a/src/tests/assets/remotedb_config_single.json
+++ b/src/tests/assets/remotedb_config_single.json
@@ -3,8 +3,8 @@
         {
             "uid": "single_peer",
             "type": "redismongodb",
+            "prefix": "remote_atomdb_test_",
             "composite_type_enabled": true,
-            "context": "remotedb_test_single_peer_",
             "redis": {
                 "endpoint": "localhost:40020",
                 "cluster": "false"
@@ -15,8 +15,7 @@
                 "password": "admin"
             },
             "local_persistence": {
-                "type": "inmemorydb",
-                "context": "remotedb_test_single_peer_local_"
+                "type": "inmemorydb"
             }
         }
     ]

--- a/src/tests/benchmark/atomdb/atomdb_main.cc
+++ b/src/tests/benchmark/atomdb/atomdb_main.cc
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include "AtomDB.h"
+#include "AtomDBFactory.h"
 #include "JsonConfig.h"
-#include "RedisMongoDB.h"
 #include "Utils.h"
 #include "atomdb_operations.h"
 #include "atomdb_runner.h"
@@ -48,8 +48,6 @@ JsonConfig benchmark_atomdb_config() {
 mutex global_mutex;
 map<string, Metrics> global_metrics;
 
-void setup() { RedisMongoDB::initialize_statics(); }
-
 shared_ptr<AtomDB> factory_create_atomdb(string type, const JsonConfig& atomdb_config) {
     JsonConfig config = atomdb_config;
     config["type"] = type;
@@ -70,7 +68,6 @@ int main(int argc, char** argv) {
     int iterations = stoi(argv[6]);
     string timestamp = argv[7];
 
-    setup();
     auto atomdb = factory_create_atomdb(atomdb_type, benchmark_atomdb_config());
 
     auto worker = [&](int tid, shared_ptr<AtomDB> atomdb) {

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -956,6 +956,7 @@ cc_test(
         "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//atomdb/remotedb:remotedb_lib",
         "//commons/atoms:atoms_lib",
+        "//tests/cpp/test_commons:test_atomdb_json_config",
         "@com_github_google_googletest//:gtest",
     ],
 )

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -774,7 +774,9 @@ cc_test(
     ],
     linkstatic = 1,
     deps = [
+        "//atomdb:atomdb_factory",
         "//atomdb:atomdb_singleton",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//tests/cpp/test_commons:mock_animals_data_lib",
         "//tests/cpp/test_commons:test_atomdb_json_config",
         "@com_github_google_googletest//:gtest_main",
@@ -803,7 +805,9 @@ cc_test(
     ],
     linkstatic = 1,
     deps = [
+        "//atomdb:atomdb_factory",
         "//atomdb:atomdb_singleton",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//tests/cpp/test_commons:mock_animals_data_lib",
         "//tests/cpp/test_commons:test_atomdb_json_config",
         "@com_github_google_googletest//:gtest_main",
@@ -829,6 +833,7 @@ cc_test(
     linkstatic = 1,
     deps = [
         "//atomdb:atomdb_singleton",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//tests/cpp/test_commons:mock_animals_data_lib",
         "//tests/cpp/test_commons:test_atomdb_json_config",
         "@com_github_google_googletest//:gtest",
@@ -891,6 +896,7 @@ cc_test(
         "//atomdb/adapterdb:adapterdb_lib",
         "//atomdb/inmemorydb:inmemorydb_lib",
         "//atomdb/morkdb:morkdb_lib",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//atomdb/remotedb:remotedb_lib",
         "//tests/cpp/test_commons:test_atomdb_json_config",
         "@com_github_google_googletest//:gtest_main",
@@ -916,6 +922,7 @@ cc_test(
     linkstatic = 1,
     deps = [
         "//atomdb:atomdb_lib",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//commons/atoms:atoms_lib",
         "//tests/cpp/test_commons:test_atomdb_json_config",
         "@com_github_google_googletest//:gtest_main",
@@ -946,6 +953,7 @@ cc_test(
         "//atomdb:atomdb_factory",
         "//atomdb:protected_atomdb",
         "//atomdb/inmemorydb:inmemorydb_lib",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//atomdb/remotedb:remotedb_lib",
         "//commons/atoms:atoms_lib",
         "@com_github_google_googletest//:gtest",
@@ -1014,6 +1022,7 @@ cc_test(
     linkstatic = 1,
     deps = [
         "//atomdb:atomdb_singleton",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//db_adapter:db_adapter_lib",
         "//tests/cpp/test_commons:test_atomdb_json_config",
         "@com_github_google_googletest//:gtest_main",
@@ -1072,7 +1081,9 @@ cc_test(
     ],
     linkstatic = 1,
     deps = [
+        "//atomdb:atomdb_factory",
         "//atomdb:atomdb_singleton",
+        "//atomdb/redis_mongodb:redis_mongodb_lib",
         "//db_adapter:db_adapter_lib",
         "//tests/cpp/test_commons:test_atomdb_json_config",
         "@com_github_google_googletest//:gtest_main",

--- a/src/tests/cpp/adapterdb_test.cc
+++ b/src/tests/cpp/adapterdb_test.cc
@@ -2,23 +2,18 @@
 
 #include <gtest/gtest.h>
 
-#include <bsoncxx/builder/basic/document.hpp>
 #include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <mongocxx/client.hpp>
-#include <mongocxx/uri.hpp>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
 #include "AtomDBFactory.h"
-#include "AtomDBSingleton.h"
 #include "Hasher.h"
 #include "Link.h"
 #include "Merger.h"
-#include "MongoInitializer.h"
 #include "MorkDB.h"
 #include "Node.h"
 #include "RedisMongoDB.h"
@@ -58,11 +53,10 @@ void seed_mork_adapter_test_data() {
 
 class AdapterDBTestBase : public ::testing::Test {
    protected:
-    static constexpr const char* back_context = "adapter_test";
     shared_ptr<RedisMongoDB> backend;
 
     void SetUpBackend() {
-        auto atomdb = AtomDBFactory::create(test_atomdb_json_config(), back_context);
+        auto atomdb = AtomDBFactory::create(test_atomdb_json_config("redismongodb", "adapterdb_test_"));
         backend = dynamic_pointer_cast<RedisMongoDB>(atomdb);
         ASSERT_NE(backend, nullptr);
     }
@@ -83,6 +77,7 @@ class AdapterDBTestBase : public ::testing::Test {
             {"atomdb_backend",
              {
                  {"type", backend_type},
+                 {"prefix", "adapterdb_test_"},
                  {"redis", {{"endpoint", "localhost:40020"}, {"cluster", false}}},
                  {"mongodb",
                   {{"endpoint", "localhost:40021"}, {"username", "admin"}, {"password", "admin"}}},
@@ -96,82 +91,17 @@ class AdapterDBTestBase : public ::testing::Test {
                                          const string& adapter_type,
                                          const nlohmann::json& db_credentials,
                                          const string& backend_type = "morkdb",
-                                         bool reuse_mongodb = true,
-                                         const string& context = back_context) {
+                                         bool reuse_mongodb = true) {
         auto config = build_adapter_config(
             mapping_path, adapter_type, db_credentials, backend_type, reuse_mongodb);
         shared_ptr<AtomDB> atomdb_backend = backend;
-        if (!atomdb_backend || context != back_context) {
-            atomdb_backend = AtomDBFactory::create(test_atomdb_json_config(), context);
+        if (!atomdb_backend) {
+            atomdb_backend =
+                AtomDBFactory::create(test_atomdb_json_config("redismongodb", "adapterdb_test_"));
         }
-        return make_shared<AdapterDB>(config, atomdb_backend, context);
-    }
-
-    static bool mapping_metadata_exists(const string& context, const string& context_id) {
-        MongoInitializer::initialize();
-        mongocxx::client client{mongocxx::uri{"mongodb://admin:admin@localhost:40021"}};
-        auto collection =
-            client[context + AdapterDB::MONGODB_DB_NAME][AdapterDB::MONGODB_ADAPTER_COLLECTION_NAME];
-        auto reply = collection.find_one(
-            bsoncxx::builder::basic::make_document(bsoncxx::builder::basic::kvp("_id", context_id)));
-        return reply != bsoncxx::v_noabi::stdx::nullopt;
-    }
-
-    static void drop_context_database(const string& context) {
-        MongoInitializer::initialize();
-        mongocxx::client client{mongocxx::uri{"mongodb://admin:admin@localhost:40021"}};
-        client[context + AdapterDB::MONGODB_DB_NAME].drop();
+        return make_shared<AdapterDB>(config, atomdb_backend);
     }
 };
-
-class AdapterDBContextIsolationTest : public AdapterDBTestBase {
-   protected:
-    string mapping_path;
-    string context_a;
-    string context_b;
-
-    void TearDown() override {
-        remove(mapping_path.c_str());
-        drop_context_database(context_a);
-        drop_context_database(context_b);
-    }
-};
-
-TEST_F(AdapterDBContextIsolationTest, DistinctContextsIsolateMappingMetadata) {
-    string suffix = to_string(Utils::get_current_time_millis());
-    mapping_path = "/tmp/adapterdb_context_isolation_" + suffix + ".sql";
-    string mapping_content = "-- context isolation " + suffix +
-                             "\n"
-                             "SELECT o.organism_id as public_organism__organism_id,\n"
-                             "       o.genus as public_organism__genus\n"
-                             "FROM public.organism as o WHERE o.organism_id=1;\n";
-    {
-        ofstream file(mapping_path);
-        file << mapping_content;
-    }
-    string context_id = Hasher::plain_string_hash(mapping_content);
-    context_a = "iso_a_" + suffix + "_";
-    context_b = "iso_b_" + suffix + "_";
-
-    nlohmann::json creds = {{"host", "localhost"},
-                            {"port", 5433},
-                            {"username", "postgres"},
-                            {"password", "test"},
-                            {"database", "postgres_wrapper_test"}};
-
-    ASSERT_FALSE(mapping_metadata_exists(context_a, context_id));
-    ASSERT_FALSE(mapping_metadata_exists(context_b, context_id));
-
-    auto adapter_a = create_adapter(mapping_path, "postgres", creds, "morkdb", true, context_a);
-    ASSERT_NE(adapter_a, nullptr);
-    EXPECT_TRUE(mapping_metadata_exists(context_a, context_id));
-    EXPECT_FALSE(mapping_metadata_exists(context_b, context_id));
-
-    auto adapter_b = create_adapter(mapping_path, "postgres", creds, "morkdb", true, context_b);
-    ASSERT_NE(adapter_b, nullptr);
-    EXPECT_TRUE(mapping_metadata_exists(context_a, context_id));
-    EXPECT_TRUE(mapping_metadata_exists(context_b, context_id));
-}
 
 class AdapterDBTest : public AdapterDBTestBase, public ::testing::WithParamInterface<AdapterTestParams> {
    protected:

--- a/src/tests/cpp/atomdb_factory_test.cc
+++ b/src/tests/cpp/atomdb_factory_test.cc
@@ -36,24 +36,21 @@ JsonConfig remotedb_config_with_inmemory_peers() {
     nlohmann::json json;
     json["type"] = "remotedb";
     json["remote_peers"] = nlohmann::json::array(
-        {{{"uid", "peer1"}, {"type", "inmemorydb"}, {"context", "factory_remote_peer1_"}},
-         {{"uid", "peer2"},
-          {"type", "inmemorydb"},
-          {"context", "factory_remote_peer2_"},
-          {"local_persistence", {{"type", "inmemorydb"}, {"context", "factory_remote_peer2_local_"}}}}});
+        {{{"uid", "peer1"}, {"type", "inmemorydb"}},
+         {{"uid", "peer2"}, {"type", "inmemorydb"}, {"local_persistence", {{"type", "inmemorydb"}}}}});
     return JsonConfig(json);
 }
 
 }  // namespace
 
 TEST(AtomDBFactoryTest, CreateInMemoryDB) {
-    auto db = AtomDBFactory::create(config_with_type("inmemorydb"), "factory_test_");
+    auto db = AtomDBFactory::create(config_with_type("inmemorydb"));
     ASSERT_NE(db, nullptr);
     EXPECT_NE(dynamic_pointer_cast<InMemoryDB>(db), nullptr);
 }
 
 TEST(AtomDBFactoryTest, CreateMorkDB) {
-    auto db = AtomDBFactory::create(test_atomdb_json_config("morkdb"), "factory_mork_create_");
+    auto db = AtomDBFactory::create(test_atomdb_json_config("morkdb", "atomdb_factory_test_"));
     ASSERT_NE(db, nullptr);
     EXPECT_NE(dynamic_pointer_cast<MorkDB>(db), nullptr);
 }
@@ -65,7 +62,7 @@ TEST(AtomDBFactoryTest, CreateRejectsMissingAndUnknownTypes) {
 }
 
 TEST(AtomDBFactoryTest, CreateRemoteAtomDBAssemblesPeers) {
-    auto db = AtomDBFactory::create(remotedb_config_with_inmemory_peers(), "");
+    auto db = AtomDBFactory::create(remotedb_config_with_inmemory_peers());
     ASSERT_NE(db, nullptr);
 
     auto remote_db = dynamic_pointer_cast<RemoteAtomDB>(db);
@@ -85,7 +82,7 @@ TEST(AtomDBFactoryTest, CreateRemoteAtomDBWithEmptyPeers) {
     config["type"] = "remotedb";
     config["remote_peers"] = nlohmann::json::array();
 
-    auto db = AtomDBFactory::create(config, "");
+    auto db = AtomDBFactory::create(config);
     ASSERT_NE(db, nullptr);
 
     auto remote_db = dynamic_pointer_cast<RemoteAtomDB>(db);
@@ -96,11 +93,10 @@ TEST(AtomDBFactoryTest, CreateRemoteAtomDBWithEmptyPeers) {
 TEST(AtomDBFactoryTest, CreateRemoteAtomDBRejectsPeerWithoutUid) {
     nlohmann::json json;
     json["type"] = "remotedb";
-    json["remote_peers"] = nlohmann::json::array(
-        {{{"type", "inmemorydb"}, {"context", "factory_remote_missing_uid_"}},
-         {{"uid", "peer_ok"}, {"type", "inmemorydb"}, {"context", "factory_remote_ok_"}}});
+    json["remote_peers"] =
+        nlohmann::json::array({{{"type", "inmemorydb"}}, {{"uid", "peer_ok"}, {"type", "inmemorydb"}}});
 
-    EXPECT_THROW(AtomDBFactory::create(JsonConfig(json), ""), runtime_error);
+    EXPECT_THROW(AtomDBFactory::create(JsonConfig(json)), runtime_error);
 }
 
 TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
@@ -109,7 +105,7 @@ TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
     missing_backend["adapterdb"] = nlohmann::json::object();
 
     // Missing adapterdb.atomdb_backend.type makes create_basic_atomdb fail via AtomDB::string_to_type.
-    EXPECT_THROW(AtomDBFactory::create(missing_backend, ""), runtime_error);
+    EXPECT_THROW(AtomDBFactory::create(missing_backend), runtime_error);
 
     // Valid adapterdb.atomdb_backend: factory constructs AdapterDB and delegates AtomDB ops.
     string mapping_path = "/tmp/atomdb_factory_adapterdb_mapping.metta";
@@ -140,10 +136,10 @@ TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
         {"database_credentials", {{"host", "localhost"}, {"port", 40032}}},
         {"persistence", {{"reuse_mongodb", true}}},
         {"export_metta_on_mapping", {{"enabled", false}, {"output_dir", "/tmp"}}},
-        {"atomdb_backend", test_atomdb_json_config("morkdb").get_json()},
+        {"atomdb_backend", test_atomdb_json_config("morkdb", "atomdb_factory_test_").get_json()},
     };
 
-    auto db = AtomDBFactory::create(JsonConfig(json), "factory_adapterdb_");
+    auto db = AtomDBFactory::create(JsonConfig(json));
     ASSERT_NE(db, nullptr);
 
     auto adapter_db = dynamic_pointer_cast<AdapterDB>(db);
@@ -159,7 +155,7 @@ TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
 }
 
 TEST(AtomDBFactoryTest, CreateInMemoryDBIsNotProtected) {
-    auto db = AtomDBFactory::create(config_with_type("inmemorydb"), "factory_unprotected_");
+    auto db = AtomDBFactory::create(config_with_type("inmemorydb"));
     ASSERT_NE(db, nullptr);
     EXPECT_EQ(db->get_protection_mode(), ProtectionMode::UNPROTECTED);
     EXPECT_EQ(dynamic_pointer_cast<ProtectedAtomDB>(db), nullptr);

--- a/src/tests/cpp/atomdbutils_test.cc
+++ b/src/tests/cpp/atomdbutils_test.cc
@@ -11,7 +11,7 @@ using namespace atoms;
 using namespace std;
 
 TEST(AtomDBTest, reachable_terminal_set) {
-    AtomDBSingleton::init(test_atomdb_json_config());
+    AtomDBSingleton::init(test_atomdb_json_config("redismongodb", "atomdbutils_test_"));
     auto db = AtomDBSingleton::get_instance();
 
     auto A = new Node("Symbol", "A");

--- a/src/tests/cpp/chain_operator_test.cc
+++ b/src/tests/cpp/chain_operator_test.cc
@@ -82,7 +82,7 @@ class ChainOperatorTestEnvironment : public ::testing::Environment {
     }
 
     void SetUp() override {
-        auto atomdb = new InMemoryDB("chain_operator_test_");
+        auto atomdb = new InMemoryDB();
         AtomDBSingleton::provide(shared_ptr<AtomDB>(atomdb));
         this->load_data();
     }

--- a/src/tests/cpp/inmemorydb_test.cc
+++ b/src/tests/cpp/inmemorydb_test.cc
@@ -27,7 +27,7 @@ using namespace std;
 
 class InMemoryDBTest : public ::testing::Test {
    protected:
-    void SetUp() override { db = make_shared<InMemoryDB>("inmemorydb_test_"); }
+    void SetUp() override { db = make_shared<InMemoryDB>(); }
 
     void TearDown() override {}
 

--- a/src/tests/cpp/morkdb_test.cc
+++ b/src/tests/cpp/morkdb_test.cc
@@ -21,7 +21,7 @@ using namespace std;
 class MorkDBTestEnvironment : public ::testing::Environment {
    public:
     void SetUp() override {
-        auto atomdb = new MorkDB("morkdb_test_", test_atomdb_json_config("morkdb"));
+        auto atomdb = new MorkDB(test_atomdb_json_config("morkdb", "morkdb_test_"));
         atomdb->drop_all();
         AtomDBSingleton::provide(shared_ptr<AtomDB>(atomdb));
         load_animals_data();
@@ -478,15 +478,15 @@ TEST_F(MorkDBTest, ReIndexPatterns) {
 }
 
 TEST(MorkDBSetupTest, RejectsMissingEndpoint) {
-    auto config = test_atomdb_json_config("morkdb");
+    auto config = test_atomdb_json_config("morkdb", "morkdb_test_");
     config["morkdb"].erase("endpoint");
-    EXPECT_THROW({ MorkDB db("setup_test_", config); }, runtime_error);
+    EXPECT_THROW({ MorkDB db(config); }, runtime_error);
 }
 
 TEST(MorkDBSetupTest, RejectsBlankEndpoint) {
-    auto config = test_atomdb_json_config("morkdb");
+    auto config = test_atomdb_json_config("morkdb", "morkdb_test_");
     config["morkdb"]["endpoint"] = "   ";
-    EXPECT_THROW({ MorkDB db("setup_test_", config); }, runtime_error);
+    EXPECT_THROW({ MorkDB db(config); }, runtime_error);
 }
 
 int main(int argc, char** argv) {

--- a/src/tests/cpp/morkdb_test.cc
+++ b/src/tests/cpp/morkdb_test.cc
@@ -449,7 +449,7 @@ TEST_F(MorkDBTest, ReIndexPatterns) {
     // Direct insertion into MongoDB
     auto inserted_count =
         db->upsert_documents({link_1_doc->value(), link_2_doc->value(), link_3_doc->value()},
-                             RedisMongoDB::MONGODB_LINKS_COLLECTION_NAME);
+                             db->MONGODB_LINKS_COLLECTION_NAME);
     EXPECT_EQ(inserted_count, 3);
 
     db->re_index_patterns();

--- a/src/tests/cpp/postgreswrapper_test.cc
+++ b/src/tests/cpp/postgreswrapper_test.cc
@@ -37,7 +37,9 @@ class SQLWrapperTestHelper : public SQLWrapper {
 
 class PostgresWrapperTestEnvironment : public ::testing::Environment {
    public:
-    void SetUp() override { AtomDBSingleton::init(test_atomdb_json_config()); }
+    void SetUp() override {
+        AtomDBSingleton::init(test_atomdb_json_config("redismongodb", "postgreswrapper_test_"));
+    }
 
     void TearDown() override {}
 };

--- a/src/tests/cpp/protected_atomdb_test.cc
+++ b/src/tests/cpp/protected_atomdb_test.cc
@@ -18,15 +18,15 @@ namespace {
 
 class ProtectedInMemoryDB : public InMemoryDB {
    public:
-    ProtectedInMemoryDB(const string& context = "") : InMemoryDB(context) {}
+    ProtectedInMemoryDB() = default;
 
     atomdb_api_types::ProtectionMode get_protection_mode() const override {
         return atomdb_api_types::ProtectionMode::PROTECTED;
     }
 };
 
-shared_ptr<ProtectedAtomDB> make_protected_db(const string& context = "protected_atomdb_test_") {
-    return make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>(context));
+shared_ptr<ProtectedAtomDB> make_protected_db() {
+    return make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>());
 }
 
 }  // namespace
@@ -34,7 +34,7 @@ shared_ptr<ProtectedAtomDB> make_protected_db(const string& context = "protected
 TEST(ProtectedAtomDBTest, RejectsNullBackend) { EXPECT_THROW(ProtectedAtomDB(nullptr), runtime_error); }
 
 TEST(ProtectedAtomDBTest, ReportsProtectionModeThroughWrapper) {
-    auto backend = make_shared<ProtectedInMemoryDB>("protected_flags_");
+    auto backend = make_shared<ProtectedInMemoryDB>();
     EXPECT_EQ(backend->get_protection_mode(), ProtectionMode::PROTECTED);
 
     ProtectedAtomDB db(backend);
@@ -42,7 +42,7 @@ TEST(ProtectedAtomDBTest, ReportsProtectionModeThroughWrapper) {
 }
 
 TEST(ProtectedAtomDBTest, DelegatesToBackend) {
-    auto backend = make_shared<ProtectedInMemoryDB>("protected_flags_");
+    auto backend = make_shared<ProtectedInMemoryDB>();
     ProtectedAtomDB db(backend);
     EXPECT_EQ(db.allow_nested_indexing(), backend->allow_nested_indexing());
     EXPECT_EQ(db.composite_type_enabled(), backend->composite_type_enabled());

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -1706,21 +1706,52 @@ TEST(RedisMongoDBPrefixIsolation, InstancesKeepIndependentNamespaces) {
         AtomDBFactory::create(test_atomdb_json_config("redismongodb", "peer_b_")));
     ASSERT_NE(db_a, nullptr);
     ASSERT_NE(db_b, nullptr);
+
     EXPECT_EQ(db_a->MONGODB_DB_NAME, "peer_a_das");
     EXPECT_EQ(db_b->MONGODB_DB_NAME, "peer_b_das");
+    EXPECT_EQ(db_a->REDIS_PATTERNS_PREFIX, "peer_a_patterns");
+    EXPECT_EQ(db_b->REDIS_PATTERNS_PREFIX, "peer_b_patterns");
+    EXPECT_EQ(db_a->REDIS_OUTGOING_PREFIX, "peer_a_outgoing_set");
+    EXPECT_EQ(db_b->REDIS_OUTGOING_PREFIX, "peer_b_outgoing_set");
 
-    Node node_a("Symbol", "PeerAOnly");
-    Node node_b("Symbol", "PeerBOnly");
-    db_a->add_node(&node_a);
-    db_b->add_node(&node_b);
+    Node pred_a("Symbol", "SimilarityA");
+    Node human_a("Symbol", "PeerAHuman");
+    Node monkey_a("Symbol", "PeerAMonkey");
+    Node pred_b("Symbol", "SimilarityB");
+    Node human_b("Symbol", "PeerBHuman");
+    Node monkey_b("Symbol", "PeerBMonkey");
+    db_a->add_nodes({&pred_a, &human_a, &monkey_a});
+    db_b->add_nodes({&pred_b, &human_b, &monkey_b});
 
-    EXPECT_TRUE(db_a->node_exists(node_a.handle()));
-    EXPECT_FALSE(db_a->node_exists(node_b.handle()));
-    EXPECT_TRUE(db_b->node_exists(node_b.handle()));
-    EXPECT_FALSE(db_b->node_exists(node_a.handle()));
+    Link link_a("Expression", {pred_a.handle(), human_a.handle(), monkey_a.handle()});
+    Link link_b("Expression", {pred_b.handle(), human_b.handle(), monkey_b.handle()});
+    db_a->add_link(&link_a);
+    db_b->add_link(&link_b);
+
+    EXPECT_TRUE(db_a->node_exists(human_a.handle()));
+    EXPECT_TRUE(db_a->link_exists(link_a.handle()));
+    EXPECT_FALSE(db_a->node_exists(human_b.handle()));
+    EXPECT_FALSE(db_a->link_exists(link_b.handle()));
+
+    EXPECT_TRUE(db_b->node_exists(human_b.handle()));
+    EXPECT_TRUE(db_b->link_exists(link_b.handle()));
+    EXPECT_FALSE(db_b->node_exists(human_a.handle()));
+    EXPECT_FALSE(db_b->link_exists(link_a.handle()));
+
+    ASSERT_NE(db_a->query_for_targets(link_a.handle()), nullptr);
+    EXPECT_EQ(db_b->query_for_targets(link_a.handle()), nullptr);
 
     db_a->drop_all();
+
+    EXPECT_FALSE(db_a->node_exists(human_a.handle()));
+    EXPECT_FALSE(db_a->link_exists(link_a.handle()));
+    EXPECT_TRUE(db_b->node_exists(human_b.handle()));
+    EXPECT_TRUE(db_b->link_exists(link_b.handle()));
+    ASSERT_NE(db_b->query_for_targets(link_b.handle()), nullptr);
+
     db_b->drop_all();
+    EXPECT_FALSE(db_b->node_exists(human_b.handle()));
+    EXPECT_FALSE(db_b->link_exists(link_b.handle()));
 }
 
 int main(int argc, char** argv) {

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -63,7 +63,8 @@ class MockDecoder : public HandleDecoder {
 class RedisMongoDBTestEnvironment : public ::testing::Environment {
    public:
     void SetUp() override {
-        auto atomdb = AtomDBFactory::create(test_atomdb_json_config(), "test_");
+        auto atomdb =
+            AtomDBFactory::create(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
         ASSERT_NE(dynamic_pointer_cast<RedisMongoDB>(atomdb), nullptr);
         AtomDBSingleton::provide(atomdb);
         load_animals_data();
@@ -111,8 +112,7 @@ class LinkSchemaHandle : public LinkSchema {
 
 class TestRedisMongoDB : public RedisMongoDB {
    public:
-    TestRedisMongoDB(const string& context, const JsonConfig& config)
-        : RedisMongoDB(context, true, config) {}
+    TestRedisMongoDB(const JsonConfig& config) : RedisMongoDB(config) {}
 };
 
 TEST_F(RedisMongoDBTest, ConcurrentQueryForPattern) {
@@ -826,18 +826,6 @@ TEST_F(RedisMongoDBTest, ReIndexPatterns) {
     handle_set = db->query_for_pattern(*odd_link_schema);
     EXPECT_EQ(handle_set->size(), 9);
 
-    // Flush Redis patterns indexes
-    db->flush_redis_by_prefix("test_patterns");
-
-    handle_set = db->query_for_pattern(*similarity_link_schema);
-    EXPECT_EQ(handle_set->size(), 0);
-
-    handle_set = db->query_for_pattern(*inheritance_link_schema);
-    EXPECT_EQ(handle_set->size(), 0);
-
-    handle_set = db->query_for_pattern(*odd_link_schema);
-    EXPECT_EQ(handle_set->size(), 0);
-
     // Clear Redis patterns indexes and re-index them
     db->re_index_patterns();
 
@@ -1200,9 +1188,9 @@ TEST_F(RedisMongoDBTest, CompositeHashDisabledSkipsTargetChecks) {
     EXPECT_THROW(db->add_links({link}), runtime_error);
 
     // Same Redis/Mongo namespace, composite_type_enabled=false: skip checks and persist the link.
-    auto config = test_atomdb_json_config();
+    auto config = test_atomdb_json_config("redismongodb", "redis_mongodb_test_");
     config["composite_type_enabled"] = false;
-    auto local_db = dynamic_pointer_cast<RedisMongoDB>(AtomDBFactory::create(config, "test_"));
+    auto local_db = dynamic_pointer_cast<RedisMongoDB>(AtomDBFactory::create(config));
     ASSERT_NE(local_db, nullptr);
 
     auto handles = local_db->add_links({link});
@@ -1256,9 +1244,9 @@ TEST_F(RedisMongoDBTest, AtomsCount) {
 TEST_F(RedisMongoDBTest, CompositeTypeEnabledFlag) {
     EXPECT_TRUE(db->composite_type_enabled());
 
-    auto config_default = test_atomdb_json_config();
+    auto config_default = test_atomdb_json_config("redismongodb", "redis_mongodb_test_");
     config_default.erase("composite_type_enabled");
-    auto db_default = dynamic_pointer_cast<RedisMongoDB>(AtomDBFactory::create(config_default, "test_"));
+    auto db_default = dynamic_pointer_cast<RedisMongoDB>(AtomDBFactory::create(config_default));
     ASSERT_NE(db_default, nullptr);
     EXPECT_TRUE(db_default->composite_type_enabled());
 
@@ -1279,10 +1267,9 @@ TEST_F(RedisMongoDBTest, CompositeTypeEnabledFlag) {
     EXPECT_EQ(string(enabled_doc->get("composite_type_hash")), enabled_link->composite_type_hash(*db));
     EXPECT_EQ(enabled_doc->get_size("composite_type"), 4);
 
-    auto config_disabled = test_atomdb_json_config();
+    auto config_disabled = test_atomdb_json_config("redismongodb", "redis_mongodb_test_");
     config_disabled["composite_type_enabled"] = false;
-    auto db_disabled =
-        dynamic_pointer_cast<RedisMongoDB>(AtomDBFactory::create(config_disabled, "test_"));
+    auto db_disabled = dynamic_pointer_cast<RedisMongoDB>(AtomDBFactory::create(config_disabled));
     ASSERT_NE(db_disabled, nullptr);
     EXPECT_FALSE(db_disabled->composite_type_enabled());
 
@@ -1537,7 +1524,7 @@ TEST_F(RedisMongoDBTest, IsProtectedWhenPersistedConfigIsTrue) {
     collection.insert_one(
         make_document(kvp("_id", protection_config_document_id()), kvp("protected", true)));
 
-    TestRedisMongoDB loaded("test_", test_atomdb_json_config());
+    TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(loaded.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
 
     collection.delete_many({});
@@ -1554,7 +1541,7 @@ TEST_F(RedisMongoDBTest, IsUnprotectedWhenPersistedConfigIsFalse) {
     collection.insert_one(
         make_document(kvp("_id", protection_config_document_id()), kvp("protected", false)));
 
-    TestRedisMongoDB loaded("test_", test_atomdb_json_config());
+    TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(loaded.get_protection_mode(), atomdb_api_types::ProtectionMode::UNPROTECTED);
 
     collection.delete_many({});
@@ -1566,7 +1553,7 @@ TEST_F(RedisMongoDBTest, IsUnprotectedWhenPersistedConfigDocumentAbsent) {
         (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
     collection.delete_many({});
 
-    TestRedisMongoDB loaded("test_", test_atomdb_json_config());
+    TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(loaded.get_protection_mode(), atomdb_api_types::ProtectionMode::UNPROTECTED);
 }
 
@@ -1581,7 +1568,9 @@ TEST_F(RedisMongoDBTest, RejectsPersistedConfigMissingProtectedField) {
     collection.insert_one(
         make_document(kvp("_id", protection_config_document_id()), kvp("other", "value")));
 
-    EXPECT_THROW({ TestRedisMongoDB loaded("test_", test_atomdb_json_config()); }, runtime_error);
+    EXPECT_THROW(
+        { TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_")); },
+        runtime_error);
 
     collection.delete_many({});
 }
@@ -1597,7 +1586,9 @@ TEST_F(RedisMongoDBTest, RejectsPersistedConfigInvalidProtectedFieldType) {
     collection.insert_one(
         make_document(kvp("_id", protection_config_document_id()), kvp("protected", "yes")));
 
-    EXPECT_THROW({ TestRedisMongoDB loaded("test_", test_atomdb_json_config()); }, runtime_error);
+    EXPECT_THROW(
+        { TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_")); },
+        runtime_error);
 
     collection.delete_many({});
 }
@@ -1633,7 +1624,7 @@ TEST_F(RedisMongoDBTest, DropAllDropsEveryCollectionExceptConfig) {
     EXPECT_FALSE(
         mongodb_collection_exists(database, RedisMongoDB::MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME));
 
-    TestRedisMongoDB reloaded("test_", test_atomdb_json_config());
+    TestRedisMongoDB reloaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(reloaded.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
 
     config_collection.delete_many({});
@@ -1650,14 +1641,14 @@ TEST_F(RedisMongoDBTest, DropAllPreservesProtectionConfiguration) {
     collection.insert_one(
         make_document(kvp("_id", protection_config_document_id()), kvp("protected", true)));
 
-    TestRedisMongoDB protected_db("test_", test_atomdb_json_config());
+    TestRedisMongoDB protected_db(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     ASSERT_EQ(protected_db.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
 
     protected_db.drop_all();
 
     EXPECT_EQ(protected_db.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
 
-    TestRedisMongoDB reloaded("test_", test_atomdb_json_config());
+    TestRedisMongoDB reloaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(reloaded.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
 
     collection.delete_many({});
@@ -1676,7 +1667,7 @@ TEST_F(RedisMongoDBTest, IgnoresConflictingProtectionConfigurationDocuments) {
         make_document(kvp("_id", protection_config_document_id()), kvp("protected", true)));
     collection.insert_one(make_document(kvp("protected", false)));
 
-    TestRedisMongoDB loaded("test_", test_atomdb_json_config());
+    TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(loaded.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
 
     collection.delete_many({});
@@ -1684,9 +1675,9 @@ TEST_F(RedisMongoDBTest, IgnoresConflictingProtectionConfigurationDocuments) {
 
 namespace {
 
-void expect_create_fails_with(nlohmann::json json, const string& context, const string& substr) {
+void expect_create_fails_with(nlohmann::json json, const string& substr) {
     try {
-        AtomDBFactory::create(commons::JsonConfig(std::move(json)), context);
+        AtomDBFactory::create(commons::JsonConfig(std::move(json)));
         FAIL() << "expected AtomDBFactory::create to throw";
     } catch (const runtime_error& e) {
         string msg = e.what();
@@ -1697,27 +1688,27 @@ void expect_create_fails_with(nlohmann::json json, const string& context, const 
 }  // namespace
 
 TEST(RedisMongoDBConfigValidation, MissingRedisEndpointFailsBeforePool) {
-    auto json = test_atomdb_json_config().get_json();
+    auto json = test_atomdb_json_config("redismongodb", "redis_mongodb_test_").get_json();
     json["redis"].erase("endpoint");
-    expect_create_fails_with(json, "missing_redis_endpoint_", "Invalid Redis configuration");
+    expect_create_fails_with(json, "Invalid Redis configuration");
 }
 
 TEST(RedisMongoDBConfigValidation, MissingMongodbEndpoint) {
-    auto json = test_atomdb_json_config().get_json();
+    auto json = test_atomdb_json_config("redismongodb", "redis_mongodb_test_").get_json();
     json["mongodb"].erase("endpoint");
-    expect_create_fails_with(json, "missing_mongodb_endpoint_", "Invalid MongoDB configuration");
+    expect_create_fails_with(json, "Invalid MongoDB configuration");
 }
 
 TEST(RedisMongoDBConfigValidation, MissingMongodbUsername) {
-    auto json = test_atomdb_json_config().get_json();
+    auto json = test_atomdb_json_config("redismongodb", "redis_mongodb_test_").get_json();
     json["mongodb"].erase("username");
-    expect_create_fails_with(json, "missing_mongodb_username_", "Invalid MongoDB configuration");
+    expect_create_fails_with(json, "Invalid MongoDB configuration");
 }
 
 TEST(RedisMongoDBConfigValidation, MissingMongodbPassword) {
-    auto json = test_atomdb_json_config().get_json();
+    auto json = test_atomdb_json_config("redismongodb", "redis_mongodb_test_").get_json();
     json["mongodb"].erase("password");
-    expect_create_fails_with(json, "missing_mongodb_password_", "Invalid MongoDB configuration");
+    expect_create_fails_with(json, "Invalid MongoDB configuration");
 }
 
 int main(int argc, char** argv) {

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -34,8 +34,8 @@ using namespace std;
 
 namespace {
 
-string protection_config_document_id() {
-    return Hasher::plain_string_hash(RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME);
+string protection_config_document_id(const RedisMongoDB& mongodb) {
+    return Hasher::plain_string_hash(mongodb.MONGODB_CONFIG_COLLECTION_NAME);
 }
 
 template <typename Database>
@@ -862,8 +862,8 @@ TEST_F(RedisMongoDBTest, GetMatchingAtoms) {
     auto link_document = db->get_atom_document(link->handle());
     EXPECT_EQ(link_document->get_bool("is_toplevel"), true);
 
-    auto all_nodes = db->get_filtered_documents(RedisMongoDB::MONGODB_NODES_COLLECTION_NAME, {}, {});
-    auto all_links = db->get_filtered_documents(RedisMongoDB::MONGODB_LINKS_COLLECTION_NAME, {}, {});
+    auto all_nodes = db->get_filtered_documents(db->MONGODB_NODES_COLLECTION_NAME, {}, {});
+    auto all_links = db->get_filtered_documents(db->MONGODB_LINKS_COLLECTION_NAME, {}, {});
 
     auto untyped_variable = new UntypedVariable("V1", true);
     matching_atoms = db->get_matching_atoms(false, *untyped_variable);
@@ -1408,8 +1408,7 @@ TEST_F(RedisMongoDBTest, TransactionalRejectedMergeStillBooksCompositeType) {
 TEST_F(RedisMongoDBTest, GetAccessPermissionsEmptyCollection) {
     auto pool = db->get_mongo_pool();
     auto conn = pool->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME];
     collection.delete_many({});
 
     auto permissions = db->get_access_permissions(PublicKey("any_key"));
@@ -1423,8 +1422,7 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsReturnsStoredDocuments) {
 
     auto pool = db->get_mongo_pool();
     auto conn = pool->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME];
     collection.delete_many({});
 
     auto similarity_tokens = make_array(
@@ -1483,8 +1481,7 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsRejectsInvalidDocument) {
 
     auto pool = db->get_mongo_pool();
     auto conn = pool->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME];
     collection.delete_many({});
 
     collection.insert_one(make_document(kvp("_id", string(compute_hash((char*) "key_broken"))),
@@ -1518,11 +1515,10 @@ TEST_F(RedisMongoDBTest, IsProtectedWhenPersistedConfigIsTrue) {
     using bsoncxx::builder::basic::make_document;
 
     auto conn = db->get_mongo_pool()->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_CONFIG_COLLECTION_NAME];
     collection.delete_many({});
     collection.insert_one(
-        make_document(kvp("_id", protection_config_document_id()), kvp("protected", true)));
+        make_document(kvp("_id", protection_config_document_id(*db)), kvp("protected", true)));
 
     TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(loaded.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
@@ -1535,11 +1531,10 @@ TEST_F(RedisMongoDBTest, IsUnprotectedWhenPersistedConfigIsFalse) {
     using bsoncxx::builder::basic::make_document;
 
     auto conn = db->get_mongo_pool()->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_CONFIG_COLLECTION_NAME];
     collection.delete_many({});
     collection.insert_one(
-        make_document(kvp("_id", protection_config_document_id()), kvp("protected", false)));
+        make_document(kvp("_id", protection_config_document_id(*db)), kvp("protected", false)));
 
     TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(loaded.get_protection_mode(), atomdb_api_types::ProtectionMode::UNPROTECTED);
@@ -1549,8 +1544,7 @@ TEST_F(RedisMongoDBTest, IsUnprotectedWhenPersistedConfigIsFalse) {
 
 TEST_F(RedisMongoDBTest, IsUnprotectedWhenPersistedConfigDocumentAbsent) {
     auto conn = db->get_mongo_pool()->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_CONFIG_COLLECTION_NAME];
     collection.delete_many({});
 
     TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
@@ -1562,11 +1556,10 @@ TEST_F(RedisMongoDBTest, RejectsPersistedConfigMissingProtectedField) {
     using bsoncxx::builder::basic::make_document;
 
     auto conn = db->get_mongo_pool()->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_CONFIG_COLLECTION_NAME];
     collection.delete_many({});
     collection.insert_one(
-        make_document(kvp("_id", protection_config_document_id()), kvp("other", "value")));
+        make_document(kvp("_id", protection_config_document_id(*db)), kvp("other", "value")));
 
     EXPECT_THROW(
         { TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_")); },
@@ -1580,11 +1573,10 @@ TEST_F(RedisMongoDBTest, RejectsPersistedConfigInvalidProtectedFieldType) {
     using bsoncxx::builder::basic::make_document;
 
     auto conn = db->get_mongo_pool()->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_CONFIG_COLLECTION_NAME];
     collection.delete_many({});
     collection.insert_one(
-        make_document(kvp("_id", protection_config_document_id()), kvp("protected", "yes")));
+        make_document(kvp("_id", protection_config_document_id(*db)), kvp("protected", "yes")));
 
     EXPECT_THROW(
         { TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_")); },
@@ -1598,31 +1590,29 @@ TEST_F(RedisMongoDBTest, DropAllDropsEveryCollectionExceptConfig) {
     using bsoncxx::builder::basic::make_document;
 
     auto conn = db->get_mongo_pool()->acquire();
-    auto database = (*conn)[RedisMongoDB::MONGODB_DB_NAME];
-    auto config_collection = database[RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
+    auto database = (*conn)[db->MONGODB_DB_NAME];
+    auto config_collection = database[db->MONGODB_CONFIG_COLLECTION_NAME];
 
-    ASSERT_GT(database[RedisMongoDB::MONGODB_NODES_COLLECTION_NAME].count_documents({}), 0u);
-    ASSERT_GT(database[RedisMongoDB::MONGODB_LINKS_COLLECTION_NAME].count_documents({}), 0u);
+    ASSERT_GT(database[db->MONGODB_NODES_COLLECTION_NAME].count_documents({}), 0u);
+    ASSERT_GT(database[db->MONGODB_LINKS_COLLECTION_NAME].count_documents({}), 0u);
 
     config_collection.delete_many({});
     config_collection.insert_one(
-        make_document(kvp("_id", protection_config_document_id()), kvp("protected", true)));
+        make_document(kvp("_id", protection_config_document_id(*db)), kvp("protected", true)));
 
     db->drop_all();
 
-    ASSERT_TRUE(mongodb_collection_exists(database, RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME));
+    ASSERT_TRUE(mongodb_collection_exists(database, db->MONGODB_CONFIG_COLLECTION_NAME));
     EXPECT_EQ(config_collection.count_documents({}), 1u);
     auto config_doc =
-        config_collection.find_one(make_document(kvp("_id", protection_config_document_id())));
+        config_collection.find_one(make_document(kvp("_id", protection_config_document_id(*db))));
     ASSERT_TRUE(config_doc.has_value());
     EXPECT_TRUE(config_doc->view()["protected"].get_bool().value);
 
-    EXPECT_FALSE(mongodb_collection_exists(database, RedisMongoDB::MONGODB_NODES_COLLECTION_NAME));
-    EXPECT_FALSE(mongodb_collection_exists(database, RedisMongoDB::MONGODB_LINKS_COLLECTION_NAME));
-    EXPECT_FALSE(
-        mongodb_collection_exists(database, RedisMongoDB::MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME));
-    EXPECT_FALSE(
-        mongodb_collection_exists(database, RedisMongoDB::MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME));
+    EXPECT_FALSE(mongodb_collection_exists(database, db->MONGODB_NODES_COLLECTION_NAME));
+    EXPECT_FALSE(mongodb_collection_exists(database, db->MONGODB_LINKS_COLLECTION_NAME));
+    EXPECT_FALSE(mongodb_collection_exists(database, db->MONGODB_PATTERN_INDEX_SCHEMA_COLLECTION_NAME));
+    EXPECT_FALSE(mongodb_collection_exists(database, db->MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME));
 
     TestRedisMongoDB reloaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     EXPECT_EQ(reloaded.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
@@ -1635,11 +1625,10 @@ TEST_F(RedisMongoDBTest, DropAllPreservesProtectionConfiguration) {
     using bsoncxx::builder::basic::make_document;
 
     auto conn = db->get_mongo_pool()->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_CONFIG_COLLECTION_NAME];
     collection.delete_many({});
     collection.insert_one(
-        make_document(kvp("_id", protection_config_document_id()), kvp("protected", true)));
+        make_document(kvp("_id", protection_config_document_id(*db)), kvp("protected", true)));
 
     TestRedisMongoDB protected_db(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
     ASSERT_EQ(protected_db.get_protection_mode(), atomdb_api_types::ProtectionMode::PROTECTED);
@@ -1659,12 +1648,11 @@ TEST_F(RedisMongoDBTest, IgnoresConflictingProtectionConfigurationDocuments) {
     using bsoncxx::builder::basic::make_document;
 
     auto conn = db->get_mongo_pool()->acquire();
-    auto collection =
-        (*conn)[RedisMongoDB::MONGODB_DB_NAME][RedisMongoDB::MONGODB_CONFIG_COLLECTION_NAME];
+    auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_CONFIG_COLLECTION_NAME];
     collection.delete_many({});
 
     collection.insert_one(
-        make_document(kvp("_id", protection_config_document_id()), kvp("protected", true)));
+        make_document(kvp("_id", protection_config_document_id(*db)), kvp("protected", true)));
     collection.insert_one(make_document(kvp("protected", false)));
 
     TestRedisMongoDB loaded(test_atomdb_json_config("redismongodb", "redis_mongodb_test_"));
@@ -1709,6 +1697,30 @@ TEST(RedisMongoDBConfigValidation, MissingMongodbPassword) {
     auto json = test_atomdb_json_config("redismongodb", "redis_mongodb_test_").get_json();
     json["mongodb"].erase("password");
     expect_create_fails_with(json, "Invalid MongoDB configuration");
+}
+
+TEST(RedisMongoDBPrefixIsolation, InstancesKeepIndependentNamespaces) {
+    auto db_a = dynamic_pointer_cast<RedisMongoDB>(
+        AtomDBFactory::create(test_atomdb_json_config("redismongodb", "peer_a_")));
+    auto db_b = dynamic_pointer_cast<RedisMongoDB>(
+        AtomDBFactory::create(test_atomdb_json_config("redismongodb", "peer_b_")));
+    ASSERT_NE(db_a, nullptr);
+    ASSERT_NE(db_b, nullptr);
+    EXPECT_EQ(db_a->MONGODB_DB_NAME, "peer_a_das");
+    EXPECT_EQ(db_b->MONGODB_DB_NAME, "peer_b_das");
+
+    Node node_a("Symbol", "PeerAOnly");
+    Node node_b("Symbol", "PeerBOnly");
+    db_a->add_node(&node_a);
+    db_b->add_node(&node_b);
+
+    EXPECT_TRUE(db_a->node_exists(node_a.handle()));
+    EXPECT_FALSE(db_a->node_exists(node_b.handle()));
+    EXPECT_TRUE(db_b->node_exists(node_b.handle()));
+    EXPECT_FALSE(db_b->node_exists(node_a.handle()));
+
+    db_a->drop_all();
+    db_b->drop_all();
 }
 
 int main(int argc, char** argv) {

--- a/src/tests/cpp/redis_mongodb_test_2.cc
+++ b/src/tests/cpp/redis_mongodb_test_2.cc
@@ -23,7 +23,8 @@ using namespace std;
 class RedisMongoDBTestEnvironment : public ::testing::Environment {
    public:
     void SetUp() override {
-        auto atomdb = AtomDBFactory::create(test_atomdb_json_config(), "test2_");
+        auto atomdb =
+            AtomDBFactory::create(test_atomdb_json_config("redismongodb", "redis_mongodb_test_2_"));
         ASSERT_NE(dynamic_pointer_cast<RedisMongoDB>(atomdb), nullptr);
         AtomDBSingleton::provide(atomdb);
     }

--- a/src/tests/cpp/remote_atomdb_test.cc
+++ b/src/tests/cpp/remote_atomdb_test.cc
@@ -21,8 +21,10 @@
 #include "LinkSchema.h"
 #include "Node.h"
 #include "ProtectedAtomDB.h"
+#include "RedisMongoDB.h"
 #include "RemoteAtomDB.h"
 #include "RemoteAtomDBPeer.h"
+#include "TestAtomDBJsonConfig.h"
 
 using namespace atomdb;
 using namespace atomdb::atomdb_api_types;
@@ -700,6 +702,45 @@ TEST_F(RemoteAtomDBConfigTest, SingleConfigWorks) {
     auto human = new Node("Symbol", "\"human\"");
     string human_handle = db_->add_node(human);
     EXPECT_TRUE(db_->node_exists(human_handle));
+}
+
+TEST(RemoteAtomDBPrefixIsolation, PeersWithDifferentPrefixesStayIsolated) {
+    nlohmann::json json;
+    json["type"] = "remotedb";
+    auto peer_a = test_atomdb_json_config("redismongodb", "remote_peer_a_").get_json();
+    peer_a["uid"] = "peer_a";
+    auto peer_b = test_atomdb_json_config("redismongodb", "remote_peer_b_").get_json();
+    peer_b["uid"] = "peer_b";
+    json["remote_peers"] = nlohmann::json::array({peer_a, peer_b});
+
+    auto db = AtomDBFactory::create(JsonConfig(json));
+    auto remote = dynamic_pointer_cast<RemoteAtomDB>(db);
+    ASSERT_NE(remote, nullptr);
+
+    auto* peer_a_wrapper = remote->get_peer("peer_a");
+    auto* peer_b_wrapper = remote->get_peer("peer_b");
+    ASSERT_NE(peer_a_wrapper, nullptr);
+    ASSERT_NE(peer_b_wrapper, nullptr);
+
+    auto redis_a = dynamic_pointer_cast<RedisMongoDB>(peer_a_wrapper->get_remote_atomdb());
+    auto redis_b = dynamic_pointer_cast<RedisMongoDB>(peer_b_wrapper->get_remote_atomdb());
+    ASSERT_NE(redis_a, nullptr);
+    ASSERT_NE(redis_b, nullptr);
+    EXPECT_EQ(redis_a->MONGODB_DB_NAME, "remote_peer_a_das");
+    EXPECT_EQ(redis_b->MONGODB_DB_NAME, "remote_peer_b_das");
+
+    Node node_a("Symbol", "RemotePeerAOnly");
+    Node node_b("Symbol", "RemotePeerBOnly");
+    redis_a->add_node(&node_a);
+    redis_b->add_node(&node_b);
+
+    EXPECT_TRUE(redis_a->node_exists(node_a.handle()));
+    EXPECT_FALSE(redis_a->node_exists(node_b.handle()));
+    EXPECT_TRUE(redis_b->node_exists(node_b.handle()));
+    EXPECT_FALSE(redis_b->node_exists(node_a.handle()));
+
+    redis_a->drop_all();
+    redis_b->drop_all();
 }
 
 // =============================================================================

--- a/src/tests/cpp/remote_atomdb_test.cc
+++ b/src/tests/cpp/remote_atomdb_test.cc
@@ -37,8 +37,8 @@ using namespace std;
 class RemoteAtomDBPeerTest : public ::testing::Test {
    protected:
     void SetUp() override {
-        remote_ = make_shared<InMemoryDB>("peer_remote_");
-        local_ = make_shared<InMemoryDB>("peer_local_");
+        remote_ = make_shared<InMemoryDB>();
+        local_ = make_shared<InMemoryDB>();
         peer_ = make_shared<RemoteAtomDBPeer>(remote_, local_, "test_peer");
     }
 
@@ -370,7 +370,7 @@ TEST_F(RemoteAtomDBPeerTest, DeleteAfterFetchReleasesRemoteCache) {
 
 TEST_F(RemoteAtomDBPeerTest, ReleaseWithoutLocalPersistence) {
     // Create a peer without local persistence (nullptr)
-    auto remote = make_shared<InMemoryDB>("no_local_remote_");
+    auto remote = make_shared<InMemoryDB>();
     auto peer_no_local = make_shared<RemoteAtomDBPeer>(remote, nullptr, "no_local_peer");
 
     auto human = new Node("Symbol", "\"human\"");
@@ -444,7 +444,7 @@ TEST_F(RemoteAtomDBPeerTest, AtomsCount) {
 // =============================================================================
 
 TEST(RemoteAtomDBPeerReadonlyTest, RepeatQuerySeesRemoteAfterRelease) {
-    auto remote = make_shared<InMemoryDB>("readonly_remote_");
+    auto remote = make_shared<InMemoryDB>();
     auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "readonly_peer");
 
     auto handles = populate_inheritance_mammal_links(remote);
@@ -484,8 +484,8 @@ TEST(RemoteAtomDBPeerReadonlyTest, RepeatQuerySeesRemoteAfterRelease) {
 }
 
 TEST(RemoteAtomDBPeerReadonlyTest, AddStagesThenPersistsOnRelease) {
-    auto remote = make_shared<InMemoryDB>("stage_remote_");
-    auto local = make_shared<InMemoryDB>("stage_local_");
+    auto remote = make_shared<InMemoryDB>();
+    auto local = make_shared<InMemoryDB>();
     auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "stage_peer");
 
     auto human = new Node("Symbol", "\"human\"");
@@ -501,7 +501,7 @@ TEST(RemoteAtomDBPeerReadonlyTest, AddStagesThenPersistsOnRelease) {
 }
 
 TEST(RemoteAtomDBPeerReadonlyTest, AddFailsWithoutLocalPersistence) {
-    auto remote = make_shared<InMemoryDB>("read_only_remote_");
+    auto remote = make_shared<InMemoryDB>();
     auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "read_only_peer");
 
     auto human = new Node("Symbol", "\"human\"");
@@ -510,8 +510,8 @@ TEST(RemoteAtomDBPeerReadonlyTest, AddFailsWithoutLocalPersistence) {
 }
 
 TEST(RemoteAtomDBPeerReadonlyTest, DeleteAtomFromLocalPersistence) {
-    auto remote = make_shared<InMemoryDB>("delete_remote_");
-    auto local = make_shared<InMemoryDB>("delete_local_");
+    auto remote = make_shared<InMemoryDB>();
+    auto local = make_shared<InMemoryDB>();
     auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "delete_peer");
 
     auto human = new Node("Symbol", "\"human\"");
@@ -523,7 +523,7 @@ TEST(RemoteAtomDBPeerReadonlyTest, DeleteAtomFromLocalPersistence) {
 }
 
 TEST(RemoteAtomDBPeerReadonlyTest, FetchWarmsCache) {
-    auto remote = make_shared<InMemoryDB>("fetch_remote_");
+    auto remote = make_shared<InMemoryDB>();
     auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "fetch_peer");
     auto handles = populate_inheritance_mammal_links(remote);
     LinkSchema link_schema = inheritance_mammal_schema();
@@ -583,7 +583,7 @@ class RemoteAtomDBTest : public ::testing::Test {
             << (std::getenv("TEST_SRCDIR") ? std::getenv("TEST_SRCDIR") : "unset") << ")";
         auto json_config = load_config(config_path_);
         json_config["type"] = "remotedb";
-        auto db = AtomDBFactory::create(json_config, "");
+        auto db = AtomDBFactory::create(json_config);
         db_ = dynamic_pointer_cast<RemoteAtomDB>(db);
         ASSERT_NE(db_, nullptr);
     }
@@ -681,7 +681,7 @@ class RemoteAtomDBConfigTest : public ::testing::Test {
         ASSERT_FALSE(config_path_.empty()) << "Could not find tests/assets/remotedb_config_single.json";
         auto json_config = load_config(config_path_);
         json_config["type"] = "remotedb";
-        auto db = AtomDBFactory::create(json_config, "");
+        auto db = AtomDBFactory::create(json_config);
         db_ = dynamic_pointer_cast<RemoteAtomDB>(db);
         ASSERT_NE(db_, nullptr);
     }
@@ -714,7 +714,7 @@ TEST_F(RemoteAtomDBConfigTest, SingleConfigWorks) {
 // metta expressions / assignments to its pattern query results.
 class NestedInMemoryDB : public InMemoryDB {
    public:
-    explicit NestedInMemoryDB(const string& context) : InMemoryDB(context) {}
+    NestedInMemoryDB() = default;
 
     bool allow_nested_indexing() override { return true; }
 
@@ -739,7 +739,7 @@ class NestedInMemoryDB : public InMemoryDB {
 // Local persistence backend that advertises composite_type_enabled.
 class CompositeTypeEnabledInMemoryDB : public InMemoryDB {
    public:
-    explicit CompositeTypeEnabledInMemoryDB(const string& context) : InMemoryDB(context) {}
+    CompositeTypeEnabledInMemoryDB() = default;
 
     bool composite_type_enabled() const override { return true; }
 };
@@ -747,20 +747,20 @@ class CompositeTypeEnabledInMemoryDB : public InMemoryDB {
 // Backend pointing at a protected database, like a RedisMongoDB whose Mongo config flags it.
 class ProtectedInMemoryDB : public InMemoryDB {
    public:
-    explicit ProtectedInMemoryDB(const string& context) : InMemoryDB(context) {}
+    ProtectedInMemoryDB() = default;
 
     ProtectionMode get_protection_mode() const override { return ProtectionMode::PROTECTED; }
 };
 
 class ForwardInMemoryDB : public InMemoryDB {
    public:
-    explicit ForwardInMemoryDB(const string& context) : InMemoryDB(context) {}
+    ForwardInMemoryDB() = default;
 
     ProtectionMode get_protection_mode() const override { return ProtectionMode::FORWARD; }
 };
 
 TEST(RemoteAtomDBFederationTest, MetadataAggregationFromNestedPeer) {
-    auto backend = make_shared<NestedInMemoryDB>("fed_nested_backend_");
+    auto backend = make_shared<NestedInMemoryDB>();
     auto handles = populate_inheritance_mammal_links(backend);
 
     map<string, shared_ptr<RemoteAtomDBPeer>> peers;
@@ -794,8 +794,8 @@ TEST(RemoteAtomDBFederationTest, MetadataAggregationFromNestedPeer) {
 TEST(RemoteAtomDBFederationTest, MixedPeersDowngradeAndDeduplicate) {
     // peer1: nested-indexing backend; peer2: plain in-memory backend.
     // Both contain the SAME two links so the facade must dedup by handle.
-    auto nested_backend = make_shared<NestedInMemoryDB>("fed_mixed_nested_");
-    auto plain_backend = make_shared<InMemoryDB>("fed_mixed_plain_");
+    auto nested_backend = make_shared<NestedInMemoryDB>();
+    auto plain_backend = make_shared<InMemoryDB>();
     auto nested_handles = populate_inheritance_mammal_links(nested_backend);
     auto plain_handles = populate_inheritance_mammal_links(plain_backend);
     ASSERT_EQ(nested_handles, plain_handles);  // identical content -> identical handles
@@ -824,9 +824,9 @@ TEST(RemoteAtomDBFederationTest, CompositeTypeEnabledAggregation) {
 
     // All disabled (no local persistence, or local persistence with flag off) -> false.
     {
-        auto remote1 = make_shared<InMemoryDB>("cte_all_off_remote1_");
-        auto remote2 = make_shared<InMemoryDB>("cte_all_off_remote2_");
-        auto local_off = make_shared<InMemoryDB>("cte_all_off_local_");
+        auto remote1 = make_shared<InMemoryDB>();
+        auto remote2 = make_shared<InMemoryDB>();
+        auto local_off = make_shared<InMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
         peers["peer1"] = make_shared<RemoteAtomDBPeer>(remote1, nullptr, "peer1");
         peers["peer2"] = make_shared<RemoteAtomDBPeer>(remote2, local_off, "peer2");
@@ -836,10 +836,10 @@ TEST(RemoteAtomDBFederationTest, CompositeTypeEnabledAggregation) {
 
     // Mixed: one enabled + one disabled -> true.
     {
-        auto remote1 = make_shared<InMemoryDB>("cte_mixed_remote1_");
-        auto remote2 = make_shared<InMemoryDB>("cte_mixed_remote2_");
-        auto local_on = make_shared<CompositeTypeEnabledInMemoryDB>("cte_mixed_local_on_");
-        auto local_off = make_shared<InMemoryDB>("cte_mixed_local_off_");
+        auto remote1 = make_shared<InMemoryDB>();
+        auto remote2 = make_shared<InMemoryDB>();
+        auto local_on = make_shared<CompositeTypeEnabledInMemoryDB>();
+        auto local_off = make_shared<InMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
         peers["enabled"] = make_shared<RemoteAtomDBPeer>(remote1, local_on, "enabled");
         peers["disabled"] = make_shared<RemoteAtomDBPeer>(remote2, local_off, "disabled");
@@ -849,10 +849,10 @@ TEST(RemoteAtomDBFederationTest, CompositeTypeEnabledAggregation) {
 
     // All enabled -> true.
     {
-        auto remote1 = make_shared<InMemoryDB>("cte_all_on_remote1_");
-        auto remote2 = make_shared<InMemoryDB>("cte_all_on_remote2_");
-        auto local1 = make_shared<CompositeTypeEnabledInMemoryDB>("cte_all_on_local1_");
-        auto local2 = make_shared<CompositeTypeEnabledInMemoryDB>("cte_all_on_local2_");
+        auto remote1 = make_shared<InMemoryDB>();
+        auto remote2 = make_shared<InMemoryDB>();
+        auto local1 = make_shared<CompositeTypeEnabledInMemoryDB>();
+        auto local2 = make_shared<CompositeTypeEnabledInMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
         peers["peer1"] = make_shared<RemoteAtomDBPeer>(remote1, local1, "peer1");
         peers["peer2"] = make_shared<RemoteAtomDBPeer>(remote2, local2, "peer2");
@@ -864,54 +864,52 @@ TEST(RemoteAtomDBFederationTest, CompositeTypeEnabledAggregation) {
 TEST(RemoteAtomDBFederationTest, PeerIsProtectedFollowsRemoteBackend) {
     // Neither the remote backend nor the local persistence is protected.
     {
-        auto remote = make_shared<InMemoryDB>("prot_none_remote_");
-        auto local = make_shared<InMemoryDB>("prot_none_local_");
+        auto remote = make_shared<InMemoryDB>();
+        auto local = make_shared<InMemoryDB>();
         auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "peer");
         EXPECT_EQ(peer->get_protection_mode(), ProtectionMode::UNPROTECTED);
     }
 
     // Read-only peer (no local persistence) over an unprotected remote.
     {
-        auto remote = make_shared<InMemoryDB>("prot_readonly_remote_");
+        auto remote = make_shared<InMemoryDB>();
         auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "peer");
         EXPECT_EQ(peer->get_protection_mode(), ProtectionMode::UNPROTECTED);
     }
 
     // Protected remote backend.
     {
-        auto remote = make_shared<ProtectedInMemoryDB>("prot_remote_remote_");
-        auto local = make_shared<InMemoryDB>("prot_remote_local_");
+        auto remote = make_shared<ProtectedInMemoryDB>();
+        auto local = make_shared<InMemoryDB>();
         auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "peer");
         EXPECT_EQ(peer->get_protection_mode(), ProtectionMode::PROTECTED);
     }
 
     // ProtectedAtomDB wrapper as remote backend propagates protection mode.
     {
-        auto remote =
-            make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>("prot_wrapped_remote_"));
+        auto remote = make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>());
         auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "peer");
         EXPECT_EQ(peer->get_protection_mode(), ProtectionMode::PROTECTED);
     }
 
     // Protected local persistence is not supported.
     {
-        auto remote = make_shared<InMemoryDB>("prot_local_remote_");
-        auto local = make_shared<ProtectedInMemoryDB>("prot_local_local_");
+        auto remote = make_shared<InMemoryDB>();
+        auto local = make_shared<ProtectedInMemoryDB>();
         EXPECT_THROW(make_shared<RemoteAtomDBPeer>(remote, local, "peer"), runtime_error);
     }
 
     // FORWARD local persistence is not supported either.
     {
-        auto remote = make_shared<InMemoryDB>("forward_local_remote_");
-        auto local = make_shared<ForwardInMemoryDB>("forward_local_local_");
+        auto remote = make_shared<InMemoryDB>();
+        auto local = make_shared<ForwardInMemoryDB>();
         EXPECT_THROW(make_shared<RemoteAtomDBPeer>(remote, local, "peer"), runtime_error);
     }
 
     // Factory-style ProtectedAtomDB wrapper over a protected backend is rejected for local persistence.
     {
-        auto remote = make_shared<InMemoryDB>("wrapped_local_remote_");
-        auto local =
-            make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>("wrapped_local_local_"));
+        auto remote = make_shared<InMemoryDB>();
+        auto local = make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>());
         EXPECT_THROW(make_shared<RemoteAtomDBPeer>(remote, local, "peer"), runtime_error);
     }
 }
@@ -926,8 +924,8 @@ TEST(RemoteAtomDBFederationTest, IsProtectedWhenAnyPeerIsProtected) {
 
     // All peers unprotected.
     {
-        auto remote1 = make_shared<InMemoryDB>("fed_prot_off_remote1_");
-        auto remote2 = make_shared<InMemoryDB>("fed_prot_off_remote2_");
+        auto remote1 = make_shared<InMemoryDB>();
+        auto remote2 = make_shared<InMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
         peers["peer1"] = make_shared<RemoteAtomDBPeer>(remote1, nullptr, "peer1");
         peers["peer2"] = make_shared<RemoteAtomDBPeer>(remote2, nullptr, "peer2");
@@ -937,8 +935,8 @@ TEST(RemoteAtomDBFederationTest, IsProtectedWhenAnyPeerIsProtected) {
 
     // A single protected peer makes the facade FORWARD (no local post-processing).
     {
-        auto unprotected_remote = make_shared<InMemoryDB>("fed_prot_mixed_remote_");
-        auto protected_remote = make_shared<ProtectedInMemoryDB>("fed_prot_mixed_protected_");
+        auto unprotected_remote = make_shared<InMemoryDB>();
+        auto protected_remote = make_shared<ProtectedInMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
         peers["unprotected"] = make_shared<RemoteAtomDBPeer>(unprotected_remote, nullptr, "unprotected");
         peers["protected"] = make_shared<RemoteAtomDBPeer>(protected_remote, nullptr, "protected");
@@ -948,9 +946,8 @@ TEST(RemoteAtomDBFederationTest, IsProtectedWhenAnyPeerIsProtected) {
 
     // ProtectedAtomDB-wrapped remote peer propagates to the federation facade.
     {
-        auto unprotected_remote = make_shared<InMemoryDB>("fed_wrapped_remote_");
-        auto protected_remote =
-            make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>("fed_wrapped_protected_"));
+        auto unprotected_remote = make_shared<InMemoryDB>();
+        auto protected_remote = make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>());
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
         peers["unprotected"] = make_shared<RemoteAtomDBPeer>(unprotected_remote, nullptr, "unprotected");
         peers["protected"] = make_shared<RemoteAtomDBPeer>(protected_remote, nullptr, "protected");
@@ -962,8 +959,8 @@ TEST(RemoteAtomDBFederationTest, IsProtectedWhenAnyPeerIsProtected) {
 TEST(RemoteAtomDBFederationTest, CacheFirstProbingAcrossPeers) {
     // An atom that exists only in peer2's backend must still resolve via the facade,
     // and the resolving peer must cache it so subsequent probes are served from cache.
-    auto backend1 = make_shared<InMemoryDB>("fed_cache_peer1_");
-    auto backend2 = make_shared<InMemoryDB>("fed_cache_peer2_");
+    auto backend1 = make_shared<InMemoryDB>();
+    auto backend2 = make_shared<InMemoryDB>();
 
     auto only_in_peer2 = new Node("Symbol", "\"only_in_peer2\"");
     string handle = backend2->add_node(only_in_peer2);
@@ -998,9 +995,9 @@ TEST(RemoteAtomDBFederationTest, PersistLinkWithoutCrossPeerTargetCopy) {
     // peer3 writable backend + local_persistence start empty; targets live only on peer1.
     // InMemoryDB (and RedisMongoDB with composite_type_enabled=false) can still persist the
     // staged link itself.
-    auto peer1_remote = make_shared<InMemoryDB>("persist_peer1_remote_");
-    auto peer3_remote = make_shared<InMemoryDB>("persist_peer3_remote_");
-    auto peer3_local = make_shared<InMemoryDB>("persist_peer3_local_");
+    auto peer1_remote = make_shared<InMemoryDB>();
+    auto peer3_remote = make_shared<InMemoryDB>();
+    auto peer3_local = make_shared<InMemoryDB>();
 
     auto a = new Node("Symbol", "\"persistA\"");
     auto b = new Node("Symbol", "\"persistB\"");
@@ -1048,10 +1045,10 @@ TEST(RemoteAtomDBFederationTest, PersistLinkWithoutCrossPeerTargetCopy) {
 TEST(RemoteAtomDBFederationTest, StrengthUpdateVisibleAcrossPeers) {
     // Writable peer3 local_persistence gets a strength update for a content-addressed handle.
     // Readonly peers may still serve a stale cached/remote copy; facade must prefer peer3.
-    auto peer1_remote = make_shared<InMemoryDB>("strength_peer1_remote_");
-    auto peer2_remote = make_shared<InMemoryDB>("strength_peer2_remote_");
-    auto peer3_remote = make_shared<InMemoryDB>("strength_peer3_remote_");
-    auto peer3_local = make_shared<InMemoryDB>("strength_peer3_local_");
+    auto peer1_remote = make_shared<InMemoryDB>();
+    auto peer2_remote = make_shared<InMemoryDB>();
+    auto peer3_remote = make_shared<InMemoryDB>();
+    auto peer3_local = make_shared<InMemoryDB>();
 
     auto a = new Node("Symbol", "\"A\"");
     auto b = new Node("Symbol", "\"B\"");
@@ -1098,8 +1095,8 @@ TEST(RemoteAtomDBFederationTest, StrengthUpdateVisibleAcrossPeers) {
 TEST(RemoteAtomDBFederationTest, StagedStrengthUpdateVisibleBeforeFlush) {
     // local_persistence already has a weak copy. A same-process upsert stages a stronger copy
     // in peer3's cache. get_atom must prefer the staged handle over local before release.
-    auto peer3_remote = make_shared<InMemoryDB>("staged_strength_peer3_remote_");
-    auto peer3_local = make_shared<InMemoryDB>("staged_strength_peer3_local_");
+    auto peer3_remote = make_shared<InMemoryDB>();
+    auto peer3_local = make_shared<InMemoryDB>();
 
     auto a = new Node("Symbol", "\"stagedA\"");
     auto b = new Node("Symbol", "\"stagedB\"");
@@ -1145,8 +1142,8 @@ TEST(RemoteAtomDBFederationTest, StagedStrengthUpdateVisibleBeforeFlush) {
 TEST(RemoteAtomDBFederationTest, NonStagedPrefersLocalOverStaleCache) {
     // Reader warmed a weak copy into cache. Another writer updates local_persistence.
     // get_atom must not keep serving the stale cache entry when the handle is not staged.
-    auto peer3_remote = make_shared<InMemoryDB>("stale_cache_peer3_remote_");
-    auto peer3_local = make_shared<InMemoryDB>("stale_cache_peer3_local_");
+    auto peer3_remote = make_shared<InMemoryDB>();
+    auto peer3_local = make_shared<InMemoryDB>();
 
     auto a = new Node("Symbol", "\"staleA\"");
     auto b = new Node("Symbol", "\"staleB\"");
@@ -1183,7 +1180,7 @@ namespace {
 // failed flush re-stages dirty atoms instead of losing them.
 class FlakyInMemoryDB : public InMemoryDB {
    public:
-    explicit FlakyInMemoryDB(const string& context) : InMemoryDB(context) {}
+    FlakyInMemoryDB() = default;
 
     atomic<bool> failing{false};
 
@@ -1216,8 +1213,8 @@ class FlakyInMemoryDB : public InMemoryDB {
 }  // namespace
 
 TEST(RemoteAtomDBFederationTest, FailedFlushRestagesDirtyAtoms) {
-    auto remote = make_shared<InMemoryDB>("flaky_remote_");
-    auto local = make_shared<FlakyInMemoryDB>("flaky_local_");
+    auto remote = make_shared<InMemoryDB>();
+    auto local = make_shared<FlakyInMemoryDB>();
     auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "flaky_peer");
 
     auto human = new Node("Symbol", "\"human\"");
@@ -1241,8 +1238,8 @@ TEST(RemoteAtomDBFederationTest, FailedFlushRestagesDirtyAtoms) {
 TEST(RemoteAtomDBFederationTest, ConcurrentAddAndReleaseLosesNoWrites) {
     // Adds racing release_cache() must never drop dirty writes. Every handle lands in
     // local_persistence after a final release once writers finish.
-    auto peer3_remote = make_shared<InMemoryDB>("race_peer3_remote_");
-    auto peer3_local = make_shared<InMemoryDB>("race_peer3_local_");
+    auto peer3_remote = make_shared<InMemoryDB>();
+    auto peer3_local = make_shared<InMemoryDB>();
     auto peer = make_shared<RemoteAtomDBPeer>(peer3_remote, peer3_local, "peer3");
 
     constexpr int kWriters = 4;

--- a/src/tests/cpp/test_commons/TestAtomDBJsonConfig.h
+++ b/src/tests/cpp/test_commons/TestAtomDBJsonConfig.h
@@ -8,9 +8,11 @@ namespace atomdb {
  * Minimal valid atomdb JsonConfig for local development / tests (all required fields present).
  * Production services should load values from the application config file instead.
  */
-inline commons::JsonConfig test_atomdb_json_config(const string& atomdb_type = "redismongodb") {
+inline commons::JsonConfig test_atomdb_json_config(const string& atomdb_type = "redismongodb",
+                                                   const string& prefix = "") {
     auto json = nlohmann::json();
     json["type"] = atomdb_type;
+    json["prefix"] = prefix;
     json["composite_type_enabled"] = true;
     json["redis"] = {{"endpoint", "localhost:40020"}, {"cluster", false}};
     json["mongodb"] = {{"endpoint", "localhost:40021"}, {"username", "admin"}, {"password", "admin"}};

--- a/src/tests/regression/adapterdb_main.cc
+++ b/src/tests/regression/adapterdb_main.cc
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
 
     AtomDBSingleton::init(atomdb_config);
 
-    auto morkdb = make_shared<MorkDB>("", morkdb_json_config());
+    auto morkdb = make_shared<MorkDB>(morkdb_json_config());
 
     size_t nodes = morkdb->node_count();
     size_t links = morkdb->link_count();


### PR DESCRIPTION
## Summary

- Remove the AtomDB `context` constructor/factory argument. Redis/Mongo namespace isolation is now optional `JsonConfig["prefix"]` on each `redismongodb` / `morkdb` backend (including remotedb peers and `adapterdb.atomdb_backend`).
- Redis key prefixes and MongoDB database/collection names are per `RedisMongoDB` instance, so two backends can use different prefixes in the same process.
- Mutating tests pass a unique prefix so they no longer share or wipe the default `das` database used by query tests.

## Breaking change

`AtomDBFactory::create()` (and the Redis/Mork/InMemory/Adapter constructors) no longer take `context`. Callers that need isolation should set `"prefix"` on the backend config, e.g. `"test_"` → Mongo DB `test_das` and Redis keys `test_patterns`, `test_outgoing_set`, `test_incoming_set`. Omit it for the default names.

## Test plan

- [ ] `make test-all` (or at least `//tests/cpp:nested_link_template_test`, `redis_mongodb_test`, `remote_atomdb_test`, `adapterdb_test`, `morkdb_test`)
- [ ] Two RedisMongoDB instances with different prefixes keep independent namespaces
- [ ] Remotedb with two RedisMongoDB peers and different prefixes stays isolated
