### PR TITLE
[#1270] Replace PublicKey with Keychain

### DIFF
--- a/src/agents/BaseQueryProxy.h
+++ b/src/agents/BaseQueryProxy.h
@@ -89,7 +89,7 @@ class BaseQueryProxy : public BaseProxy {
                                                 // as well as complete ones.
 
     static string PUBLIC_KEY_TOKENS;  // A string with a list of tokens which can be used to build a
-                                      // AtomDBAPITypes::PublicKey object. This is required to use
+                                      // Keychain object. This is required to use
                                       // public keys(s) when querying a ProtectedAtomDB. The list is
                                       // supposed to be a space separated string with all the pairs
                                       // (uid, key). E.g. "uid1 key1 uid2 key2 ... uidn keyn".

--- a/src/agents/query_engine/query_element/LinkTemplate.cc
+++ b/src/agents/query_engine/query_element/LinkTemplate.cc
@@ -67,8 +67,7 @@ LinkTemplate::LinkTemplate(const string& type,
                 }
             }
             if (!parse_error && (keymap.size() == (tokens.size() / 2))) {
-                // TODO __AUTH__ uncomment line below
-                // this->keychain = new Keychain(keymap);
+                this->keychain = make_shared<Keychain>(keymap);
             } else {
                 parse_error = true;
             }

--- a/src/agents/query_engine/query_element/LinkTemplate.h
+++ b/src/agents/query_engine/query_element/LinkTemplate.h
@@ -7,6 +7,7 @@
 
 #include "Assignment.h"
 #include "AtomDB.h"
+#include "Keychain.h"
 #include "LinkSchema.h"
 #include "QueryElement.h"
 #include "Source.h"
@@ -77,9 +78,7 @@ class LinkTemplate : public QueryElement {
     bool positive_importance_flag;
     bool disregard_importance_flag;
     bool unique_value_flag;
-    // TODO __AUTH__ change declaration below to
-    // Keychain keychain;
-    map<string, string> keychain;
+    shared_ptr<Keychain> keychain;
     bool inner_flag;
     LinkSchema link_schema;
     shared_ptr<SourceElement> source_element;

--- a/src/atomdb/AtomDB.h
+++ b/src/atomdb/AtomDB.h
@@ -115,9 +115,9 @@ class AtomDB : public HandleDecoder {
 
     bool empty() const { return atom_count() == 0; }
 
-    virtual vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
-        const atomdb_api_types::PublicKey& public_key) const {
-        return {};
+    virtual shared_ptr<atomdb_api_types::AccessPermissionDocument> get_access_permissions(
+        const string& public_key) const {
+        return nullptr;
     }
 };
 

--- a/src/atomdb/AtomDBAPITypes.h
+++ b/src/atomdb/AtomDBAPITypes.h
@@ -82,23 +82,6 @@ class AccessPermissionEntry {
     virtual const char* get_token(unsigned int index) const = 0;
 };
 
-class PublicKey {
-   public:
-    vector<string> keys;
-    map<string, unsigned int> peer_to_key;
-
-    bool is_single_key() const { return this->peer_to_key.empty(); }
-
-    explicit PublicKey(const string& key) : keys{key} {}
-    explicit PublicKey(const map<string, string>& peer_keys) {
-        this->keys.reserve(peer_keys.size());
-        for (const auto& [peer, key] : peer_keys) {
-            this->peer_to_key[peer] = this->keys.size();
-            this->keys.push_back(key);
-        }
-    }
-};
-
 class AccessPermissionDocument {
    public:
     AccessPermissionDocument() = default;

--- a/src/atomdb/ProtectedAtomDB.cc
+++ b/src/atomdb/ProtectedAtomDB.cc
@@ -22,157 +22,151 @@ ProtectedAtomDB::ProtectedAtomDB(shared_ptr<AtomDB> backend) : backend(backend) 
 // --------------------------------------------------------------------------------
 // Public methods
 
-shared_ptr<Atom> ProtectedAtomDB::get_atom(const string& handle,
-                                           const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<Atom> ProtectedAtomDB::get_atom(const string& handle, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::get_atom(handle, public_key) is not implemented yet");
 }
 
-shared_ptr<Node> ProtectedAtomDB::get_node(const string& handle,
-                                           const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<Node> ProtectedAtomDB::get_node(const string& handle, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::get_node(handle, public_key) is not implemented yet");
 }
 
-shared_ptr<Link> ProtectedAtomDB::get_link(const string& handle,
-                                           const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<Link> ProtectedAtomDB::get_link(const string& handle, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::get_link(handle, public_key) is not implemented yet");
 }
 
-vector<shared_ptr<Atom>> ProtectedAtomDB::get_matching_atoms(
-    bool is_toplevel, Atom& key, const atomdb_api_types::PublicKey& public_key) {
+vector<shared_ptr<Atom>> ProtectedAtomDB::get_matching_atoms(bool is_toplevel,
+                                                             Atom& key,
+                                                             const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::get_matching_atoms(..., public_key) is not implemented yet");
 }
 
-shared_ptr<atomdb_api_types::HandleSet> ProtectedAtomDB::query_for_pattern(
-    const LinkSchema& link_schema, const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<atomdb_api_types::HandleSet> ProtectedAtomDB::query_for_pattern(const LinkSchema& link_schema,
+                                                                           const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::query_for_pattern(link_schema, public_key) is not implemented yet");
 }
 
-shared_ptr<atomdb_api_types::HandleList> ProtectedAtomDB::query_for_targets(
-    const string& handle, const atomdb_api_types::PublicKey& public_key) {
+shared_ptr<atomdb_api_types::HandleList> ProtectedAtomDB::query_for_targets(const string& handle,
+                                                                            const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::query_for_targets(handle, public_key) is not implemented yet");
 }
 
 shared_ptr<atomdb_api_types::HandleSet> ProtectedAtomDB::query_for_incoming_set(
-    const string& handle, const atomdb_api_types::PublicKey& public_key) {
+    const string& handle, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::query_for_incoming_set(handle, public_key) is not implemented yet");
 }
 
-bool ProtectedAtomDB::atom_exists(const string& handle, const atomdb_api_types::PublicKey& public_key) {
+bool ProtectedAtomDB::atom_exists(const string& handle, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::atom_exists(handle, public_key) is not implemented yet");
 }
 
-bool ProtectedAtomDB::node_exists(const string& handle, const atomdb_api_types::PublicKey& public_key) {
+bool ProtectedAtomDB::node_exists(const string& handle, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::node_exists(handle, public_key) is not implemented yet");
 }
 
-bool ProtectedAtomDB::link_exists(const string& handle, const atomdb_api_types::PublicKey& public_key) {
+bool ProtectedAtomDB::link_exists(const string& handle, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::link_exists(handle, public_key) is not implemented yet");
 }
 
-set<string> ProtectedAtomDB::atoms_exist(const vector<string>& handles,
-                                         const atomdb_api_types::PublicKey& public_key) {
+set<string> ProtectedAtomDB::atoms_exist(const vector<string>& handles, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::atoms_exist(handles, public_key) is not implemented yet");
 }
 
-set<string> ProtectedAtomDB::nodes_exist(const vector<string>& handles,
-                                         const atomdb_api_types::PublicKey& public_key) {
+set<string> ProtectedAtomDB::nodes_exist(const vector<string>& handles, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::nodes_exist(handles, public_key) is not implemented yet");
 }
 
-set<string> ProtectedAtomDB::links_exist(const vector<string>& handles,
-                                         const atomdb_api_types::PublicKey& public_key) {
+set<string> ProtectedAtomDB::links_exist(const vector<string>& handles, const Keychain& keychain) {
     RAISE_ERROR("ProtectedAtomDB::links_exist(handles, public_key) is not implemented yet");
 }
 
 string ProtectedAtomDB::add_atom(const atoms::Atom* atom,
-                                 const atomdb_api_types::PublicKey& public_key,
+                                 const Keychain& keychain,
                                  const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_atom(atom, public_key) is not implemented yet");
 }
 
 string ProtectedAtomDB::add_node(const atoms::Node* node,
-                                 const atomdb_api_types::PublicKey& public_key,
+                                 const Keychain& keychain,
                                  const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_node(node, public_key) is not implemented yet");
 }
 
 string ProtectedAtomDB::add_link(const atoms::Link* link,
-                                 const atomdb_api_types::PublicKey& public_key,
+                                 const Keychain& keychain,
                                  const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_link(link, public_key) is not implemented yet");
 }
 
 vector<string> ProtectedAtomDB::add_atoms(const vector<atoms::Atom*>& atom_list,
-                                          const atomdb_api_types::PublicKey& public_key,
+                                          const Keychain& keychain,
                                           bool is_transactional,
                                           const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_atoms(atom_list, public_key) is not implemented yet");
 }
 
 vector<string> ProtectedAtomDB::add_nodes(const vector<atoms::Node*>& nodes,
-                                          const atomdb_api_types::PublicKey& public_key,
+                                          const Keychain& keychain,
                                           bool is_transactional,
                                           const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_nodes(nodes, public_key) is not implemented yet");
 }
 
 vector<string> ProtectedAtomDB::add_links(const vector<atoms::Link*>& links,
-                                          const atomdb_api_types::PublicKey& public_key,
+                                          const Keychain& keychain,
                                           bool is_transactional,
                                           const atoms::Merger* merger) {
     RAISE_ERROR("ProtectedAtomDB::add_links(links, public_key) is not implemented yet");
 }
 
 bool ProtectedAtomDB::delete_atom(const string& handle,
-                                  const atomdb_api_types::PublicKey& public_key,
+                                  const Keychain& keychain,
                                   bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_atom(handle, public_key) is not implemented yet");
 }
 
 bool ProtectedAtomDB::delete_node(const string& handle,
-                                  const atomdb_api_types::PublicKey& public_key,
+                                  const Keychain& keychain,
                                   bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_node(handle, public_key) is not implemented yet");
 }
 
 bool ProtectedAtomDB::delete_link(const string& handle,
-                                  const atomdb_api_types::PublicKey& public_key,
+                                  const Keychain& keychain,
                                   bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_link(handle, public_key) is not implemented yet");
 }
 
 uint ProtectedAtomDB::delete_atoms(const vector<string>& handles,
-                                   const atomdb_api_types::PublicKey& public_key,
+                                   const Keychain& keychain,
                                    bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_atoms(handles, public_key) is not implemented yet");
 }
 
 uint ProtectedAtomDB::delete_nodes(const vector<string>& handles,
-                                   const atomdb_api_types::PublicKey& public_key,
+                                   const Keychain& keychain,
                                    bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_nodes(handles, public_key) is not implemented yet");
 }
 
 uint ProtectedAtomDB::delete_links(const vector<string>& handles,
-                                   const atomdb_api_types::PublicKey& public_key,
+                                   const Keychain& keychain,
                                    bool delete_link_targets) {
     RAISE_ERROR("ProtectedAtomDB::delete_links(handles, public_key) is not implemented yet");
 }
 
-void ProtectedAtomDB::re_index_patterns(const atomdb_api_types::PublicKey& public_key,
-                                        bool flush_patterns) {
+void ProtectedAtomDB::re_index_patterns(const Keychain& keychain, bool flush_patterns) {
     RAISE_ERROR("ProtectedAtomDB::re_index_patterns(public_key) is not implemented yet");
 }
 
-size_t ProtectedAtomDB::node_count(const atomdb_api_types::PublicKey& public_key) const {
+size_t ProtectedAtomDB::node_count(const Keychain& keychain) const {
     RAISE_ERROR("ProtectedAtomDB::node_count(public_key) is not implemented yet");
 }
 
-size_t ProtectedAtomDB::link_count(const atomdb_api_types::PublicKey& public_key) const {
+size_t ProtectedAtomDB::link_count(const Keychain& keychain) const {
     RAISE_ERROR("ProtectedAtomDB::link_count(public_key) is not implemented yet");
 }
 
-size_t ProtectedAtomDB::atom_count(const atomdb_api_types::PublicKey& public_key) const {
+size_t ProtectedAtomDB::atom_count(const Keychain& keychain) const {
     RAISE_ERROR("ProtectedAtomDB::atom_count(public_key) is not implemented yet");
 }
 
@@ -304,5 +298,5 @@ size_t ProtectedAtomDB::atom_count() const { raise_public_key_required("atom_cou
 void ProtectedAtomDB::raise_public_key_required(const string& method_name) {
     RAISE_ERROR("ProtectedAtomDB::" + method_name +
                 "() is unavailable in protected AtomDBs. Use the public API in ProtectedAtomDB passing "
-                "a PublicKey.");
+                "a Keychain.");
 }

--- a/src/atomdb/ProtectedAtomDB.h
+++ b/src/atomdb/ProtectedAtomDB.h
@@ -7,6 +7,7 @@
 
 #include "AtomDB.h"
 #include "AuthorizationManifest.h"
+#include "Keychain.h"
 
 using namespace std;
 using namespace atoms;
@@ -17,8 +18,8 @@ namespace atomdb {
  * @brief Authorization wrapper around any AtomDB backend for protected databases.
  *
  * Data-access methods expose two forms:
- * - overloads without PublicKey: reject the call (protected access requires a key)
- * - overloads with PublicKey: authorize and delegate to the backend
+ * - overloads without Keychain: reject the call (protected access requires a key)
+ * - overloads with Keychain: authorize and delegate to the backend
  *
  * When the backend reports ProtectionMode::FORWARD, this wrapper forwards the
  * access key without applying local authorization post-processing.
@@ -38,72 +39,67 @@ class ProtectedAtomDB : public AtomDB {
     atomdb_api_types::ProtectionMode get_protection_mode() const override;
 
     shared_ptr<Atom> get_atom(const string& handle) override;
-    shared_ptr<Atom> get_atom(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<Atom> get_atom(const string& handle, const Keychain& keychain);
 
     shared_ptr<Node> get_node(const string& handle) override;
-    shared_ptr<Node> get_node(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<Node> get_node(const string& handle, const Keychain& keychain);
 
     shared_ptr<Link> get_link(const string& handle) override;
-    shared_ptr<Link> get_link(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<Link> get_link(const string& handle, const Keychain& keychain);
 
     vector<shared_ptr<Atom>> get_matching_atoms(bool is_toplevel, Atom& key) override;
-    vector<shared_ptr<Atom>> get_matching_atoms(bool is_toplevel,
-                                                Atom& key,
-                                                const atomdb_api_types::PublicKey& public_key);
+    vector<shared_ptr<Atom>> get_matching_atoms(bool is_toplevel, Atom& key, const Keychain& keychain);
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const LinkSchema& link_schema) override;
-    shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(
-        const LinkSchema& link_schema, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<atomdb_api_types::HandleSet> query_for_pattern(const LinkSchema& link_schema,
+                                                              const Keychain& keychain);
 
     shared_ptr<atomdb_api_types::HandleList> query_for_targets(const string& handle) override;
-    shared_ptr<atomdb_api_types::HandleList> query_for_targets(
-        const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<atomdb_api_types::HandleList> query_for_targets(const string& handle,
+                                                               const Keychain& keychain);
 
     shared_ptr<atomdb_api_types::HandleSet> query_for_incoming_set(const string& handle) override;
-    shared_ptr<atomdb_api_types::HandleSet> query_for_incoming_set(
-        const string& handle, const atomdb_api_types::PublicKey& public_key);
+    shared_ptr<atomdb_api_types::HandleSet> query_for_incoming_set(const string& handle,
+                                                                   const Keychain& keychain);
 
     bool atom_exists(const string& handle) override;
-    bool atom_exists(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    bool atom_exists(const string& handle, const Keychain& keychain);
 
     bool node_exists(const string& handle) override;
-    bool node_exists(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    bool node_exists(const string& handle, const Keychain& keychain);
 
     bool link_exists(const string& handle) override;
-    bool link_exists(const string& handle, const atomdb_api_types::PublicKey& public_key);
+    bool link_exists(const string& handle, const Keychain& keychain);
 
     set<string> atoms_exist(const vector<string>& handles) override;
-    set<string> atoms_exist(const vector<string>& handles,
-                            const atomdb_api_types::PublicKey& public_key);
+    set<string> atoms_exist(const vector<string>& handles, const Keychain& keychain);
 
     set<string> nodes_exist(const vector<string>& handles) override;
-    set<string> nodes_exist(const vector<string>& handles,
-                            const atomdb_api_types::PublicKey& public_key);
+    set<string> nodes_exist(const vector<string>& handles, const Keychain& keychain);
 
     set<string> links_exist(const vector<string>& handles) override;
-    set<string> links_exist(const vector<string>& handles,
-                            const atomdb_api_types::PublicKey& public_key);
+    set<string> links_exist(const vector<string>& handles, const Keychain& keychain);
 
     string add_atom(const atoms::Atom* atom, const atoms::Merger* merger = NULL) override;
     string add_atom(const atoms::Atom* atom,
-                    const atomdb_api_types::PublicKey& public_key,
+                    const Keychain& keychain,
                     const atoms::Merger* merger = NULL);
 
     string add_node(const atoms::Node* node, const atoms::Merger* merger = NULL) override;
     string add_node(const atoms::Node* node,
-                    const atomdb_api_types::PublicKey& public_key,
+                    const Keychain& keychain,
                     const atoms::Merger* merger = NULL);
 
     string add_link(const atoms::Link* link, const atoms::Merger* merger = NULL) override;
     string add_link(const atoms::Link* link,
-                    const atomdb_api_types::PublicKey& public_key,
+                    const Keychain& keychain,
                     const atoms::Merger* merger = NULL);
 
     vector<string> add_atoms(const vector<atoms::Atom*>& atom_list,
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL) override;
     vector<string> add_atoms(const vector<atoms::Atom*>& atom_list,
-                             const atomdb_api_types::PublicKey& public_key,
+                             const Keychain& keychain,
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL);
 
@@ -111,7 +107,7 @@ class ProtectedAtomDB : public AtomDB {
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL) override;
     vector<string> add_nodes(const vector<atoms::Node*>& nodes,
-                             const atomdb_api_types::PublicKey& public_key,
+                             const Keychain& keychain,
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL);
 
@@ -119,51 +115,45 @@ class ProtectedAtomDB : public AtomDB {
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL) override;
     vector<string> add_links(const vector<atoms::Link*>& links,
-                             const atomdb_api_types::PublicKey& public_key,
+                             const Keychain& keychain,
                              bool is_transactional = false,
                              const atoms::Merger* merger = NULL);
 
     bool delete_atom(const string& handle, bool delete_link_targets = false) override;
-    bool delete_atom(const string& handle,
-                     const atomdb_api_types::PublicKey& public_key,
-                     bool delete_link_targets = false);
+    bool delete_atom(const string& handle, const Keychain& keychain, bool delete_link_targets = false);
 
     bool delete_node(const string& handle, bool delete_link_targets = false) override;
-    bool delete_node(const string& handle,
-                     const atomdb_api_types::PublicKey& public_key,
-                     bool delete_link_targets = false);
+    bool delete_node(const string& handle, const Keychain& keychain, bool delete_link_targets = false);
 
     bool delete_link(const string& handle, bool delete_link_targets = false) override;
-    bool delete_link(const string& handle,
-                     const atomdb_api_types::PublicKey& public_key,
-                     bool delete_link_targets = false);
+    bool delete_link(const string& handle, const Keychain& keychain, bool delete_link_targets = false);
 
     uint delete_atoms(const vector<string>& handles, bool delete_link_targets = false) override;
     uint delete_atoms(const vector<string>& handles,
-                      const atomdb_api_types::PublicKey& public_key,
+                      const Keychain& keychain,
                       bool delete_link_targets = false);
 
     uint delete_nodes(const vector<string>& handles, bool delete_link_targets = false) override;
     uint delete_nodes(const vector<string>& handles,
-                      const atomdb_api_types::PublicKey& public_key,
+                      const Keychain& keychain,
                       bool delete_link_targets = false);
 
     uint delete_links(const vector<string>& handles, bool delete_link_targets = false) override;
     uint delete_links(const vector<string>& handles,
-                      const atomdb_api_types::PublicKey& public_key,
+                      const Keychain& keychain,
                       bool delete_link_targets = false);
 
     void re_index_patterns(bool flush_patterns = true) override;
-    void re_index_patterns(const atomdb_api_types::PublicKey& public_key, bool flush_patterns = true);
+    void re_index_patterns(const Keychain& keychain, bool flush_patterns = true);
 
     size_t node_count() const override;
-    size_t node_count(const atomdb_api_types::PublicKey& public_key) const;
+    size_t node_count(const Keychain& keychain) const;
 
     size_t link_count() const override;
-    size_t link_count(const atomdb_api_types::PublicKey& public_key) const;
+    size_t link_count(const Keychain& keychain) const;
 
     size_t atom_count() const override;
-    size_t atom_count(const atomdb_api_types::PublicKey& public_key) const;
+    size_t atom_count(const Keychain& keychain) const;
 
    private:
     shared_ptr<AtomDB> backend;

--- a/src/atomdb/adapterdb/AdapterDB.cc
+++ b/src/atomdb/adapterdb/AdapterDB.cc
@@ -65,8 +65,8 @@ bool AdapterDB::composite_type_enabled() const {
     this->ensure_backend_ready();
     return this->atomdb_backend->composite_type_enabled();
 }
-vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> AdapterDB::get_access_permissions(
-    const atomdb_api_types::PublicKey& public_key) const {
+shared_ptr<atomdb_api_types::AccessPermissionDocument> AdapterDB::get_access_permissions(
+    const string& public_key) const {
     this->ensure_backend_ready();
     return this->atomdb_backend->get_access_permissions(public_key);
 }

--- a/src/atomdb/adapterdb/AdapterDB.h
+++ b/src/atomdb/adapterdb/AdapterDB.h
@@ -114,10 +114,10 @@ class AdapterDB : public AtomDB {
 
     /**
      * Forwards the lookup to the backend once it is ready.
-     * Returns an empty vector if the backend has no matching permissions.
+     * Returns nullptr if the backend has no matching permission.
      */
-    vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
-        const atomdb_api_types::PublicKey& public_key) const override;
+    shared_ptr<atomdb_api_types::AccessPermissionDocument> get_access_permissions(
+        const string& public_key) const override;
 
    private:
     AdapterDbType adapter_type;

--- a/src/atomdb/auth/Keychain.h
+++ b/src/atomdb/auth/Keychain.h
@@ -8,11 +8,11 @@ using namespace std;
 namespace atomdb {
 
 /**
- * @brief Caller credentials: public keys keyed by AtomDB UID.
+ * @brief Caller credentials: one public key per AtomDB UID.
  *
- * Keychain is the identity token passed into ProtectedAtomDB.
- * AuthorizationManifest looks up the public key for a given
- * database UID and checks the corresponding AuthorizationProfile.
+ * Holds the map `uid → public_key` that identifies the caller to each
+ * AtomDB. `get_public_key(uid)` returns the key for that database, or
+ * an empty string if the UID is absent or stored as empty.
  */
 class Keychain {
    public:

--- a/src/atomdb/redis_mongodb/RedisMongoDB.cc
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.cc
@@ -71,36 +71,18 @@ RedisMongoDB::~RedisMongoDB() {
 
 bool RedisMongoDB::allow_nested_indexing() { return false; }
 
-vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> RedisMongoDB::get_access_permissions(
-    const atomdb_api_types::PublicKey& public_key) const {
-    vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> documents;
-
-    if (public_key.is_single_key()) {
-        auto document = this->load_access_permission_document(public_key.keys[0]);
-        if (document.has_value()) {
-            documents.push_back(document.value());
-        }
-        return documents;
+shared_ptr<atomdb_api_types::AccessPermissionDocument> RedisMongoDB::get_access_permissions(
+    const string& public_key) const {
+    if (public_key.empty()) {
+        return nullptr;
     }
 
-    for (const auto& [peer_uid, idx] : (public_key.peer_to_key)) {
-        string key = public_key.keys[idx];
-        auto document = this->load_access_permission_document(key);
-        if (document.has_value()) {
-            documents.push_back(document.value());
-        }
-    }
-    return documents;
-}
-
-optional<shared_ptr<atomdb_api_types::AccessPermissionDocument>>
-RedisMongoDB::load_access_permission_document(const string& public_key) const {
     string handle = Hasher::plain_string_hash(public_key);
 
     auto access_permission_doc = this->get_document(handle, MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME);
 
     if (access_permission_doc == nullptr) {
-        return nullopt;
+        return nullptr;
     }
 
     auto mongodb_doc = dynamic_pointer_cast<atomdb_api_types::MongodbDocument>(access_permission_doc);

--- a/src/atomdb/redis_mongodb/RedisMongoDB.h
+++ b/src/atomdb/redis_mongodb/RedisMongoDB.h
@@ -10,7 +10,6 @@
 #include <mongocxx/options/find.hpp>
 #include <mongocxx/pool.hpp>
 #include <mutex>
-#include <optional>
 #include <set>
 #include <vector>
 
@@ -34,11 +33,11 @@ class RedisMongoDB : public AtomDB {
     bool allow_nested_indexing() override;
     bool composite_type_enabled() const override { return this->composite_type_enabled_; }
     /**
-     * Looks up access-permission documents in MongoDB for the given public key(s).
-     * Returns an empty vector if no matching documents exist.
+     * Looks up the access-permission document in MongoDB for the given public key.
+     * Returns nullptr if the key is empty or no matching document exists.
      */
-    vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
-        const atomdb_api_types::PublicKey& public_key) const override;
+    shared_ptr<atomdb_api_types::AccessPermissionDocument> get_access_permissions(
+        const string& public_key) const override;
     atomdb_api_types::ProtectionMode get_protection_mode() const override;
 
     // Redis key prefixes and MongoDB database/collection names are per-instance so two
@@ -160,12 +159,6 @@ class RedisMongoDB : public AtomDB {
 
     shared_ptr<atomdb_api_types::AtomDocument> get_document(const string& handle,
                                                             const string& collection_name) const;
-    /**
-     * @brief Loads and parses one access_permissions Mongo document for the given public key.
-     * @return nullopt when no document exists for that key.
-     */
-    optional<shared_ptr<atomdb_api_types::AccessPermissionDocument>> load_access_permission_document(
-        const string& public_key) const;
 
     vector<shared_ptr<atomdb_api_types::AtomDocument>> get_documents(const vector<string>& handles,
                                                                      const vector<string>& fields,

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.cc
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.cc
@@ -43,8 +43,8 @@ bool RemoteAtomDBPeer::allow_nested_indexing() { return atomdb_->allow_nested_in
 bool RemoteAtomDBPeer::composite_type_enabled() const {
     return local_persistence_ && local_persistence_->composite_type_enabled();
 }
-vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> RemoteAtomDBPeer::get_access_permissions(
-    const atomdb_api_types::PublicKey& public_key) const {
+shared_ptr<atomdb_api_types::AccessPermissionDocument> RemoteAtomDBPeer::get_access_permissions(
+    const string& public_key) const {
     if (!atomdb_) return AtomDB::get_access_permissions(public_key);
     return atomdb_->get_access_permissions(public_key);
 }

--- a/src/atomdb/remotedb/RemoteAtomDBPeer.h
+++ b/src/atomdb/remotedb/RemoteAtomDBPeer.h
@@ -118,10 +118,10 @@ class RemoteAtomDBPeer : public AtomDB, public processor::ThreadMethod {
 
     /**
      * Delegates the lookup to the remote AtomDB; local persistence is not consulted.
-     * Returns an empty vector if there is no remote AtomDB or it has no matching permissions.
+     * Returns nullptr if there is no remote AtomDB or it has no matching permission.
      */
-    vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>> get_access_permissions(
-        const atomdb_api_types::PublicKey& public_key) const override;
+    shared_ptr<atomdb_api_types::AccessPermissionDocument> get_access_permissions(
+        const string& public_key) const override;
 
    private:
     shared_ptr<InMemoryDB> write_buffer() const;

--- a/src/tests/cpp/inmemorydb_test.cc
+++ b/src/tests/cpp/inmemorydb_test.cc
@@ -1372,8 +1372,8 @@ TEST_F(InMemoryDBTest, ConcurrentPatternQueriesSurviveReIndex) {
 }
 
 TEST_F(InMemoryDBTest, GetAccessPermissionsReturnsEmpty) {
-    auto permissions = db->get_access_permissions(PublicKey("any_key"));
-    EXPECT_TRUE(permissions.empty());
+    auto permissions = db->get_access_permissions("any_key");
+    EXPECT_EQ(permissions, nullptr);
 }
 
 TEST_F(InMemoryDBTest, IsUnprotected) {

--- a/src/tests/cpp/protected_atomdb_test.cc
+++ b/src/tests/cpp/protected_atomdb_test.cc
@@ -47,12 +47,12 @@ TEST(ProtectedAtomDBTest, DelegatesToBackend) {
     EXPECT_EQ(db.allow_nested_indexing(), backend->allow_nested_indexing());
     EXPECT_EQ(db.composite_type_enabled(), backend->composite_type_enabled());
 
-    PublicKey key("any_key");
+    string key = "any_key";
 
-    EXPECT_EQ(db.get_access_permissions(key).size(), backend->get_access_permissions(key).size());
+    EXPECT_EQ(db.get_access_permissions(key), backend->get_access_permissions(key));
 }
 
-TEST(ProtectedAtomDBTest, RejectsOperationsWithoutPublicKey) {
+TEST(ProtectedAtomDBTest, RejectsOperationsWithoutKeychain) {
     auto db = make_protected_db();
 
     Node node("Symbol", "\"node\"");

--- a/src/tests/cpp/redis_mongodb_test.cc
+++ b/src/tests/cpp/redis_mongodb_test.cc
@@ -1411,11 +1411,11 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsEmptyCollection) {
     auto collection = (*conn)[db->MONGODB_DB_NAME][db->MONGODB_ACCESS_PERMISSIONS_COLLECTION_NAME];
     collection.delete_many({});
 
-    auto permissions = db->get_access_permissions(PublicKey("any_key"));
-    EXPECT_TRUE(permissions.empty());
+    auto permissions = db->get_access_permissions("any_key");
+    EXPECT_EQ(permissions, nullptr);
 }
 
-TEST_F(RedisMongoDBTest, GetAccessPermissionsReturnsStoredDocuments) {
+TEST_F(RedisMongoDBTest, GetAccessPermissionsReturnsStoredDocument) {
     using bsoncxx::builder::basic::kvp;
     using bsoncxx::builder::basic::make_array;
     using bsoncxx::builder::basic::make_document;
@@ -1441,18 +1441,18 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsReturnsStoredDocuments) {
             make_array(make_document(
                 kvp("tokens", similarity_tokens), kvp("read", true), kvp("write", false))))));
 
-    auto admin_permissions = db->get_access_permissions(PublicKey("key_admin"));
-    ASSERT_EQ(admin_permissions.size(), 1u);
-    EXPECT_STREQ(admin_permissions[0]->get_access_key(), "key_admin");
-    EXPECT_TRUE(admin_permissions[0]->get_full_access());
-    EXPECT_EQ(admin_permissions[0]->get_entries_size(), 0u);
+    auto admin_permissions = db->get_access_permissions("key_admin");
+    ASSERT_NE(admin_permissions, nullptr);
+    EXPECT_STREQ(admin_permissions->get_access_key(), "key_admin");
+    EXPECT_TRUE(admin_permissions->get_full_access());
+    EXPECT_EQ(admin_permissions->get_entries_size(), 0u);
 
-    auto reader_permissions = db->get_access_permissions(PublicKey("key_reader"));
-    ASSERT_EQ(reader_permissions.size(), 1u);
-    EXPECT_STREQ(reader_permissions[0]->get_access_key(), "key_reader");
-    EXPECT_FALSE(reader_permissions[0]->get_full_access());
-    ASSERT_EQ(reader_permissions[0]->get_entries_size(), 1u);
-    const auto& reader_entry = reader_permissions[0]->get_entry(0);
+    auto reader_permissions = db->get_access_permissions("key_reader");
+    ASSERT_NE(reader_permissions, nullptr);
+    EXPECT_STREQ(reader_permissions->get_access_key(), "key_reader");
+    EXPECT_FALSE(reader_permissions->get_full_access());
+    ASSERT_EQ(reader_permissions->get_entries_size(), 1u);
+    const auto& reader_entry = reader_permissions->get_entry(0);
     EXPECT_TRUE(reader_entry.get_read());
     EXPECT_FALSE(reader_entry.get_write());
     vector<string> expected_tokens = {
@@ -1465,14 +1465,10 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsReturnsStoredDocuments) {
     }
     EXPECT_EQ(LinkSchema(actual_tokens).handle(), expected_schema.handle());
 
-    auto map_permissions = db->get_access_permissions(
-        PublicKey(map<string, string>{{"peer_a", "key_admin"}, {"peer_b", "key_reader"}}));
-    ASSERT_EQ(map_permissions.size(), 2u);
-
-    EXPECT_TRUE(db->get_access_permissions(PublicKey("missing_key")).empty());
+    EXPECT_EQ(db->get_access_permissions("missing_key"), nullptr);
 
     collection.delete_many({});
-    EXPECT_TRUE(db->get_access_permissions(PublicKey("key_admin")).empty());
+    EXPECT_EQ(db->get_access_permissions("key_admin"), nullptr);
 }
 
 TEST_F(RedisMongoDBTest, GetAccessPermissionsRejectsInvalidDocument) {
@@ -1487,7 +1483,7 @@ TEST_F(RedisMongoDBTest, GetAccessPermissionsRejectsInvalidDocument) {
     collection.insert_one(make_document(kvp("_id", string(compute_hash((char*) "key_broken"))),
                                         kvp("full_access", false)));
 
-    EXPECT_THROW(db->get_access_permissions(PublicKey("key_broken")), runtime_error);
+    EXPECT_THROW(db->get_access_permissions("key_broken"), runtime_error);
 
     collection.delete_many({});
 }

--- a/src/tests/cpp/test_commons/mocks/MockAtomDB.h
+++ b/src/tests/cpp/test_commons/mocks/MockAtomDB.h
@@ -26,9 +26,9 @@ class AtomDBMock : public AtomDB {
    public:
     MOCK_METHOD(bool, allow_nested_indexing, (), (override));
     MOCK_METHOD(bool, composite_type_enabled, (), (const, override));
-    MOCK_METHOD(vector<shared_ptr<atomdb_api_types::AccessPermissionDocument>>,
+    MOCK_METHOD(shared_ptr<atomdb_api_types::AccessPermissionDocument>,
                 get_access_permissions,
-                (const atomdb_api_types::PublicKey& public_key),
+                (const string& public_key),
                 (const, override));
     MOCK_METHOD(ProtectionMode, get_protection_mode, (), (const, override));
     MOCK_METHOD(shared_ptr<Atom>, get_atom, (const string& handle), (override));


### PR DESCRIPTION
- Remove `atomdb_api_types::PublicKey`. Key selection now lives in `Keychain`; `ProtectedAtomDB` methods take `const Keychain&` instead of `const PublicKey&`.
- Simplify `AtomDB::get_access_permissions` to a single `public_key` string, returning one document or `nullptr` (empty key short-circuits before hashing).

Resolves #1270 