### PR TITLE
[#1269] Add Keychain

### DIFF
--- a/src/atomdb/auth/BUILD
+++ b/src/atomdb/auth/BUILD
@@ -7,6 +7,8 @@ cc_library(
     includes = ["."],
     deps = [
         ":authorization_manifest",
+        ":authorization_types",
+        ":keychain",
         ":mongodb_authorization_persistence",
     ],
 )
@@ -59,4 +61,11 @@ cc_library(
         "//commons:commons_lib",
         "//commons/atoms:atoms_lib",
     ],
+)
+
+cc_library(
+    name = "keychain",
+    srcs = ["Keychain.cc"],
+    hdrs = ["Keychain.h"],
+    includes = ["."],
 )

--- a/src/atomdb/auth/Keychain.cc
+++ b/src/atomdb/auth/Keychain.cc
@@ -1,0 +1,20 @@
+#include "Keychain.h"
+
+using namespace std;
+using namespace atomdb;
+
+// -------------------------------------------------------------------------------------------------
+// Constructor
+
+Keychain::Keychain(map<Keychain::AtomDB_UID, Keychain::PublicKey> keys) : keys_(keys) {}
+
+// -------------------------------------------------------------------------------------------------
+// Public methods
+
+Keychain::PublicKey Keychain::get_public_key(const Keychain::AtomDB_UID& uid) const {
+    auto it = this->keys_.find(uid);
+    if (it != this->keys_.end()) {
+        return it->second;
+    }
+    return "";
+}

--- a/src/atomdb/auth/Keychain.cc
+++ b/src/atomdb/auth/Keychain.cc
@@ -6,7 +6,7 @@ using namespace atomdb;
 // -------------------------------------------------------------------------------------------------
 // Constructor
 
-Keychain::Keychain(map<Keychain::AtomDB_UID, Keychain::PublicKey> keys) : keys_(keys) {}
+Keychain::Keychain(map<Keychain::AtomDB_UID, Keychain::PublicKey> keys) : keys_(std::move(keys)) {}
 
 // -------------------------------------------------------------------------------------------------
 // Public methods

--- a/src/atomdb/auth/Keychain.h
+++ b/src/atomdb/auth/Keychain.h
@@ -8,11 +8,11 @@ using namespace std;
 namespace atomdb {
 
 /**
- * @brief Caller credentials: public keys keyed by AtomDB UID.
+ * @brief Caller credentials: one public key per AtomDB UID.
  *
- * Keychain is the identity token passed into ProtectedAtomDB.
- * AuthorizationManifest looks up the public key for a given
- * database UID and checks the corresponding AuthorizationProfile.
+ * Holds the map `uid → public_key` that identifies the caller to each
+ * AtomDB. `get_public_key(uid)` returns the key for that database, or
+ * an empty string if the UID is absent or stored as empty.
  */
 class Keychain {
    public:

--- a/src/atomdb/auth/Keychain.h
+++ b/src/atomdb/auth/Keychain.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+using namespace std;
+
+namespace atomdb {
+
+/**
+ * @brief Caller credentials: public keys keyed by AtomDB UID.
+ *
+ * Keychain is the identity token passed into ProtectedAtomDB.
+ * AuthorizationManifest looks up the public key for a given
+ * database UID and checks the corresponding AuthorizationProfile.
+ */
+class Keychain {
+   public:
+    using AtomDB_UID = string;
+    using PublicKey = string;
+
+    explicit Keychain(map<AtomDB_UID, PublicKey> keys);
+    ~Keychain() = default;
+
+    /**
+     * @brief Returns the public key registered for `uid`.
+     *
+     * Empty string means no usable key: the UID is missing or its stored
+     * value is empty.
+     *
+     * @param uid AtomDB UID to look up.
+     * @return The stored public key, or empty string.
+     */
+    PublicKey get_public_key(const AtomDB_UID& uid) const;
+
+   private:
+    map<AtomDB_UID, PublicKey> keys_;
+};
+
+}  // namespace atomdb

--- a/src/atomdb/auth/Keychain.h
+++ b/src/atomdb/auth/Keychain.h
@@ -10,7 +10,7 @@ namespace atomdb {
 /**
  * @brief Caller credentials: one public key per AtomDB UID.
  *
- * Holds the map `uid → public_key` that identifies the caller to each
+ * Holds the map `uid -> public_key` that identifies the caller to each
  * AtomDB. `get_public_key(uid)` returns the key for that database, or
  * an empty string if the UID is absent or stored as empty.
  */

--- a/src/tests/cpp/BUILD
+++ b/src/tests/cpp/BUILD
@@ -875,6 +875,21 @@ cc_test(
 )
 
 cc_test(
+    name = "keychain_test",
+    size = "small",
+    srcs = ["keychain_test.cc"],
+    copts = [
+        "-Iexternal/gtest/googletest/include",
+        "-Iexternal/gtest/googletest",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//atomdb/auth:keychain",
+        "@com_github_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "authorization_test",
     size = "small",
     srcs = ["authorization_test.cc"],

--- a/src/tests/cpp/keychain_test.cc
+++ b/src/tests/cpp/keychain_test.cc
@@ -1,0 +1,29 @@
+#include "Keychain.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+
+using namespace atomdb;
+using namespace std;
+
+TEST(KeychainTest, GetPublicKeyReturnsEmpty) {
+    Keychain empty_keychain({});
+    EXPECT_EQ(empty_keychain.get_public_key("blah"), "");
+    EXPECT_EQ(empty_keychain.get_public_key(""), "");
+
+    Keychain keychain(map<string, string>{{"uid1", "key1"}});
+    EXPECT_EQ(keychain.get_public_key("uid2"), "");
+    EXPECT_EQ(keychain.get_public_key("uid"), "");
+    EXPECT_EQ(keychain.get_public_key(""), "");
+
+    Keychain empty_stored_key(map<string, string>{{"uid", ""}});
+    EXPECT_EQ(empty_stored_key.get_public_key("uid"), "");
+}
+
+TEST(KeychainTest, GetPublicKeyReturnsStoredKey) {
+    Keychain keychain(map<string, string>{{"uid1", "key1"}, {"uid2", "key2"}});
+    EXPECT_EQ(keychain.get_public_key("uid1"), "key1");
+    EXPECT_EQ(keychain.get_public_key("uid2"), "key2");
+}


### PR DESCRIPTION
## Summary
- Introduce `Keychain` for protected AtomDB, mapping AtomDB UIDs to public keys.
- Add `get_public_key(uid)`, which returns the associated public key or an empty string if the UID is not found or the stored key is empty.

Resolves #1269 