### PR TITLE
Add uid to `AtomDB`

### DIFF
--- a/config/das.json
+++ b/config/das.json
@@ -1,5 +1,6 @@
 {
     "atomdb": {
+        "uid": "local",
         "type": "redismongodb",
         "composite_type_enabled": true,
         "redis": {
@@ -51,6 +52,7 @@
                 "reuse_mongodb": true
             },
             "atomdb_backend": {
+                "uid": "local",
                 "type": "morkdb",
                 "composite_type_enabled": true,
                 "mongodb": {

--- a/config/das.json
+++ b/config/das.json
@@ -115,6 +115,7 @@
                 "uid": "peer3",
                 "type": "inmemorydb",
                 "local_persistence": {
+                    "uid": "peer3_local",
                     "type": "redismongodb",
                     "composite_type_enabled": false,
                     "mongodb": {

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -26,8 +26,9 @@ class AtomDB : public HandleDecoder {
     virtual ~AtomDB() = default;
 
     /**
-     * Stable identifier for this AtomDB instance (from JsonConfig["uid"]).
-     * Empty when the config omitted uid. Remote peers require a non-empty uid.
+     * Identifier for this AtomDB instance (from JsonConfig["uid"]).
+     * The config key is required; the value may be empty. The default
+     * constructor also leaves it empty (internal InMemoryDB caches).
      */
     const string& get_uid() const { return uid_; }
 

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -22,7 +22,14 @@ enum class AtomDBType { RedisMongoDB, MorkDB, InMemoryDB, RemoteAtomDB, AdapterD
 class AtomDB : public HandleDecoder {
    public:
     AtomDB() = default;
+    explicit AtomDB(const string& uid) : uid_(uid) {}
     virtual ~AtomDB() = default;
+
+    /**
+     * Stable identifier for this AtomDB instance (from JsonConfig["uid"]).
+     * Empty when the config omitted uid. Remote peers require a non-empty uid.
+     */
+    const string& get_uid() const { return uid_; }
 
     static AtomDBType string_to_type(const string& type) {
         if (type == "redismongodb") return AtomDBType::RedisMongoDB;
@@ -119,6 +126,9 @@ class AtomDB : public HandleDecoder {
         const atomdb_api_types::PublicKey& public_key) const {
         return {};
     }
+
+   protected:
+    string uid_;
 };
 
 }  // namespace atomdb

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -89,6 +89,21 @@ class PublicKey {
 
     bool is_single_key() const { return this->peer_to_key.empty(); }
 
+    /**
+     * Key this AtomDB should use for access-permission lookup.
+     * - Single-key: the one key, regardless of uid.
+     * - Per-peer map: the key registered for `uid`, if present.
+     */
+    optional<string> key_for_uid(const string& uid) const {
+        if (is_single_key()) {
+            if (keys.empty()) return nullopt;
+            return keys.front();
+        }
+        auto it = peer_to_key.find(uid);
+        if (it == peer_to_key.end()) return nullopt;
+        return keys[it->second];
+    }
+
     explicit PublicKey(const string& key) : keys{key} {}
     explicit PublicKey(const map<string, string>& peer_keys) {
         this->keys.reserve(peer_keys.size());

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <map>
-#include <optional>
 #include <vector>
 
 #include "Link.h"
@@ -93,14 +92,15 @@ class PublicKey {
      * Key this AtomDB should use for access-permission lookup.
      * - Single-key: the one key, regardless of uid.
      * - Per-peer map: the key registered for `uid`, if present.
+     * Returns "" if no key exists for `uid`.
      */
-    optional<string> key_for_uid(const string& uid) const {
+    string key_for_uid(const string& uid) const {
         if (is_single_key()) {
-            if (keys.empty()) return nullopt;
+            if (keys.empty()) return "";
             return keys.front();
         }
         auto it = peer_to_key.find(uid);
-        if (it == peer_to_key.end()) return nullopt;
+        if (it == peer_to_key.end()) return "";
         return keys[it->second];
     }
 

--- a/src/atomdb/AtomDBFactory.cc
+++ b/src/atomdb/AtomDBFactory.cc
@@ -15,6 +15,10 @@ using namespace commons;
 // Public methods
 
 shared_ptr<AtomDB> AtomDBFactory::create(const JsonConfig& config) {
+    if (config.at_path("uid").is_null()) {
+        RAISE_ERROR("AtomDBFactory: missing uid");
+    }
+
     auto atomdb_type = config.at_path("type").get_or<string>("");
 
     AtomDBType type = AtomDB::string_to_type(atomdb_type);
@@ -71,22 +75,28 @@ shared_ptr<AtomDB> AtomDBFactory::create_composite_atomdb(const JsonConfig& conf
 
         for (auto& entry : remote_peers_config) {
             auto peer_config = JsonConfig(entry);
+            if (peer_config.at_path("uid").is_null()) {
+                RAISE_ERROR("AtomDBFactory: remote peer is missing uid");
+            }
             string uid = peer_config.at_path("uid").get_or<string>("");
-            if (uid.empty()) {
-                RAISE_ERROR("AtomDBFactory: remote peer is missing a non-empty uid");
+            if (remote_peers.find(uid) != remote_peers.end()) {
+                RAISE_ERROR("AtomDBFactory: duplicate remote peer uid: " + uid);
             }
 
             shared_ptr<AtomDB> local_persistence = nullptr;
             auto local_persistence_config =
                 peer_config.at_path("local_persistence").get_or<JsonConfig>(JsonConfig());
             if (!local_persistence_config.empty()) {
+                if (local_persistence_config.at_path("uid").is_null()) {
+                    local_persistence_config["uid"] = uid;
+                }
                 local_persistence = create_basic_atomdb(local_persistence_config);
             }
             remote_peers[uid] =
-                make_shared<RemoteAtomDBPeer>(create_basic_atomdb(peer_config), local_persistence, uid);
+                make_shared<RemoteAtomDBPeer>(uid, create_basic_atomdb(peer_config), local_persistence);
         }
 
-        atomdb = make_shared<RemoteAtomDB>(remote_peers, config.at_path("uid").get_or<string>(""));
+        atomdb = make_shared<RemoteAtomDB>(config.at_path("uid").get_or<string>(""), remote_peers);
     } else if (type == AtomDBType::AdapterDB) {
         // The backend AtomDB in AdapterDB could be RemoteAtomDB ?
         auto atomdb_backend_config =

--- a/src/atomdb/AtomDBFactory.cc
+++ b/src/atomdb/AtomDBFactory.cc
@@ -49,7 +49,7 @@ shared_ptr<AtomDB> AtomDBFactory::create_basic_atomdb(const JsonConfig& config) 
     } else if (type == AtomDBType::MorkDB) {
         atomdb = make_shared<MorkDB>(config);
     } else if (type == AtomDBType::InMemoryDB) {
-        atomdb = make_shared<InMemoryDB>();
+        atomdb = make_shared<InMemoryDB>(config);
     } else {
         RAISE_ERROR("AtomDBFactory: '" + atomdb_type + "' is not a basic AtomDB type");
     }
@@ -86,7 +86,7 @@ shared_ptr<AtomDB> AtomDBFactory::create_composite_atomdb(const JsonConfig& conf
                 make_shared<RemoteAtomDBPeer>(create_basic_atomdb(peer_config), local_persistence, uid);
         }
 
-        atomdb = make_shared<RemoteAtomDB>(remote_peers);
+        atomdb = make_shared<RemoteAtomDB>(remote_peers, config.at_path("uid").get_or<string>(""));
     } else if (type == AtomDBType::AdapterDB) {
         // The backend AtomDB in AdapterDB could be RemoteAtomDB ?
         auto atomdb_backend_config =

--- a/src/atomdb/AtomDBFactory.cc
+++ b/src/atomdb/AtomDBFactory.cc
@@ -41,6 +41,10 @@ shared_ptr<AtomDB> AtomDBFactory::create(const JsonConfig& config) {
 // Private methods
 
 shared_ptr<AtomDB> AtomDBFactory::create_basic_atomdb(const JsonConfig& config) {
+    if (config.at_path("uid").is_null()) {
+        RAISE_ERROR("AtomDBFactory: missing uid");
+    }
+
     auto atomdb_type = config.at_path("type").get_or<string>("");
 
     AtomDBType type = AtomDB::string_to_type(atomdb_type);
@@ -87,9 +91,6 @@ shared_ptr<AtomDB> AtomDBFactory::create_composite_atomdb(const JsonConfig& conf
             auto local_persistence_config =
                 peer_config.at_path("local_persistence").get_or<JsonConfig>(JsonConfig());
             if (!local_persistence_config.empty()) {
-                if (local_persistence_config.at_path("uid").is_null()) {
-                    local_persistence_config["uid"] = uid;
-                }
                 local_persistence = create_basic_atomdb(local_persistence_config);
             }
             remote_peers[uid] =
@@ -101,6 +102,10 @@ shared_ptr<AtomDB> AtomDBFactory::create_composite_atomdb(const JsonConfig& conf
         // The backend AtomDB in AdapterDB could be RemoteAtomDB ?
         auto atomdb_backend_config =
             config.at_path("adapterdb.atomdb_backend").get_or<JsonConfig>(JsonConfig());
+        string backend_uid = atomdb_backend_config.at_path("uid").get_or<string>("");
+        if (atomdb_backend_config.at_path("uid").is_null() || backend_uid.empty()) {
+            RAISE_ERROR("AtomDBFactory: adapterdb backend requires a nonempty uid");
+        }
         auto basic_atomdb = create_basic_atomdb(atomdb_backend_config);
         atomdb = make_shared<AdapterDB>(config, basic_atomdb);
     } else {

--- a/src/atomdb/AtomDBFactory.h
+++ b/src/atomdb/AtomDBFactory.h
@@ -29,7 +29,8 @@ class AtomDBFactory {
      * @brief Creates an AtomDB from config and wraps it with ProtectedAtomDB when applicable.
      *
      * @param config AtomDB configuration. Required key: `"type"` (`redismongodb`, `morkdb`,
-     *        `inmemorydb`, `remotedb`, or `adapterdb`).
+     *        `inmemorydb`, `remotedb`, or `adapterdb`). Optional `"uid"` identifies this
+     *        instance (required and non-empty on each remotedb peer).
      *
      * Breaking change: `create()` no longer takes a `context` argument. Redis/Mongo namespace
      * isolation is now per backend via optional `JsonConfig["prefix"]` on that backend's

--- a/src/atomdb/AtomDBFactory.h
+++ b/src/atomdb/AtomDBFactory.h
@@ -31,6 +31,8 @@ class AtomDBFactory {
      * @param config AtomDB configuration. Required keys: `"type"` (`redismongodb`, `morkdb`,
      *        `inmemorydb`, `remotedb`, or `adapterdb`) and `"uid"` (may be empty). Each remotedb
      *        peer also requires a `"uid"` key (may be empty; must be unique among peers).
+     *        `adapterdb.atomdb_backend` requires a nonempty `"uid"`. Each remotedb peer
+     *        `local_persistence` also requires its own `"uid"` key.
      *
      * Breaking change: `create()` no longer takes a `context` argument. Redis/Mongo namespace
      * isolation is now per backend via optional `JsonConfig["prefix"]` on that backend's

--- a/src/atomdb/AtomDBFactory.h
+++ b/src/atomdb/AtomDBFactory.h
@@ -28,9 +28,9 @@ class AtomDBFactory {
     /**
      * @brief Creates an AtomDB from config and wraps it with ProtectedAtomDB when applicable.
      *
-     * @param config AtomDB configuration. Required key: `"type"` (`redismongodb`, `morkdb`,
-     *        `inmemorydb`, `remotedb`, or `adapterdb`). Optional `"uid"` identifies this
-     *        instance (required and non-empty on each remotedb peer).
+     * @param config AtomDB configuration. Required keys: `"type"` (`redismongodb`, `morkdb`,
+     *        `inmemorydb`, `remotedb`, or `adapterdb`) and `"uid"` (may be empty). Each remotedb
+     *        peer also requires a `"uid"` key (may be empty; must be unique among peers).
      *
      * Breaking change: `create()` no longer takes a `context` argument. Redis/Mongo namespace
      * isolation is now per backend via optional `JsonConfig["prefix"]` on that backend's

--- a/src/atomdb/ProtectedAtomDB.cc
+++ b/src/atomdb/ProtectedAtomDB.cc
@@ -15,6 +15,7 @@ ProtectedAtomDB::ProtectedAtomDB(shared_ptr<AtomDB> backend) : backend(backend) 
     if (this->backend == nullptr) {
         RAISE_ERROR("ProtectedAtomDB requires a non-null backend AtomDB");
     }
+    this->uid_ = this->backend->get_uid();
     LOG_INFO("ProtectedAtomDB initialized");
 }
 

--- a/src/atomdb/adapterdb/AdapterDB.cc
+++ b/src/atomdb/adapterdb/AdapterDB.cc
@@ -33,7 +33,7 @@ string AdapterDB::MONGODB_ADAPTER_COLLECTION_NAME = "adapterdb";
 // ==============================
 
 AdapterDB::AdapterDB(const JsonConfig& config, std::shared_ptr<AtomDB> backend)
-    : config(config), atomdb_backend(backend) {
+    : AtomDB(config.at_path("uid").get_or<string>("")), config(config), atomdb_backend(backend) {
     this->initialize(true);
 }
 

--- a/src/atomdb/inmemorydb/InMemoryDB.cc
+++ b/src/atomdb/inmemorydb/InMemoryDB.cc
@@ -149,6 +149,9 @@ shared_ptr<InMemoryDB::Tries> InMemoryDB::make_tries() {
 
 InMemoryDB::InMemoryDB() : tries_(make_tries()) {}
 
+InMemoryDB::InMemoryDB(const JsonConfig& config)
+    : AtomDB(config.at_path("uid").get_or<string>("")), tries_(make_tries()) {}
+
 InMemoryDB::~InMemoryDB() = default;
 
 bool InMemoryDB::allow_nested_indexing() { return false; }

--- a/src/atomdb/inmemorydb/InMemoryDB.h
+++ b/src/atomdb/inmemorydb/InMemoryDB.h
@@ -12,6 +12,7 @@
 #include "AtomDB.h"
 #include "HandleTrie.h"
 #include "InMemoryDBAPITypes.h"
+#include "JsonConfig.h"
 #include "LinkSchema.h"
 
 using namespace std;
@@ -45,6 +46,7 @@ namespace atomdb {
 class InMemoryDB : public AtomDB {
    public:
     InMemoryDB();
+    explicit InMemoryDB(const JsonConfig& config);
     ~InMemoryDB();
 
     bool allow_nested_indexing() override;

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -50,7 +50,8 @@ void RedisMongoDB::initialize_namespace(const string& prefix) {
 }
 
 RedisMongoDB::RedisMongoDB(const JsonConfig& config)
-    : skip_redis_(config.at_path("type").get_or<string>("") != "redismongodb"),
+    : AtomDB(config.at_path("uid").get_or<string>("")),
+      skip_redis_(config.at_path("type").get_or<string>("") != "redismongodb"),
       composite_type_enabled_(config.at_path("composite_type_enabled").get_or<bool>(true)),
       cluster_flag(false),
       protection_mode(atomdb_api_types::ProtectionMode::PROTECTED) {
@@ -75,20 +76,14 @@ vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> RedisMongoDB::get
     const atomdb_api_types::PublicKey& public_key) const {
     vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> documents;
 
-    if (public_key.is_single_key()) {
-        auto document = this->load_access_permission_document(public_key.keys[0]);
-        if (document.has_value()) {
-            documents.push_back(document.value());
-        }
+    auto key = public_key.key_for_uid(this->get_uid());
+    if (!key.has_value()) {
         return documents;
     }
 
-    for (const auto& [peer_uid, idx] : (public_key.peer_to_key)) {
-        string key = public_key.keys[idx];
-        auto document = this->load_access_permission_document(key);
-        if (document.has_value()) {
-            documents.push_back(document.value());
-        }
+    auto document = this->load_access_permission_document(*key);
+    if (document.has_value()) {
+        documents.push_back(*document);
     }
     return documents;
 }

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -77,11 +77,11 @@ vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> RedisMongoDB::get
     vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> documents;
 
     auto key = public_key.key_for_uid(this->get_uid());
-    if (!key.has_value()) {
+    if (key.empty()) {
         return documents;
     }
 
-    auto document = this->load_access_permission_document(*key);
+    auto document = this->load_access_permission_document(key);
     if (document.has_value()) {
         documents.push_back(*document);
     }

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -23,7 +23,7 @@ using namespace commons;
 
 using json = nlohmann::json;
 
-RemoteAtomDB::RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers, const string& uid)
+RemoteAtomDB::RemoteAtomDB(const string& uid, map<string, shared_ptr<RemoteAtomDBPeer>> peers)
     : AtomDB(uid), remote_db_(std::move(peers)) {
     LOG_INFO("RemoteAtomDB initialized with " << remote_db_.size() << " pre-built peers");
     finalize_peer_lists();

--- a/src/atomdb/remotedb/RemoteAtomDB.cc
+++ b/src/atomdb/remotedb/RemoteAtomDB.cc
@@ -23,8 +23,8 @@ using namespace commons;
 
 using json = nlohmann::json;
 
-RemoteAtomDB::RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers)
-    : remote_db_(std::move(peers)) {
+RemoteAtomDB::RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers, const string& uid)
+    : AtomDB(uid), remote_db_(std::move(peers)) {
     LOG_INFO("RemoteAtomDB initialized with " << remote_db_.size() << " pre-built peers");
     finalize_peer_lists();
 }

--- a/src/atomdb/remotedb/RemoteAtomDB.h
+++ b/src/atomdb/remotedb/RemoteAtomDB.h
@@ -23,7 +23,7 @@ class RemoteAtomDB : public AtomDB {
      * Dependency-injection constructor for pre-built peers.
      * Primarily used by tests to federate controllable backends without live config/connection.
      */
-    explicit RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers);
+    explicit RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers, const string& uid = "");
     ~RemoteAtomDB();
 
     bool allow_nested_indexing() override;

--- a/src/atomdb/remotedb/RemoteAtomDB.h
+++ b/src/atomdb/remotedb/RemoteAtomDB.h
@@ -23,7 +23,7 @@ class RemoteAtomDB : public AtomDB {
      * Dependency-injection constructor for pre-built peers.
      * Primarily used by tests to federate controllable backends without live config/connection.
      */
-    explicit RemoteAtomDB(map<string, shared_ptr<RemoteAtomDBPeer>> peers, const string& uid = "");
+    explicit RemoteAtomDB(const string& uid, map<string, shared_ptr<RemoteAtomDBPeer>> peers);
     ~RemoteAtomDB();
 
     bool allow_nested_indexing() override;

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -21,9 +21,9 @@ using namespace atomdb_api_types;
 using namespace atoms;
 using namespace commons;
 
-RemoteAtomDBPeer::RemoteAtomDBPeer(shared_ptr<AtomDB> remote_atomdb,
-                                   shared_ptr<AtomDB> local_persistence,
-                                   const string& uid)
+RemoteAtomDBPeer::RemoteAtomDBPeer(const string& uid,
+                                   shared_ptr<AtomDB> remote_atomdb,
+                                   shared_ptr<AtomDB> local_persistence)
     : AtomDB(uid),
       write_buffer_(make_shared<InMemoryDB>()),
       read_cache_(make_shared<InMemoryDB>()),

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -24,7 +24,7 @@ using namespace commons;
 RemoteAtomDBPeer::RemoteAtomDBPeer(shared_ptr<AtomDB> remote_atomdb,
                                    shared_ptr<AtomDB> local_persistence,
                                    const string& uid)
-    : uid_(uid),
+    : AtomDB(uid),
       write_buffer_(make_shared<InMemoryDB>()),
       read_cache_(make_shared<InMemoryDB>()),
       atomdb_(remote_atomdb),

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -112,7 +112,6 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
     // ThreadMethod interface
     bool thread_one_step() override;
 
-    const string& get_uid() const { return uid_; }
     bool is_readonly() const { return local_persistence_ == nullptr; }
     shared_ptr<AtomDB> get_remote_atomdb() const { return atomdb_; }
 
@@ -138,7 +137,6 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
     // release retries them instead of losing dirty writes.
     void restage_atoms(const vector<shared_ptr<atoms::Atom>>& atoms);
 
-    string uid_;
     shared_ptr<InMemoryDB> write_buffer_;
     shared_ptr<InMemoryDB> read_cache_;
     shared_ptr<AtomDB> atomdb_;

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -36,9 +36,9 @@ namespace atomdb {
  */
 class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
    public:
-    RemoteAtomDBPeer(shared_ptr<AtomDB> remote_atomdb,
-                     shared_ptr<AtomDB> local_persistence = nullptr,
-                     const string& uid = "");
+    RemoteAtomDBPeer(const string& uid,
+                     shared_ptr<AtomDB> remote_atomdb,
+                     shared_ptr<AtomDB> local_persistence = nullptr);
     ~RemoteAtomDBPeer();
 
     bool allow_nested_indexing() override;

--- a/src/commons/JsonConfigParser.cc
+++ b/src/commons/JsonConfigParser.cc
@@ -18,8 +18,14 @@ namespace commons {
 namespace {
 
 const vector<string> required_fields_by_version() {
-    static const vector<string> required = {
-        "atomdb", "atomdb.type", "loaders", "agents", "vault", "vault.type", "vault.endpoint"};
+    static const vector<string> required = {"atomdb",
+                                            "atomdb.uid",
+                                            "atomdb.type",
+                                            "loaders",
+                                            "agents",
+                                            "vault",
+                                            "vault.type",
+                                            "vault.endpoint"};
     return required;
 }
 

--- a/src/scripts/test_all_setup.sh
+++ b/src/scripts/test_all_setup.sh
@@ -15,7 +15,7 @@ DAS_MORK_HOSTNAME=0.0.0.0
 DAS_MORK_PORT=40022
 
 REDIS_IMAGE=redis:7.2.3-alpine
-MONGODB_IMAGE=mongodb/mongodb-community-server:8.2-ubuntu2204
+MONGODB_IMAGE=mongodb/mongodb-community-server:8.0.4-ubuntu2204
 METTA_LOADER_IMAGE=trueagi/das:1.0.0-metta-parser
 MORK_IMAGE=trueagi/das:mork-server-1.1.0
 MORK_LOADER_IMAGE=trueagi/das:mork-loader-1.1.0

--- a/src/scripts/test_all_setup.sh
+++ b/src/scripts/test_all_setup.sh
@@ -15,7 +15,7 @@ DAS_MORK_HOSTNAME=0.0.0.0
 DAS_MORK_PORT=40022
 
 REDIS_IMAGE=redis:7.2.3-alpine
-MONGODB_IMAGE=mongodb/mongodb-community-server:8.0.4-ubuntu2204
+MONGODB_IMAGE=mongodb/mongodb-community-server:8.2-ubuntu2204
 METTA_LOADER_IMAGE=trueagi/das:1.0.0-metta-parser
 MORK_IMAGE=trueagi/das:mork-server-1.1.0
 MORK_LOADER_IMAGE=trueagi/das:mork-loader-1.1.0

--- a/src/tests/assets/adapterdb_config.json
+++ b/src/tests/assets/adapterdb_config.json
@@ -1,6 +1,7 @@
 {
     "schema_version": "1.0",
     "atomdb": {
+        "uid": "adapter",
         "type": "adapterdb",
         "adapterdb": {
             "endpoint": "localhost:40023",
@@ -19,6 +20,7 @@
                 "reuse_mongodb": true
             },
             "atomdb_backend": {
+                "uid": "adapter",
                 "type": "morkdb",
                 "composite_type_enabled": true,
                 "mongodb": {

--- a/src/tests/assets/adapterdb_config.json
+++ b/src/tests/assets/adapterdb_config.json
@@ -58,6 +58,7 @@
                     "cluster": false
                 },
                 "local_persistence": {
+                    "uid": "peer1",
                     "type": "morkdb",
                     "prefix": "remotedb_test_peer1_local_",
                     "composite_type_enabled": true,
@@ -75,6 +76,7 @@
                 "uid": "peer2",
                 "type": "inmemorydb",
                 "local_persistence": {
+                    "uid": "peer2",
                     "type": "inmemorydb"
                 }
             }

--- a/src/tests/assets/remotedb_config.json
+++ b/src/tests/assets/remotedb_config.json
@@ -1,4 +1,5 @@
 {
+    "uid": "remote",
     "remote_peers": [
         {
             "uid": "peer1",

--- a/src/tests/assets/remotedb_config.json
+++ b/src/tests/assets/remotedb_config.json
@@ -5,6 +5,7 @@
             "uid": "peer1",
             "type": "inmemorydb",
             "local_persistence": {
+                "uid": "peer1",
                 "type": "morkdb",
                 "prefix": "remote_atomdb_test_",
                 "morkdb": {

--- a/src/tests/assets/remotedb_config_single.json
+++ b/src/tests/assets/remotedb_config_single.json
@@ -16,6 +16,7 @@
                 "password": "admin"
             },
             "local_persistence": {
+                "uid": "single_peer",
                 "type": "inmemorydb"
             }
         }

--- a/src/tests/assets/remotedb_config_single.json
+++ b/src/tests/assets/remotedb_config_single.json
@@ -1,4 +1,5 @@
 {
+    "uid": "remote_single",
     "remote_peers": [
         {
             "uid": "single_peer",

--- a/src/tests/benchmark/atomdb/atomdb_main.cc
+++ b/src/tests/benchmark/atomdb/atomdb_main.cc
@@ -33,6 +33,7 @@ namespace {
 /** Benchmark compose ports (see scripts/run_benchmark.sh). */
 JsonConfig benchmark_atomdb_config() {
     return JsonConfig(nlohmann::json::parse(R"({
+        "uid": "benchmark",
         "redis": { "endpoint": "localhost:29000", "cluster": false },
         "mongodb": {
             "endpoint": "localhost:28000",

--- a/src/tests/cpp/atomdb_factory_test.cc
+++ b/src/tests/cpp/atomdb_factory_test.cc
@@ -39,7 +39,9 @@ JsonConfig remotedb_config_with_inmemory_peers() {
     json["uid"] = "federation";
     json["remote_peers"] = nlohmann::json::array(
         {{{"uid", "peer1"}, {"type", "inmemorydb"}},
-         {{"uid", "peer2"}, {"type", "inmemorydb"}, {"local_persistence", {{"type", "inmemorydb"}}}}});
+         {{"uid", "peer2"},
+          {"type", "inmemorydb"},
+          {"local_persistence", {{"uid", "peer2_local"}, {"type", "inmemorydb"}}}}});
     return JsonConfig(json);
 }
 
@@ -134,6 +136,16 @@ TEST(AtomDBFactoryTest, CreateRemoteAtomDBRejectsPeerWithoutUid) {
     EXPECT_THROW(AtomDBFactory::create(JsonConfig(json)), runtime_error);
 }
 
+TEST(AtomDBFactoryTest, CreateRemoteAtomDBRejectsLocalPersistenceWithoutUid) {
+    nlohmann::json json;
+    json["type"] = "remotedb";
+    json["uid"] = "federation";
+    json["remote_peers"] = nlohmann::json::array(
+        {{{"uid", "peer2"}, {"type", "inmemorydb"}, {"local_persistence", {{"type", "inmemorydb"}}}}});
+
+    EXPECT_THROW(AtomDBFactory::create(JsonConfig(json)), runtime_error);
+}
+
 TEST(AtomDBFactoryTest, CreateRemoteAtomDBAllowsEmptyPeerUid) {
     nlohmann::json json;
     json["type"] = "remotedb";
@@ -154,7 +166,7 @@ TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
     missing_backend["uid"] = "adapter_factory";
     missing_backend["adapterdb"] = nlohmann::json::object();
 
-    // Missing adapterdb.atomdb_backend.type makes create_basic_atomdb fail via AtomDB::string_to_type.
+    // Missing adapterdb.atomdb_backend (and its nonempty uid) is rejected before construction.
     EXPECT_THROW(AtomDBFactory::create(missing_backend), runtime_error);
 
     // Valid adapterdb.atomdb_backend: factory constructs AdapterDB and delegates AtomDB ops.
@@ -205,6 +217,18 @@ TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
     ASSERT_NE(adapter_db->get_node(handle), nullptr);
 
     remove(mapping_path.c_str());
+}
+
+TEST(AtomDBFactoryTest, CreateAdapterDBRejectsBackendWithoutUid) {
+    nlohmann::json json;
+    json["type"] = "adapterdb";
+    json["uid"] = "adapter_factory";
+    json["adapterdb"] = {{"atomdb_backend", {{"type", "inmemorydb"}}}};
+
+    EXPECT_THROW(AtomDBFactory::create(JsonConfig(json)), runtime_error);
+
+    json["adapterdb"]["atomdb_backend"]["uid"] = "";
+    EXPECT_THROW(AtomDBFactory::create(JsonConfig(json)), runtime_error);
 }
 
 TEST(AtomDBFactoryTest, CreateInMemoryDBIsNotProtected) {

--- a/src/tests/cpp/atomdb_factory_test.cc
+++ b/src/tests/cpp/atomdb_factory_test.cc
@@ -47,12 +47,24 @@ TEST(AtomDBFactoryTest, CreateInMemoryDB) {
     auto db = AtomDBFactory::create(config_with_type("inmemorydb"));
     ASSERT_NE(db, nullptr);
     EXPECT_NE(dynamic_pointer_cast<InMemoryDB>(db), nullptr);
+    EXPECT_EQ(db->get_uid(), "");
+}
+
+TEST(AtomDBFactoryTest, CreateInMemoryDBReadsUid) {
+    JsonConfig config;
+    config["type"] = "inmemorydb";
+    config["uid"] = "mem1";
+    auto db = AtomDBFactory::create(config);
+    ASSERT_NE(db, nullptr);
+    EXPECT_EQ(db->get_uid(), "mem1");
 }
 
 TEST(AtomDBFactoryTest, CreateMorkDB) {
-    auto db = AtomDBFactory::create(test_atomdb_json_config("morkdb", "atomdb_factory_test_"));
+    auto db =
+        AtomDBFactory::create(test_atomdb_json_config("morkdb", "atomdb_factory_test_", "mork_factory"));
     ASSERT_NE(db, nullptr);
     EXPECT_NE(dynamic_pointer_cast<MorkDB>(db), nullptr);
+    EXPECT_EQ(db->get_uid(), "mork_factory");
 }
 
 TEST(AtomDBFactoryTest, CreateRejectsMissingAndUnknownTypes) {
@@ -75,6 +87,18 @@ TEST(AtomDBFactoryTest, CreateRemoteAtomDBAssemblesPeers) {
     // peer1 has no local_persistence; peer2 does.
     EXPECT_TRUE(peers.at("peer1")->is_readonly());
     EXPECT_FALSE(peers.at("peer2")->is_readonly());
+    EXPECT_EQ(db->get_uid(), "");
+    EXPECT_EQ(peers.at("peer1")->get_uid(), "peer1");
+    EXPECT_EQ(peers.at("peer1")->get_remote_atomdb()->get_uid(), "peer1");
+    EXPECT_EQ(peers.at("peer2")->get_uid(), "peer2");
+}
+
+TEST(AtomDBFactoryTest, CreateRemoteAtomDBReadsFacadeUid) {
+    auto json = remotedb_config_with_inmemory_peers().get_json();
+    json["uid"] = "federation";
+    auto db = AtomDBFactory::create(JsonConfig(json));
+    ASSERT_NE(db, nullptr);
+    EXPECT_EQ(db->get_uid(), "federation");
 }
 
 TEST(AtomDBFactoryTest, CreateRemoteAtomDBWithEmptyPeers) {
@@ -130,6 +154,7 @@ TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
 
     nlohmann::json json;
     json["type"] = "adapterdb";
+    json["uid"] = "adapter_factory";
     json["adapterdb"] = {
         {"type", "mork"},
         {"context_mapping_paths", nlohmann::json::array({mapping_path})},
@@ -144,6 +169,7 @@ TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
 
     auto adapter_db = dynamic_pointer_cast<AdapterDB>(db);
     ASSERT_NE(adapter_db, nullptr);
+    EXPECT_EQ(adapter_db->get_uid(), "adapter_factory");
 
     Node node("Symbol", "FactoryAdapterDBDelegationNode");
     string handle = adapter_db->add_node(&node);

--- a/src/tests/cpp/atomdb_factory_test.cc
+++ b/src/tests/cpp/atomdb_factory_test.cc
@@ -29,12 +29,14 @@ namespace {
 JsonConfig config_with_type(const string& type) {
     JsonConfig config;
     config["type"] = type;
+    config["uid"] = "test";
     return config;
 }
 
 JsonConfig remotedb_config_with_inmemory_peers() {
     nlohmann::json json;
     json["type"] = "remotedb";
+    json["uid"] = "federation";
     json["remote_peers"] = nlohmann::json::array(
         {{{"uid", "peer1"}, {"type", "inmemorydb"}},
          {{"uid", "peer2"}, {"type", "inmemorydb"}, {"local_persistence", {{"type", "inmemorydb"}}}}});
@@ -47,7 +49,7 @@ TEST(AtomDBFactoryTest, CreateInMemoryDB) {
     auto db = AtomDBFactory::create(config_with_type("inmemorydb"));
     ASSERT_NE(db, nullptr);
     EXPECT_NE(dynamic_pointer_cast<InMemoryDB>(db), nullptr);
-    EXPECT_EQ(db->get_uid(), "");
+    EXPECT_EQ(db->get_uid(), "test");
 }
 
 TEST(AtomDBFactoryTest, CreateInMemoryDBReadsUid) {
@@ -73,6 +75,21 @@ TEST(AtomDBFactoryTest, CreateRejectsMissingAndUnknownTypes) {
     EXPECT_THROW(AtomDBFactory::create(config_with_type("unknown")), runtime_error);
 }
 
+TEST(AtomDBFactoryTest, CreateRejectsMissingUid) {
+    JsonConfig config;
+    config["type"] = "inmemorydb";
+    EXPECT_THROW(AtomDBFactory::create(config), runtime_error);
+}
+
+TEST(AtomDBFactoryTest, CreateAllowsEmptyUid) {
+    JsonConfig config;
+    config["type"] = "inmemorydb";
+    config["uid"] = "";
+    auto db = AtomDBFactory::create(config);
+    ASSERT_NE(db, nullptr);
+    EXPECT_EQ(db->get_uid(), "");
+}
+
 TEST(AtomDBFactoryTest, CreateRemoteAtomDBAssemblesPeers) {
     auto db = AtomDBFactory::create(remotedb_config_with_inmemory_peers());
     ASSERT_NE(db, nullptr);
@@ -87,23 +104,16 @@ TEST(AtomDBFactoryTest, CreateRemoteAtomDBAssemblesPeers) {
     // peer1 has no local_persistence; peer2 does.
     EXPECT_TRUE(peers.at("peer1")->is_readonly());
     EXPECT_FALSE(peers.at("peer2")->is_readonly());
-    EXPECT_EQ(db->get_uid(), "");
+    EXPECT_EQ(db->get_uid(), "federation");
     EXPECT_EQ(peers.at("peer1")->get_uid(), "peer1");
     EXPECT_EQ(peers.at("peer1")->get_remote_atomdb()->get_uid(), "peer1");
     EXPECT_EQ(peers.at("peer2")->get_uid(), "peer2");
 }
 
-TEST(AtomDBFactoryTest, CreateRemoteAtomDBReadsFacadeUid) {
-    auto json = remotedb_config_with_inmemory_peers().get_json();
-    json["uid"] = "federation";
-    auto db = AtomDBFactory::create(JsonConfig(json));
-    ASSERT_NE(db, nullptr);
-    EXPECT_EQ(db->get_uid(), "federation");
-}
-
 TEST(AtomDBFactoryTest, CreateRemoteAtomDBWithEmptyPeers) {
     JsonConfig config;
     config["type"] = "remotedb";
+    config["uid"] = "federation";
     config["remote_peers"] = nlohmann::json::array();
 
     auto db = AtomDBFactory::create(config);
@@ -117,15 +127,31 @@ TEST(AtomDBFactoryTest, CreateRemoteAtomDBWithEmptyPeers) {
 TEST(AtomDBFactoryTest, CreateRemoteAtomDBRejectsPeerWithoutUid) {
     nlohmann::json json;
     json["type"] = "remotedb";
+    json["uid"] = "federation";
     json["remote_peers"] =
         nlohmann::json::array({{{"type", "inmemorydb"}}, {{"uid", "peer_ok"}, {"type", "inmemorydb"}}});
 
     EXPECT_THROW(AtomDBFactory::create(JsonConfig(json)), runtime_error);
 }
 
+TEST(AtomDBFactoryTest, CreateRemoteAtomDBAllowsEmptyPeerUid) {
+    nlohmann::json json;
+    json["type"] = "remotedb";
+    json["uid"] = "";
+    json["remote_peers"] = nlohmann::json::array({{{"uid", ""}, {"type", "inmemorydb"}}});
+
+    auto db = AtomDBFactory::create(JsonConfig(json));
+    auto remote_db = dynamic_pointer_cast<RemoteAtomDB>(db);
+    ASSERT_NE(remote_db, nullptr);
+    EXPECT_EQ(db->get_uid(), "");
+    ASSERT_NE(remote_db->get_peer(""), nullptr);
+    EXPECT_EQ(remote_db->get_peer("")->get_uid(), "");
+}
+
 TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
     JsonConfig missing_backend;
     missing_backend["type"] = "adapterdb";
+    missing_backend["uid"] = "adapter_factory";
     missing_backend["adapterdb"] = nlohmann::json::object();
 
     // Missing adapterdb.atomdb_backend.type makes create_basic_atomdb fail via AtomDB::string_to_type.
@@ -161,7 +187,8 @@ TEST(AtomDBFactoryTest, CreateAdapterDBRequiresBackendType) {
         {"database_credentials", {{"host", "localhost"}, {"port", 40032}}},
         {"persistence", {{"reuse_mongodb", true}}},
         {"export_metta_on_mapping", {{"enabled", false}, {"output_dir", "/tmp"}}},
-        {"atomdb_backend", test_atomdb_json_config("morkdb", "atomdb_factory_test_").get_json()},
+        {"atomdb_backend",
+         test_atomdb_json_config("morkdb", "atomdb_factory_test_", "adapter_backend").get_json()},
     };
 
     auto db = AtomDBFactory::create(JsonConfig(json));

--- a/src/tests/cpp/config_parser_test.cc
+++ b/src/tests/cpp/config_parser_test.cc
@@ -16,6 +16,7 @@ namespace {
 
 const char* kValidConfigV1 = R"({
   "atomdb": {
+    "uid": "local",
     "type": "redismongodb",
     "composite_type_enabled": true,
     "redis": {
@@ -57,6 +58,8 @@ TEST(ConfigParserTest, GetNestedStructure) {
     auto atomdb = config.at_path("atomdb").get_or<JsonConfig>(JsonConfig());
     string type = atomdb.at_path("type").get_or<string>("");
     EXPECT_EQ(type, "redismongodb");
+    string uid = atomdb.at_path("uid").get_or<string>("");
+    EXPECT_EQ(uid, "local");
     bool composite_type_enabled = atomdb.at_path("composite_type_enabled").get_or<bool>(false);
     EXPECT_TRUE(composite_type_enabled);
 

--- a/src/tests/cpp/config_parser_test.cc
+++ b/src/tests/cpp/config_parser_test.cc
@@ -117,9 +117,30 @@ TEST(ConfigParserTest, GetJsonReturnsRoot) {
     EXPECT_EQ(j["atomdb"]["redis"]["port"].get<long>(), 40020);
 }
 
+TEST(ConfigParserTest, MissingAtomdbUidThrows) {
+    string without_uid = R"({
+      "atomdb": { "type": "redismongodb" },
+      "loaders": {},
+      "agents": {},
+      "vault": { "type": "openbao", "endpoint": "http://localhost:40010" }
+    })";
+    EXPECT_THROW(JsonConfigParser::load_from_string(without_uid), runtime_error);
+}
+
+TEST(ConfigParserTest, EmptyAtomdbUidIsAllowed) {
+    string empty_uid = R"({
+      "atomdb": { "uid": "", "type": "redismongodb" },
+      "loaders": {},
+      "agents": {},
+      "vault": { "type": "openbao", "endpoint": "http://localhost:40010" }
+    })";
+    JsonConfig config = JsonConfigParser::load_from_string(empty_uid);
+    EXPECT_EQ(config.at_path("atomdb.uid").get_or<string>("missing"), "");
+}
+
 TEST(ConfigParserTest, MissingVaultFieldThrows) {
     string without_vault = R"({
-      "atomdb": { "type": "redismongodb" },
+      "atomdb": { "uid": "local", "type": "redismongodb" },
       "loaders": {},
       "agents": {}
     })";
@@ -128,7 +149,7 @@ TEST(ConfigParserTest, MissingVaultFieldThrows) {
 
 TEST(ConfigParserTest, VaultTypeValueNotCheckedWithoutRefs) {
     string other_type = R"({
-      "atomdb": { "type": "redismongodb" },
+      "atomdb": { "uid": "local", "type": "redismongodb" },
       "loaders": {},
       "agents": {},
       "vault": { "type": "hashicorp", "endpoint": "localhost:40010" }
@@ -329,7 +350,7 @@ TEST(VaultJsonResolverTest, HttpAndHttpsEndpointsReachTokenPrompt) {
 
 TEST(ConfigParserTest, MalformedVaultUriFailsBeforeTokenPrompt) {
     string json = R"({
-      "atomdb": { "type": "redismongodb", "password": "vault://test" },
+      "atomdb": { "uid": "local", "type": "redismongodb", "password": "vault://test" },
       "loaders": {},
       "agents": {},
       "vault": { "type": "openbao", "endpoint": "http://localhost:40010" }
@@ -347,6 +368,7 @@ TEST(ConfigParserTest, MalformedVaultUriFailsBeforeTokenPrompt) {
 TEST(ConfigParserTest, VaultRefsWithoutTerminalTokenFail) {
     string with_ref = R"({
       "atomdb": {
+        "uid": "local",
         "type": "redismongodb",
         "mongodb": { "password": "vault://test/dbs/pass" }
       },

--- a/src/tests/cpp/inmemorydb_test.cc
+++ b/src/tests/cpp/inmemorydb_test.cc
@@ -1381,6 +1381,13 @@ TEST(InMemoryDBConfigTest, GetUidFromConfig) {
     EXPECT_EQ(db->get_uid(), "mem");
 }
 
+TEST(InMemoryDBConfigTest, AllowsEmptyUid) {
+    JsonConfig config;
+    config["uid"] = "";
+    auto db = make_shared<InMemoryDB>(config);
+    EXPECT_EQ(db->get_uid(), "");
+}
+
 TEST_F(InMemoryDBTest, GetAccessPermissionsReturnsEmpty) {
     auto permissions = db->get_access_permissions(PublicKey("any_key"));
     EXPECT_TRUE(permissions.empty());

--- a/src/tests/cpp/inmemorydb_test.cc
+++ b/src/tests/cpp/inmemorydb_test.cc
@@ -13,6 +13,7 @@
 
 #include "Assignment.h"
 #include "InMemoryDBAPITypes.h"
+#include "JsonConfig.h"
 #include "Link.h"
 #include "LinkSchema.h"
 #include "Merger.h"
@@ -1369,6 +1370,15 @@ TEST_F(InMemoryDBTest, ConcurrentPatternQueriesSurviveReIndex) {
     EXPECT_EQ(reader_failures.load(), 0);
     EXPECT_GT(overlapping_queries.load(), 0);  // queries really raced the swaps
     EXPECT_EQ(db->atom_count(), static_cast<size_t>(2 * kNodes));
+}
+
+TEST_F(InMemoryDBTest, GetUidDefaultEmpty) { EXPECT_EQ(db->get_uid(), ""); }
+
+TEST(InMemoryDBConfigTest, GetUidFromConfig) {
+    JsonConfig config;
+    config["uid"] = "mem";
+    auto db = make_shared<InMemoryDB>(config);
+    EXPECT_EQ(db->get_uid(), "mem");
 }
 
 TEST_F(InMemoryDBTest, GetAccessPermissionsReturnsEmpty) {

--- a/src/tests/cpp/protected_atomdb_test.cc
+++ b/src/tests/cpp/protected_atomdb_test.cc
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "InMemoryDB.h"
+#include "JsonConfig.h"
 #include "Link.h"
 #include "Node.h"
 #include "ProtectedAtomDB.h"
@@ -12,6 +13,7 @@
 using namespace atomdb;
 using namespace atomdb_api_types;
 using namespace atoms;
+using namespace commons;
 using namespace std;
 
 namespace {
@@ -41,11 +43,20 @@ TEST(ProtectedAtomDBTest, ReportsProtectionModeThroughWrapper) {
     EXPECT_EQ(db.get_protection_mode(), ProtectionMode::PROTECTED);
 }
 
+TEST(ProtectedAtomDBTest, CopiesBackendUid) {
+    JsonConfig config;
+    config["uid"] = "wrapped";
+    auto backend = make_shared<InMemoryDB>(config);
+    ProtectedAtomDB db(backend);
+    EXPECT_EQ(db.get_uid(), "wrapped");
+}
+
 TEST(ProtectedAtomDBTest, DelegatesToBackend) {
     auto backend = make_shared<ProtectedInMemoryDB>();
     ProtectedAtomDB db(backend);
     EXPECT_EQ(db.allow_nested_indexing(), backend->allow_nested_indexing());
     EXPECT_EQ(db.composite_type_enabled(), backend->composite_type_enabled());
+    EXPECT_EQ(db.get_uid(), backend->get_uid());
 
     PublicKey key("any_key");
 

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -1465,9 +1465,17 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsReturnsStoredDocuments) {
     }
     EXPECT_EQ(LinkSchema(actual_tokens).handle(), expected_schema.handle());
 
-    auto map_permissions = db->get_access_permissions(
+    EXPECT_TRUE(db->get_access_permissions(
+                      PublicKey(map<string, string>{{"peer_a", "key_admin"}, {"peer_b", "key_reader"}}))
+                    .empty());
+
+    auto config_peer_a = test_atomdb_json_config("redismongodb", "redis_mongodb_test_", "peer_a");
+    TestRedisMongoDB db_peer_a(config_peer_a);
+    EXPECT_EQ(db_peer_a.get_uid(), "peer_a");
+    auto map_permissions = db_peer_a.get_access_permissions(
         PublicKey(map<string, string>{{"peer_a", "key_admin"}, {"peer_b", "key_reader"}}));
-    ASSERT_EQ(map_permissions.size(), 2u);
+    ASSERT_EQ(map_permissions.size(), 1u);
+    EXPECT_STREQ(map_permissions[0]->get_access_key(), "key_admin");
 
     EXPECT_TRUE(db->get_access_permissions(PublicKey("missing_key")).empty());
 
@@ -1490,6 +1498,23 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsRejectsInvalidDocument) {
     EXPECT_THROW(db->get_access_permissions(PublicKey("key_broken")), runtime_error);
 
     collection.delete_many({});
+}
+
+TEST(PublicKeyTest, KeyForUid) {
+    PublicKey single("only_key");
+    EXPECT_TRUE(single.is_single_key());
+    ASSERT_TRUE(single.key_for_uid("").has_value());
+    EXPECT_EQ(*single.key_for_uid(""), "only_key");
+    EXPECT_EQ(*single.key_for_uid("ignored"), "only_key");
+
+    PublicKey mapped({{"peer_a", "key_a"}, {"peer_b", "key_b"}});
+    EXPECT_FALSE(mapped.is_single_key());
+    ASSERT_TRUE(mapped.key_for_uid("peer_a").has_value());
+    EXPECT_EQ(*mapped.key_for_uid("peer_a"), "key_a");
+    ASSERT_TRUE(mapped.key_for_uid("peer_b").has_value());
+    EXPECT_EQ(*mapped.key_for_uid("peer_b"), "key_b");
+    EXPECT_FALSE(mapped.key_for_uid("peer_c").has_value());
+    EXPECT_FALSE(mapped.key_for_uid("").has_value());
 }
 
 TEST(MongodbAccessPermissionEntryTest, GetTokensSizeReturnsArrayLength) {

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -1503,18 +1503,15 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsRejectsInvalidDocument) {
 TEST(PublicKeyTest, KeyForUid) {
     PublicKey single("only_key");
     EXPECT_TRUE(single.is_single_key());
-    ASSERT_TRUE(single.key_for_uid("").has_value());
-    EXPECT_EQ(*single.key_for_uid(""), "only_key");
-    EXPECT_EQ(*single.key_for_uid("ignored"), "only_key");
+    EXPECT_EQ(single.key_for_uid(""), "only_key");
+    EXPECT_EQ(single.key_for_uid("ignored"), "only_key");
 
     PublicKey mapped({{"peer_a", "key_a"}, {"peer_b", "key_b"}});
     EXPECT_FALSE(mapped.is_single_key());
-    ASSERT_TRUE(mapped.key_for_uid("peer_a").has_value());
-    EXPECT_EQ(*mapped.key_for_uid("peer_a"), "key_a");
-    ASSERT_TRUE(mapped.key_for_uid("peer_b").has_value());
-    EXPECT_EQ(*mapped.key_for_uid("peer_b"), "key_b");
-    EXPECT_FALSE(mapped.key_for_uid("peer_c").has_value());
-    EXPECT_FALSE(mapped.key_for_uid("").has_value());
+    EXPECT_EQ(mapped.key_for_uid("peer_a"), "key_a");
+    EXPECT_EQ(mapped.key_for_uid("peer_b"), "key_b");
+    EXPECT_EQ(mapped.key_for_uid("peer_c"), "");
+    EXPECT_EQ(mapped.key_for_uid(""), "");
 }
 
 TEST(MongodbAccessPermissionEntryTest, GetTokensSizeReturnsArrayLength) {

--- a/src/tests/cpp/remote_atomdb_test.cc
+++ b/src/tests/cpp/remote_atomdb_test.cc
@@ -601,6 +601,7 @@ TEST_F(RemoteAtomDBTest, Initialization) {
     EXPECT_EQ(peers.size(), 2u);
     EXPECT_NE(peers.find("peer1"), peers.end());
     EXPECT_NE(peers.find("peer2"), peers.end());
+    EXPECT_EQ(db_->get_uid(), "remote");
 }
 
 TEST_F(RemoteAtomDBTest, GetPeer) {
@@ -698,6 +699,7 @@ TEST_F(RemoteAtomDBConfigTest, SingleConfigWorks) {
     const auto& peers = db_->get_remote_dbs();
     EXPECT_EQ(peers.size(), 1u);
     EXPECT_NE(peers.find("single_peer"), peers.end());
+    EXPECT_EQ(db_->get_uid(), "remote_single");
 
     auto human = new Node("Symbol", "\"human\"");
     string human_handle = db_->add_node(human);

--- a/src/tests/cpp/remote_atomdb_test.cc
+++ b/src/tests/cpp/remote_atomdb_test.cc
@@ -41,7 +41,7 @@ class RemoteAtomDBPeerTest : public ::testing::Test {
     void SetUp() override {
         remote_ = make_shared<InMemoryDB>();
         local_ = make_shared<InMemoryDB>();
-        peer_ = make_shared<RemoteAtomDBPeer>(remote_, local_, "test_peer");
+        peer_ = make_shared<RemoteAtomDBPeer>("test_peer", remote_, local_);
     }
 
     void TearDown() override {}
@@ -373,7 +373,7 @@ TEST_F(RemoteAtomDBPeerTest, DeleteAfterFetchReleasesRemoteCache) {
 TEST_F(RemoteAtomDBPeerTest, ReleaseWithoutLocalPersistence) {
     // Create a peer without local persistence (nullptr)
     auto remote = make_shared<InMemoryDB>();
-    auto peer_no_local = make_shared<RemoteAtomDBPeer>(remote, nullptr, "no_local_peer");
+    auto peer_no_local = make_shared<RemoteAtomDBPeer>("no_local_peer", remote, nullptr);
 
     auto human = new Node("Symbol", "\"human\"");
     auto mammal = new Node("Symbol", "\"mammal\"");
@@ -447,7 +447,7 @@ TEST_F(RemoteAtomDBPeerTest, AtomsCount) {
 
 TEST(RemoteAtomDBPeerReadonlyTest, RepeatQuerySeesRemoteAfterRelease) {
     auto remote = make_shared<InMemoryDB>();
-    auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "readonly_peer");
+    auto peer = make_shared<RemoteAtomDBPeer>("readonly_peer", remote, nullptr);
 
     auto handles = populate_inheritance_mammal_links(remote);
     string link1_handle = handles[0];
@@ -488,7 +488,7 @@ TEST(RemoteAtomDBPeerReadonlyTest, RepeatQuerySeesRemoteAfterRelease) {
 TEST(RemoteAtomDBPeerReadonlyTest, AddStagesThenPersistsOnRelease) {
     auto remote = make_shared<InMemoryDB>();
     auto local = make_shared<InMemoryDB>();
-    auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "stage_peer");
+    auto peer = make_shared<RemoteAtomDBPeer>("stage_peer", remote, local);
 
     auto human = new Node("Symbol", "\"human\"");
     string human_handle = peer->add_node(human);
@@ -504,7 +504,7 @@ TEST(RemoteAtomDBPeerReadonlyTest, AddStagesThenPersistsOnRelease) {
 
 TEST(RemoteAtomDBPeerReadonlyTest, AddFailsWithoutLocalPersistence) {
     auto remote = make_shared<InMemoryDB>();
-    auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "read_only_peer");
+    auto peer = make_shared<RemoteAtomDBPeer>("read_only_peer", remote, nullptr);
 
     auto human = new Node("Symbol", "\"human\"");
     EXPECT_TRUE(peer->add_node(human).empty());
@@ -514,7 +514,7 @@ TEST(RemoteAtomDBPeerReadonlyTest, AddFailsWithoutLocalPersistence) {
 TEST(RemoteAtomDBPeerReadonlyTest, DeleteAtomFromLocalPersistence) {
     auto remote = make_shared<InMemoryDB>();
     auto local = make_shared<InMemoryDB>();
-    auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "delete_peer");
+    auto peer = make_shared<RemoteAtomDBPeer>("delete_peer", remote, local);
 
     auto human = new Node("Symbol", "\"human\"");
     string human_handle = local->add_node(human);
@@ -526,7 +526,7 @@ TEST(RemoteAtomDBPeerReadonlyTest, DeleteAtomFromLocalPersistence) {
 
 TEST(RemoteAtomDBPeerReadonlyTest, FetchWarmsCache) {
     auto remote = make_shared<InMemoryDB>();
-    auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "fetch_peer");
+    auto peer = make_shared<RemoteAtomDBPeer>("fetch_peer", remote, nullptr);
     auto handles = populate_inheritance_mammal_links(remote);
     LinkSchema link_schema = inheritance_mammal_schema();
 
@@ -709,6 +709,7 @@ TEST_F(RemoteAtomDBConfigTest, SingleConfigWorks) {
 TEST(RemoteAtomDBPrefixIsolation, PeersWithDifferentPrefixesStayIsolated) {
     nlohmann::json json;
     json["type"] = "remotedb";
+    json["uid"] = "remote";
     auto peer_a = test_atomdb_json_config("redismongodb", "remote_peer_a_").get_json();
     peer_a["uid"] = "peer_a";
     auto peer_b = test_atomdb_json_config("redismongodb", "remote_peer_b_").get_json();
@@ -807,8 +808,8 @@ TEST(RemoteAtomDBFederationTest, MetadataAggregationFromNestedPeer) {
     auto handles = populate_inheritance_mammal_links(backend);
 
     map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-    peers["nested"] = make_shared<RemoteAtomDBPeer>(backend, nullptr, "nested");
-    auto db = make_shared<RemoteAtomDB>(peers);
+    peers["nested"] = make_shared<RemoteAtomDBPeer>("nested", backend, nullptr);
+    auto db = make_shared<RemoteAtomDB>("remote", peers);
 
     // All peers are nested-indexing -> facade advertises nested indexing.
     EXPECT_TRUE(db->allow_nested_indexing());
@@ -844,9 +845,9 @@ TEST(RemoteAtomDBFederationTest, MixedPeersDowngradeAndDeduplicate) {
     ASSERT_EQ(nested_handles, plain_handles);  // identical content -> identical handles
 
     map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-    peers["nested"] = make_shared<RemoteAtomDBPeer>(nested_backend, nullptr, "nested");
-    peers["plain"] = make_shared<RemoteAtomDBPeer>(plain_backend, nullptr, "plain");
-    auto db = make_shared<RemoteAtomDB>(peers);
+    peers["nested"] = make_shared<RemoteAtomDBPeer>("nested", nested_backend, nullptr);
+    peers["plain"] = make_shared<RemoteAtomDBPeer>("plain", plain_backend, nullptr);
+    auto db = make_shared<RemoteAtomDB>("remote", peers);
 
     // Mixed nested/non-nested peers -> facade downgrades to false.
     EXPECT_FALSE(db->allow_nested_indexing());
@@ -861,7 +862,7 @@ TEST(RemoteAtomDBFederationTest, CompositeTypeEnabledAggregation) {
     // No peers -> false.
     {
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-        auto db = make_shared<RemoteAtomDB>(peers);
+        auto db = make_shared<RemoteAtomDB>("remote", peers);
         EXPECT_FALSE(db->composite_type_enabled());
     }
 
@@ -871,9 +872,9 @@ TEST(RemoteAtomDBFederationTest, CompositeTypeEnabledAggregation) {
         auto remote2 = make_shared<InMemoryDB>();
         auto local_off = make_shared<InMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-        peers["peer1"] = make_shared<RemoteAtomDBPeer>(remote1, nullptr, "peer1");
-        peers["peer2"] = make_shared<RemoteAtomDBPeer>(remote2, local_off, "peer2");
-        auto db = make_shared<RemoteAtomDB>(peers);
+        peers["peer1"] = make_shared<RemoteAtomDBPeer>("peer1", remote1, nullptr);
+        peers["peer2"] = make_shared<RemoteAtomDBPeer>("peer2", remote2, local_off);
+        auto db = make_shared<RemoteAtomDB>("remote", peers);
         EXPECT_FALSE(db->composite_type_enabled());
     }
 
@@ -884,9 +885,9 @@ TEST(RemoteAtomDBFederationTest, CompositeTypeEnabledAggregation) {
         auto local_on = make_shared<CompositeTypeEnabledInMemoryDB>();
         auto local_off = make_shared<InMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-        peers["enabled"] = make_shared<RemoteAtomDBPeer>(remote1, local_on, "enabled");
-        peers["disabled"] = make_shared<RemoteAtomDBPeer>(remote2, local_off, "disabled");
-        auto db = make_shared<RemoteAtomDB>(peers);
+        peers["enabled"] = make_shared<RemoteAtomDBPeer>("enabled", remote1, local_on);
+        peers["disabled"] = make_shared<RemoteAtomDBPeer>("disabled", remote2, local_off);
+        auto db = make_shared<RemoteAtomDB>("remote", peers);
         EXPECT_TRUE(db->composite_type_enabled());
     }
 
@@ -897,9 +898,9 @@ TEST(RemoteAtomDBFederationTest, CompositeTypeEnabledAggregation) {
         auto local1 = make_shared<CompositeTypeEnabledInMemoryDB>();
         auto local2 = make_shared<CompositeTypeEnabledInMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-        peers["peer1"] = make_shared<RemoteAtomDBPeer>(remote1, local1, "peer1");
-        peers["peer2"] = make_shared<RemoteAtomDBPeer>(remote2, local2, "peer2");
-        auto db = make_shared<RemoteAtomDB>(peers);
+        peers["peer1"] = make_shared<RemoteAtomDBPeer>("peer1", remote1, local1);
+        peers["peer2"] = make_shared<RemoteAtomDBPeer>("peer2", remote2, local2);
+        auto db = make_shared<RemoteAtomDB>("remote", peers);
         EXPECT_TRUE(db->composite_type_enabled());
     }
 }
@@ -909,14 +910,14 @@ TEST(RemoteAtomDBFederationTest, PeerIsProtectedFollowsRemoteBackend) {
     {
         auto remote = make_shared<InMemoryDB>();
         auto local = make_shared<InMemoryDB>();
-        auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "peer");
+        auto peer = make_shared<RemoteAtomDBPeer>("peer", remote, local);
         EXPECT_EQ(peer->get_protection_mode(), ProtectionMode::UNPROTECTED);
     }
 
     // Read-only peer (no local persistence) over an unprotected remote.
     {
         auto remote = make_shared<InMemoryDB>();
-        auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "peer");
+        auto peer = make_shared<RemoteAtomDBPeer>("peer", remote, nullptr);
         EXPECT_EQ(peer->get_protection_mode(), ProtectionMode::UNPROTECTED);
     }
 
@@ -924,14 +925,14 @@ TEST(RemoteAtomDBFederationTest, PeerIsProtectedFollowsRemoteBackend) {
     {
         auto remote = make_shared<ProtectedInMemoryDB>();
         auto local = make_shared<InMemoryDB>();
-        auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "peer");
+        auto peer = make_shared<RemoteAtomDBPeer>("peer", remote, local);
         EXPECT_EQ(peer->get_protection_mode(), ProtectionMode::PROTECTED);
     }
 
     // ProtectedAtomDB wrapper as remote backend propagates protection mode.
     {
         auto remote = make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>());
-        auto peer = make_shared<RemoteAtomDBPeer>(remote, nullptr, "peer");
+        auto peer = make_shared<RemoteAtomDBPeer>("peer", remote, nullptr);
         EXPECT_EQ(peer->get_protection_mode(), ProtectionMode::PROTECTED);
     }
 
@@ -939,21 +940,21 @@ TEST(RemoteAtomDBFederationTest, PeerIsProtectedFollowsRemoteBackend) {
     {
         auto remote = make_shared<InMemoryDB>();
         auto local = make_shared<ProtectedInMemoryDB>();
-        EXPECT_THROW(make_shared<RemoteAtomDBPeer>(remote, local, "peer"), runtime_error);
+        EXPECT_THROW(make_shared<RemoteAtomDBPeer>("peer", remote, local), runtime_error);
     }
 
     // FORWARD local persistence is not supported either.
     {
         auto remote = make_shared<InMemoryDB>();
         auto local = make_shared<ForwardInMemoryDB>();
-        EXPECT_THROW(make_shared<RemoteAtomDBPeer>(remote, local, "peer"), runtime_error);
+        EXPECT_THROW(make_shared<RemoteAtomDBPeer>("peer", remote, local), runtime_error);
     }
 
     // Factory-style ProtectedAtomDB wrapper over a protected backend is rejected for local persistence.
     {
         auto remote = make_shared<InMemoryDB>();
         auto local = make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>());
-        EXPECT_THROW(make_shared<RemoteAtomDBPeer>(remote, local, "peer"), runtime_error);
+        EXPECT_THROW(make_shared<RemoteAtomDBPeer>("peer", remote, local), runtime_error);
     }
 }
 
@@ -961,7 +962,7 @@ TEST(RemoteAtomDBFederationTest, IsProtectedWhenAnyPeerIsProtected) {
     // No peers -> nothing to protect.
     {
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-        auto db = make_shared<RemoteAtomDB>(peers);
+        auto db = make_shared<RemoteAtomDB>("remote", peers);
         EXPECT_EQ(db->get_protection_mode(), ProtectionMode::UNPROTECTED);
     }
 
@@ -970,9 +971,9 @@ TEST(RemoteAtomDBFederationTest, IsProtectedWhenAnyPeerIsProtected) {
         auto remote1 = make_shared<InMemoryDB>();
         auto remote2 = make_shared<InMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-        peers["peer1"] = make_shared<RemoteAtomDBPeer>(remote1, nullptr, "peer1");
-        peers["peer2"] = make_shared<RemoteAtomDBPeer>(remote2, nullptr, "peer2");
-        auto db = make_shared<RemoteAtomDB>(peers);
+        peers["peer1"] = make_shared<RemoteAtomDBPeer>("peer1", remote1, nullptr);
+        peers["peer2"] = make_shared<RemoteAtomDBPeer>("peer2", remote2, nullptr);
+        auto db = make_shared<RemoteAtomDB>("remote", peers);
         EXPECT_EQ(db->get_protection_mode(), ProtectionMode::UNPROTECTED);
     }
 
@@ -981,9 +982,9 @@ TEST(RemoteAtomDBFederationTest, IsProtectedWhenAnyPeerIsProtected) {
         auto unprotected_remote = make_shared<InMemoryDB>();
         auto protected_remote = make_shared<ProtectedInMemoryDB>();
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-        peers["unprotected"] = make_shared<RemoteAtomDBPeer>(unprotected_remote, nullptr, "unprotected");
-        peers["protected"] = make_shared<RemoteAtomDBPeer>(protected_remote, nullptr, "protected");
-        auto db = make_shared<RemoteAtomDB>(peers);
+        peers["unprotected"] = make_shared<RemoteAtomDBPeer>("unprotected", unprotected_remote, nullptr);
+        peers["protected"] = make_shared<RemoteAtomDBPeer>("protected", protected_remote, nullptr);
+        auto db = make_shared<RemoteAtomDB>("remote", peers);
         EXPECT_EQ(db->get_protection_mode(), ProtectionMode::FORWARD);
     }
 
@@ -992,9 +993,9 @@ TEST(RemoteAtomDBFederationTest, IsProtectedWhenAnyPeerIsProtected) {
         auto unprotected_remote = make_shared<InMemoryDB>();
         auto protected_remote = make_shared<ProtectedAtomDB>(make_shared<ProtectedInMemoryDB>());
         map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-        peers["unprotected"] = make_shared<RemoteAtomDBPeer>(unprotected_remote, nullptr, "unprotected");
-        peers["protected"] = make_shared<RemoteAtomDBPeer>(protected_remote, nullptr, "protected");
-        auto db = make_shared<RemoteAtomDB>(peers);
+        peers["unprotected"] = make_shared<RemoteAtomDBPeer>("unprotected", unprotected_remote, nullptr);
+        peers["protected"] = make_shared<RemoteAtomDBPeer>("protected", protected_remote, nullptr);
+        auto db = make_shared<RemoteAtomDB>("remote", peers);
         EXPECT_EQ(db->get_protection_mode(), ProtectionMode::FORWARD);
     }
 }
@@ -1009,9 +1010,9 @@ TEST(RemoteAtomDBFederationTest, CacheFirstProbingAcrossPeers) {
     string handle = backend2->add_node(only_in_peer2);
 
     map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-    peers["peer1"] = make_shared<RemoteAtomDBPeer>(backend1, nullptr, "peer1");
-    peers["peer2"] = make_shared<RemoteAtomDBPeer>(backend2, nullptr, "peer2");
-    auto db = make_shared<RemoteAtomDB>(peers);
+    peers["peer1"] = make_shared<RemoteAtomDBPeer>("peer1", backend1, nullptr);
+    peers["peer2"] = make_shared<RemoteAtomDBPeer>("peer2", backend2, nullptr);
+    auto db = make_shared<RemoteAtomDB>("remote", peers);
 
     auto* peer2 = db->get_peer("peer2");
     ASSERT_NE(peer2, nullptr);
@@ -1050,9 +1051,9 @@ TEST(RemoteAtomDBFederationTest, PersistLinkWithoutCrossPeerTargetCopy) {
     string impl_h = peer1_remote->add_node(implication);
 
     map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-    peers["peer1"] = make_shared<RemoteAtomDBPeer>(peer1_remote, nullptr, "peer1");
-    peers["peer3"] = make_shared<RemoteAtomDBPeer>(peer3_remote, peer3_local, "peer3");
-    auto db = make_shared<RemoteAtomDB>(peers);
+    peers["peer1"] = make_shared<RemoteAtomDBPeer>("peer1", peer1_remote, nullptr);
+    peers["peer3"] = make_shared<RemoteAtomDBPeer>("peer3", peer3_remote, peer3_local);
+    auto db = make_shared<RemoteAtomDB>("remote", peers);
 
     auto link = make_shared<Link>(
         "Expression", vector<string>{impl_h, a_h, b_h}, true, Properties{{"strength", 0.833333}});
@@ -1077,9 +1078,9 @@ TEST(RemoteAtomDBFederationTest, PersistLinkWithoutCrossPeerTargetCopy) {
 
     // Fresh facade sharing peer3 local persistence still sees the updated link.
     map<string, shared_ptr<RemoteAtomDBPeer>> reader_peers;
-    reader_peers["peer1"] = make_shared<RemoteAtomDBPeer>(peer1_remote, nullptr, "peer1");
-    reader_peers["peer3"] = make_shared<RemoteAtomDBPeer>(peer3_remote, peer3_local, "peer3");
-    auto reader = make_shared<RemoteAtomDB>(reader_peers);
+    reader_peers["peer1"] = make_shared<RemoteAtomDBPeer>("peer1", peer1_remote, nullptr);
+    reader_peers["peer3"] = make_shared<RemoteAtomDBPeer>("peer3", peer3_remote, peer3_local);
+    auto reader = make_shared<RemoteAtomDB>("remote", reader_peers);
     auto from_reader = reader->get_atom(handle);
     ASSERT_NE(from_reader, nullptr);
     EXPECT_DOUBLE_EQ(from_reader->custom_attributes.get_or<double>("strength", -1.0), 0.833333);
@@ -1109,10 +1110,10 @@ TEST(RemoteAtomDBFederationTest, StrengthUpdateVisibleAcrossPeers) {
     peer1_remote->add_link(weak.get());
 
     map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-    peers["peer1"] = make_shared<RemoteAtomDBPeer>(peer1_remote, nullptr, "peer1");
-    peers["peer2"] = make_shared<RemoteAtomDBPeer>(peer2_remote, nullptr, "peer2");
-    peers["peer3"] = make_shared<RemoteAtomDBPeer>(peer3_remote, peer3_local, "peer3");
-    auto db = make_shared<RemoteAtomDB>(peers);
+    peers["peer1"] = make_shared<RemoteAtomDBPeer>("peer1", peer1_remote, nullptr);
+    peers["peer2"] = make_shared<RemoteAtomDBPeer>("peer2", peer2_remote, nullptr);
+    peers["peer3"] = make_shared<RemoteAtomDBPeer>("peer3", peer3_remote, peer3_local);
+    auto db = make_shared<RemoteAtomDB>("remote", peers);
 
     // Warm readonly peer1 cache with the weak strength.
     auto first = db->get_atom(handle);
@@ -1154,8 +1155,8 @@ TEST(RemoteAtomDBFederationTest, StagedStrengthUpdateVisibleBeforeFlush) {
     ASSERT_FALSE(handle.empty());
 
     map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-    peers["peer3"] = make_shared<RemoteAtomDBPeer>(peer3_remote, peer3_local, "peer3");
-    auto db = make_shared<RemoteAtomDB>(peers);
+    peers["peer3"] = make_shared<RemoteAtomDBPeer>("peer3", peer3_remote, peer3_local);
+    auto db = make_shared<RemoteAtomDB>("remote", peers);
 
     auto before = db->get_atom(handle);
     ASSERT_NE(before, nullptr);
@@ -1201,8 +1202,8 @@ TEST(RemoteAtomDBFederationTest, NonStagedPrefersLocalOverStaleCache) {
     ASSERT_FALSE(handle.empty());
 
     map<string, shared_ptr<RemoteAtomDBPeer>> peers;
-    peers["peer3"] = make_shared<RemoteAtomDBPeer>(peer3_remote, peer3_local, "peer3");
-    auto db = make_shared<RemoteAtomDB>(peers);
+    peers["peer3"] = make_shared<RemoteAtomDBPeer>("peer3", peer3_remote, peer3_local);
+    auto db = make_shared<RemoteAtomDB>("remote", peers);
 
     auto warmed = db->get_atom(handle);
     ASSERT_NE(warmed, nullptr);
@@ -1258,7 +1259,7 @@ class FlakyInMemoryDB : public InMemoryDB {
 TEST(RemoteAtomDBFederationTest, FailedFlushRestagesDirtyAtoms) {
     auto remote = make_shared<InMemoryDB>();
     auto local = make_shared<FlakyInMemoryDB>();
-    auto peer = make_shared<RemoteAtomDBPeer>(remote, local, "flaky_peer");
+    auto peer = make_shared<RemoteAtomDBPeer>("flaky_peer", remote, local);
 
     auto human = new Node("Symbol", "\"human\"");
     string human_handle = peer->add_node(human);
@@ -1283,7 +1284,7 @@ TEST(RemoteAtomDBFederationTest, ConcurrentAddAndReleaseLosesNoWrites) {
     // local_persistence after a final release once writers finish.
     auto peer3_remote = make_shared<InMemoryDB>();
     auto peer3_local = make_shared<InMemoryDB>();
-    auto peer = make_shared<RemoteAtomDBPeer>(peer3_remote, peer3_local, "peer3");
+    auto peer = make_shared<RemoteAtomDBPeer>("peer3", peer3_remote, peer3_local);
 
     constexpr int kWriters = 4;
     constexpr int kAddsPerWriter = 25;

--- a/src/tests/cpp/test_commons/TestAtomDBJsonConfig.h
+++ b/src/tests/cpp/test_commons/TestAtomDBJsonConfig.h
@@ -10,7 +10,7 @@ namespace atomdb {
  */
 inline commons::JsonConfig test_atomdb_json_config(const string& atomdb_type = "redismongodb",
                                                    const string& prefix = "",
-                                                   const string& uid = "") {
+                                                   const string& uid = "test") {
     auto json = nlohmann::json();
     json["type"] = atomdb_type;
     json["prefix"] = prefix;

--- a/src/tests/cpp/test_commons/TestAtomDBJsonConfig.h
+++ b/src/tests/cpp/test_commons/TestAtomDBJsonConfig.h
@@ -9,10 +9,12 @@ namespace atomdb {
  * Production services should load values from the application config file instead.
  */
 inline commons::JsonConfig test_atomdb_json_config(const string& atomdb_type = "redismongodb",
-                                                   const string& prefix = "") {
+                                                   const string& prefix = "",
+                                                   const string& uid = "") {
     auto json = nlohmann::json();
     json["type"] = atomdb_type;
     json["prefix"] = prefix;
+    json["uid"] = uid;
     json["composite_type_enabled"] = true;
     json["redis"] = {{"endpoint", "localhost:40020"}, {"cluster", false}};
     json["mongodb"] = {{"endpoint", "localhost:40021"}, {"username", "admin"}, {"password", "admin"}};


### PR DESCRIPTION
## Summary

- Require `uid` on AtomDB config (`atomdb.uid` in `das.json`, factory `create()`, remotedb peers). The value may be empty.
- `get_uid()` exposes it. Internal `InMemoryDB()` caches also use an empty uid.
- `PublicKey::key_for_uid()` selects this instance’s key; `RedisMongoDB::get_access_permissions()` uses that instead of scanning every peer key.

## Test plan

- [ ] `//tests/cpp:inmemorydb_test`, `protected_atomdb_test`, `config_parser_test`, `redis_mongodb_test`
- [ ] `//tests/cpp:atomdb_factory_test`, `remote_atomdb_test` (need MORK)
- [ ] Startup fails if `atomdb.uid` is missing; `"uid": ""` is accepted
